### PR TITLE
Feature/check recipe edits before leaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   [#379](https://github.com/nextcloud/cookbook/pull/379/) @seyfeb
 - Selectable keywords for filtering in recipe lists
   [#375](https://github.com/nextcloud/cookbook/pull/375/) @seyfeb
+- Check recipe for changes when leaving edit page withour saving
+  [#359]((https://github.com/nextcloud/cookbook/pull/359) @seyfeb
 
 ### Changed
 - Switch of project ownership to neextcloud organization in GitHub

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -80,6 +80,13 @@ export default {
         addEntry: function(field, index, content='') {
             this.recipe[field].splice(index, 0, content)
         },
+        beforeWindowUnload(e) {
+          if (this.confirmStayInEditedForm()) {
+            // Cancel the window unload event
+            e.preventDefault()
+            e.returnValue = ''
+          }   
+        },
         /**
          * Compares initial with current recipe. Returns true if they are the
          * same. Ignores padding that has been added to the hours and minutes
@@ -281,6 +288,9 @@ export default {
         })
         this.savingRecipe = false
     },
+    beforeDestroy() {
+      window.removeEventListener('beforeunload', this.beforeWindowUnload)
+    },
     // We can check if the user has browsed from the same recipe's view to this
     // edit and save some time by not reloading the recipe data, leading to a
     // more seamless experience.
@@ -331,6 +341,9 @@ export default {
         if (this.$window.shouldReloadContent(from.fullPath, to.fullPath)) {
             this.setup()
         }
+    },
+    created() {
+      window.addEventListener('beforeunload', this.beforeWindowUnload)
     },
 
 }

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -80,6 +80,63 @@ export default {
         addEntry: function(field, index, content='') {
             this.recipe[field].splice(index, 0, content)
         },
+        /**
+         * Compares initial with current recipe. Returns true if they are the
+         * same. Ignores padding that has been added to the hours and minutes
+         * of preparation, cooking, and total time.
+         */
+        compareCurrentWithInitialRecipe: function () {
+          const initKeys = Object.keys(this.recipeInit)
+          const currKeys = Object.keys(this.recipe)
+          var recipe = this.recipe
+
+          if (initKeys.length != currKeys.length)
+          {
+            return false
+          }
+
+          for(let key of initKeys)
+          {
+            if (this.recipeInit[key] instanceof Array) {
+              if(! (this.recipe[key] instanceof Array) ) {
+                return false
+              }
+              var arrIdentical = (this.recipeInit[key].length == this.recipe[key].length) 
+                && this.recipeInit[key].every(function(element, index) {
+                    return element === recipe[key][index]
+                  });
+              if(!arrIdentical) {
+                return false
+              }
+              
+            }
+            else {
+              if(["prepTime", "cookTime", "totalTime"].includes(key)) {
+                // ignore added padding changes in datetime fields
+                let timeStringInit = this.recipeInit[key]
+                let timeString = this.recipe[key]
+
+                // Parse time values
+                let timeComps = timeString ? timeStringInit.match(/PT(\d+?)H(\d+?)M/) : null
+                let hours = timeComps[1].toString().padStart(2, '0')
+                let minutes = timeComps[2].toString().padStart(2, '0')
+
+                timeComps = timeStringInit ? timeStringInit.match(/PT(\d+?)H(\d+?)M/) : null
+                let hoursInit = timeComps[1].toString().padStart(2, '0')
+                let minutesInit = timeComps[2].toString().padStart(2, '0')
+
+                if (hours != hoursInit || minutes != minutesInit) {
+                  return false
+                }
+              } else {
+                if (this.recipeInit[key] != this.recipe[key]) {
+                  return false
+                }
+              }
+            }
+          }
+          return true
+        },
         deleteEntry: function(field, index) {
             this.recipe[field].splice(index, 1)
         },

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -202,6 +202,7 @@ export default {
         // Store the initial recipe configuration for possible later use
         if (this.recipeInit === null) {
             this.recipeInit = this.recipe
+            this.recipeInit = Object.assign({}, this.recipe)
         }
         // Register save method hook for access from the controls components
         // The event hookmust first be destroyed to avoid it from firing multiple


### PR DESCRIPTION
Before leaving the edit page, the current edited recipe data is compared to the initial data. If there are changes, the user is prompted if she wants to leave the page.

Padding zeros in prep, cooking, and total time are ignored.

Closes #310 