### PR TITLE
Change RegEx for yield value to match digits in json-ld less restrictive

### DIFF
--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -214,10 +214,11 @@ class RecipeService
 
         $json['recipeCategory'] = $this->cleanUpString($json['recipeCategory'], false, true);
 
+        
         // Make sure that "recipeYield" is an integer which is at least 1
         if (isset($json['recipeYield']) && $json['recipeYield']) {
             $regex_matches = [];
-            preg_match('/^.*?(\d*)/', $json['recipeYield'], $regex_matches);
+            preg_match('/(\d*)/', $json['recipeYield'], $regex_matches);
             if (count($regex_matches) >= 1 ){
                 $yield = filter_var($regex_matches[0], FILTER_SANITIZE_NUMBER_INT);
             }


### PR DESCRIPTION
According to https://schema.org/recipeYield the yield value is specified like "recipeYield": "1 loaf"
The suggested RegEx  /(\d*)/ is a more generic approach to find digits in the recipeYield string instead of  /^.*?(\d*)/ 

For example this works for chefkoch.de ("recipeYield": "6 Portion(en)") and fittastetic.com ("recipeYield": ["2","2 Portionen"]).
The old RegEx /^.*?(\d*)/ worked on chefkoch.de but not e.g. on fittastetic.com

Because we have the if function in the next line (221) that deals with several occurrences and picks the first one, it should be save to do it that way.