### PR TITLE
Added known Android Clients to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Chanage in issue managment
 - Changes to `.gitignore` file
 - Translation issues
+- Added available Android apps to README
 
 ### Fixed
 - Add a min PHP restriction in the metadata

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 
 A library for all your recipes. It uses JSON files following the schema.org recipe format. To add a recipe to the collection, you can paste in the URL of the recipe, and the provided web page will be parsed and downloaded to whichever folder you specify in the app settings.
 
+## Clients
+
+### Android
+The currently available clients are
+
+- Nextcloud Cookbook (by MicMun) ([Google Play](https://play.google.com/store/apps/details?id=de.micmun.android.nextcloudcookbook&hl=en_US&gl=US), [FDroid](https://f-droid.org/en/packages/de.micmun.android.nextcloudcookbook/), [homepage](https://micmun.de/nextcloud-cookbook-english/))
+- Nextcloud Cookbook (by Teifun2) ([Google Play](https://play.google.com/store/apps/details?id=com.nextcloud_cookbook_flutter&hl=en_US&gl=US))
+
 ## Join the discussion
 
 * [#nextcloud-cookbook:matrix.org](https://matrix.to/#/#nextcloud-cookbook:matrix.org)


### PR DESCRIPTION
I added the two Android clients I found to the main README to make them easily discoverable by users. This list can be extended if there are more clients (also for other OSes).

Closes #319 