### PR TITLE
Handle libxml errors and warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
             "name": "Jeppe Zapp"
         }
     ],
-    "require": {},
+    "require": {
+      "ext-libxml": "*"
+    },
     "require-dev": {
         "phpunit/phpunit": "^5.4"
     }

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -418,7 +418,7 @@ class RecipeService
      *
      * @return array
      */
-    private function parseRecipeHtml($html)
+    private function parseRecipeHtml($url, $html)
     {
         if (!$html) {
             return null;
@@ -437,7 +437,7 @@ class RecipeService
                 throw new \Exception('Malformed HTML');
             }
             $errors = libxml_get_errors();
-            $this->display_libxml_errors($errors);
+            $this->display_libxml_errors($url, $errors);
             libxml_clear_errors();
         } finally {
             libxml_use_internal_errors($libxml_previous_state);
@@ -596,7 +596,7 @@ class RecipeService
         return $this->checkRecipe($json);
     }
 
-    private function display_libxml_errors($errors)
+    private function display_libxml_errors($url, $errors)
     {
         $error_counter = [];
         $by_error_code = [];
@@ -624,7 +624,7 @@ class RecipeService
                     $error_message = "Unknown Error ";
             }
 
-            $error_message .= "occurred " . $count . " times. Last time in line $error->line" .
+            $error_message .= "occurred " . $count . " times while parsing " . $url . ". Last time in line $error->line" .
                 " and column $error->column: " . $error->message;
             
             $this->logger->warning($error_message);
@@ -802,7 +802,7 @@ class RecipeService
             throw new Exception('Could not fetch site ' . $url);
         }
 
-        $json = $this->parseRecipeHtml($html);
+        $json = $this->parseRecipeHtml($url, $html);
 
         if (!$json) {
             throw new Exception('No recipe data found');


### PR DESCRIPTION
This PR improves how libxml errors are handled. Because there can be a lot of duplicate errrors I decided to count similar errors and show how often it occurred. The log output for multiple failure looks like this:

```
{"reqId":"EYcnDGGmhWZ8kXC4Te7E","level":2,"time":"2020-10-25T18:02:51+00:00","remoteAddr":"2a02:810d:640:1e52:3f8c:68c2:b41d:b462","user":"max","app":"no app in context","method":"POST","url":"/index.php/apps/cookbook/import","message":"libxml: Error 68 occurred 907 times while parsing https://www.chefkoch.de/rezepte/18711004787789/Risotto-mit-gruenem-Spargel-und-Parmesan.html. Last time in line 7728 and column 119: htmlParseEntityRef: no name\n","userAgent":"Mozilla/5.0 (X11; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0","version":"19.0.4.2"}
{"reqId":"EYcnDGGmhWZ8kXC4Te7E","level":2,"time":"2020-10-25T18:02:51+00:00","remoteAddr":"2a02:810d:640:1e52:3f8c:68c2:b41d:b462","user":"max","app":"no app in context","method":"POST","url":"/index.php/apps/cookbook/import","message":"libxml: Error 801 occurred 329 times while parsing https://www.chefkoch.de/rezepte/18711004787789/Risotto-mit-gruenem-Spargel-und-Parmesan.html. Last time in line 10225 and column 50: Tag amp-install-serviceworker invalid\n","userAgent":"Mozilla/5.0 (X11; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0","version":"19.0.4.2"}
{"reqId":"EYcnDGGmhWZ8kXC4Te7E","level":2,"time":"2020-10-25T18:02:51+00:00","remoteAddr":"2a02:810d:640:1e52:3f8c:68c2:b41d:b462","user":"max","app":"no app in context","method":"POST","url":"/index.php/apps/cookbook/import","message":"libxml: Error 42 occurred 3 times while parsing https://www.chefkoch.de/rezepte/18711004787789/Risotto-mit-gruenem-Spargel-und-Parmesan.html. Last time in line 5041 and column 109: Attribute parentid redefined\n","userAgent":"Mozilla/5.0 (X11; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0","version":"19.0.4.2"}
{"reqId":"EYcnDGGmhWZ8kXC4Te7E","level":2,"time":"2020-10-25T18:02:51+00:00","remoteAddr":"2a02:810d:640:1e52:3f8c:68c2:b41d:b462","user":"max","app":"no app in context","method":"POST","url":"/index.php/apps/cookbook/import","message":"libxml: Error 23 occurred 333 times while parsing https://www.chefkoch.de/rezepte/18711004787789/Risotto-mit-gruenem-Spargel-und-Parmesan.html. Last time in line 10210 and column 96: htmlParseEntityRef: expecting ';'\n","userAgent":"Mozilla/5.0 (X11; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0","version":"19.0.4.2"}
{"reqId":"EYcnDGGmhWZ8kXC4Te7E","level":2,"time":"2020-10-25T18:02:51+00:00","remoteAddr":"2a02:810d:640:1e52:3f8c:68c2:b41d:b462","user":"max","app":"no app in context","method":"POST","url":"/index.php/apps/cookbook/import","message":"libxml: Error 76 occurred 10 times while parsing https://www.chefkoch.de/rezepte/18711004787789/Risotto-mit-gruenem-Spargel-und-Parmesan.html. Last time in line 6509 and column 7: Unexpected end tag : div\n","userAgent":"Mozilla/5.0 (X11; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0","version":"19.0.4.2"}
```

The problem with the handling before this is that nextcloud alwas logs the parameters of the function where an libxml error occurred. This meany in the above example the $html is logged a few hundred times.
