### PR TITLE
Make the folder name persistend under changes of the language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
   [#350](https://github.com/nextcloud/cookbook/pull/350) @maxammann
 - Make complete sentence in transifex translation from parts
   [#358](https://github.com/nextcloud/cookbook/pull/358) @christianlupus
+- Avoid recipe are no longer reachable when user changes locales
+  [#371](https://github.com/nextcloud/cookbook/pull/371) @christianlupus
 
 ### Removed
 - Travis build system

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -954,6 +954,7 @@ class RecipeService
 
         if (!$path) {
             $path = '/' . $this->il10n->t('Recipes');
+            $this->config->setUserValue($this->user_id, 'cookbook', 'folder', $path);
         }
 
         return $path;


### PR DESCRIPTION
If the recipe folder is not specified explicitly in the config, it should be stored nevertheless. Otherwise the folder is changed if the language of the user is changed. This will cause a stale database and needs reindexing.
This PR will store the setting in the configs if no config was found. If the user wants to move the/rename the folder it is up to his manual work.