### PR TITLE
Make name of package compatible with composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Cookbook",
+    "name": "nextcloud-apps/cookbook",
     "description": "An integrated cookbook using YAML files as recipes",
     "type": "project",
     "license": "AGPL",


### PR DESCRIPTION
Today Composer 2 was released and it requires the package name to be of a certain structure. This was a warning unser the old composer 1.x but now failed the CI builds.