### PR TITLE
Show tag cloud in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   [#373](https://github.com/nextcloud/cookbook/pull/373/) @seyfeb
 - Pasted content with newlines creates new input fields automatically for tools and ingredients in recipe editor
   [#379](https://github.com/nextcloud/cookbook/pull/379/) @seyfeb
+- Selectable keywords for filtering in recipe lists
+  [#375](https://github.com/nextcloud/cookbook/pull/375/) @seyfeb
 
 ### Changed
 - Switch of project ownership to neextcloud organization in GitHub

--- a/src/components/AppIndex.vue
+++ b/src/components/AppIndex.vue
@@ -1,10 +1,10 @@
 <template>
     <div>
         <ul v-if="keywords.length" class="keywords">
-            <RecipeKeyword v-for="(keyword,idx) in keywords" :key="'kw'+idx" :keyword="keyword" v-on:keyword-clicked="keywordClicked(keyword)" v-bind:class="{active : keywordFilter.includes(keyword)}" />
+            <RecipeKeyword v-for="(keyword,idx) in keywords" :key="'kw'+idx" :keyword="keyword" v-on:keyword-clicked="keywordClicked(keyword)" v-bind:class="{active : keywordFilter.includes(keyword), disabled : !keywordContainedInVisibleRecipes(keyword)}" />
         </ul>
         <ul class="recipes">
-            <li v-for="recipe in filteredRecipes" :key="recipe.recipe_id" v-show="recipeVisible(recipe.keywords)">
+            <li v-for="(recipe, index) in filteredRecipes" :key="recipe.recipe_id" v-show="recipeVisible(index)">
                 <router-link :to="'/recipe/'+recipe.recipe_id">
                     <img v-if="recipe.imageUrl" :src="recipe.imageUrl">
                     <span>{{ recipe.name }}</span>
@@ -58,6 +58,19 @@ export default {
             }
         },
         /**
+         * Check if a keyword exists in the currently visible recipes.
+         */
+        keywordContainedInVisibleRecipes: function(keyword) {
+            for (let i=0; i<this.recipes.length; ++i) {
+                if (this.recipeVisible(i) 
+                    && this.recipes[i].keywords
+                    && this.recipes[i].keywords.split(',').includes(keyword)) {
+                    return true
+                }                
+            }
+            return false
+        },
+        /**
          * Load all recipes from the database
          */
         loadAll: function () {
@@ -80,12 +93,12 @@ export default {
          * Check if recipe should be displayed, depending on selected keyword filter.
          * Returns true if recipe contains all selected keywords.
          */
-        recipeVisible: function(keywords) {     
+        recipeVisible: function(index) {     
             if (this.keywordFilter.length == 0) {
                 return true;
             } else {
-                if (!keywords) return false;
-                let kw_array = keywords.split(',');
+                if (!this.recipes[index].keywords) return false;
+                let kw_array = this.recipes[index].keywords.split(',');
                 return this.keywordFilter.every(kw => kw_array.includes(kw));
             }
         },

--- a/src/components/AppIndex.vue
+++ b/src/components/AppIndex.vue
@@ -50,9 +50,9 @@ export default {
          * Callback for click on keyword
          */
         keywordClicked: function(keyword) {
-            const index = this.keywordFilter.indexOf(keyword);
+            const index = this.keywordFilter.indexOf(keyword)
             if (index > -1) {
-                this.keywordFilter.splice(index, 1);
+                this.keywordFilter.splice(index, 1)
             } else {
                 this.keywordFilter.push(keyword)
             }
@@ -95,11 +95,13 @@ export default {
          */
         recipeVisible: function(index) {     
             if (this.keywordFilter.length == 0) {
-                return true;
+                return true
             } else {
-                if (!this.recipes[index].keywords) return false;
-                let kw_array = this.recipes[index].keywords.split(',');
-                return this.keywordFilter.every(kw => kw_array.includes(kw));
+                if (!this.recipes[index].keywords) {
+                    return false
+                }
+                let kw_array = this.recipes[index].keywords.split(',')
+                return this.keywordFilter.every(kw => kw_array.includes(kw))
             }
         },
         /**

--- a/src/components/RecipeKeyword.vue
+++ b/src/components/RecipeKeyword.vue
@@ -8,7 +8,7 @@ export default {
     props: ['keyword'],
     data () {
         return {
-        };
+        }
     },
     computed: {
     },

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -1,10 +1,10 @@
 <template>
 <div>
     <ul v-if="keywords.length" class="keywords">
-        <RecipeKeyword v-for="(keyword,idx) in keywords" :key="'kw'+idx" :keyword="keyword" v-on:keyword-clicked="keywordClicked(keyword)" v-bind:class="{active : keywordFilter.includes(keyword)}" />
+        <RecipeKeyword v-for="(keyword,idx) in keywords" :key="'kw'+idx" :keyword="keyword" v-on:keyword-clicked="keywordClicked(keyword)" v-bind:class="{active : keywordFilter.includes(keyword), disabled : !keywordContainedInVisibleRecipes(keyword)}" />
     </ul>
     <ul class="recipes">
-        <li v-for="result in results" :key="result.recipe_id" v-show="recipeVisible(result.keywords)">
+        <li v-for="(result, index) in results" :key="result.recipe_id" v-show="recipeVisible(index)">
             <router-link :to="'/recipe/'+result.recipe_id">
                 <img v-if="result.imageUrl" :src="result.imageUrl">
                 <span>{{ result.name }}</span>
@@ -35,19 +35,6 @@ export default {
     },    
     methods: {
         /**
-         * Check if recipe should be displayed, depending on selected keyword filter.
-         * Returns true if recipe contains all selected keywords.
-         */
-        recipeVisible: function(keywords) {     
-            if (this.keywordFilter.length == 0) {
-                return true;
-            } else {
-                if (!keywords) return false;
-                let kw_array = keywords.split(',');
-                return this.keywordFilter.every(kw => kw_array.includes(kw));
-            }
-        },
-        /**
          * Callback for click on keyword
          */
         keywordClicked: function(keyword) {
@@ -56,6 +43,32 @@ export default {
                 this.keywordFilter.splice(index, 1);
             } else {
                 this.keywordFilter.push(keyword)
+            }
+        },
+        /**
+         * Check if a keyword exists in the currently visible recipes.
+         */
+        keywordContainedInVisibleRecipes: function(keyword) {
+            for (let i=0; i<this.results.length; ++i) {
+                if (this.recipeVisible(i) 
+                    && this.recipes[i].keywords
+                    && this.results[i].keywords.split(',').includes(keyword)) {
+                    return true
+                }                
+            }
+            return false
+        },
+        /**
+         * Check if recipe should be displayed, depending on selected keyword filter.
+         * Returns true if recipe contains all selected keywords.
+         */
+        recipeVisible: function(index) {     
+            if (this.keywordFilter.length == 0) {
+                return true;
+            } else {
+                if (!this.results[index].keywords) return false;
+                let kw_array = this.results[index].keywords.split(',');
+                return this.keywordFilter.every(kw => kw_array.includes(kw));
             }
         },
         /**

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -1,25 +1,82 @@
 <template>
-    <ul>
-        <li v-for="result in results" :key="result.recipe_id">
+<div>
+    <ul v-if="keywords.length" class="keywords">
+        <RecipeKeyword v-for="(keyword,idx) in keywords" :key="'kw'+idx" :keyword="keyword" v-on:keyword-clicked="keywordClicked(keyword)" v-bind:class="{active : keywordFilter.includes(keyword)}" />
+    </ul>
+    <ul class="recipes">
+        <li v-for="result in results" :key="result.recipe_id" v-show="recipeVisible(result.keywords)">
             <router-link :to="'/recipe/'+result.recipe_id">
                 <img v-if="result.imageUrl" :src="result.imageUrl">
                 <span>{{ result.name }}</span>
             </router-link>
         </li>
     </ul>
+</div>
 </template>
 
 <script>
+
+import RecipeKeyword from './RecipeKeyword'
+
 export default {
     name: "Search",
+    components: {
+        RecipeKeyword,
+    },
     props: ['query'],
     data () {
         return {
             results: [],
+            keywords: [],
+            keywordFilter: [],
         }
     },
+    computed: {
+    },    
     methods: {
+        /**
+         * Check if recipe should be displayed, depending on selected keyword filter.
+         * Returns true if recipe contains all selected keywords.
+         */
+        recipeVisible: function(keywords) {     
+            if (this.keywordFilter.length == 0) {
+                return true;
+            } else {
+                if (!keywords) return false;
+                let kw_array = keywords.split(',');
+                return this.keywordFilter.every(kw => kw_array.includes(kw));
+            }
+        },
+        /**
+         * Callback for click on keyword
+         */
+        keywordClicked: function(keyword) {
+            const index = this.keywordFilter.indexOf(keyword);
+            if (index > -1) {
+                this.keywordFilter.splice(index, 1);
+            } else {
+                this.keywordFilter.push(keyword)
+            }
+        },
+        /**
+         * Extract and set list of keywords from the returned recipes.
+         */
+        setKeywords: function(results) {
+            this.keywords = []
+            if ((results.length) > 0) {
+                results.forEach(recipe => {
+                    if(recipe['keywords']) {
+                        recipe['keywords'].split(',').forEach(kw => {
+                            if(!this.keywords.includes(kw)) {
+                                this.keywords.push(kw)
+                            }
+                        })
+                    }
+                });
+            }
+        },
         setup: function() {
+            
             // TODO: This is a mess of different implementation styles, needs cleanup
             if (this.query === 'name') {
                 // Search by name
@@ -44,6 +101,7 @@ export default {
                 let cat = this.$route.params.value
                 $.get(this.$window.baseUrl + '/api/category/'+cat).done(function(json) {
                     $this.results = json
+                    $this.setKeywords($this.results)
                 }).fail(function (jqXHR, textStatus, errorThrown) {
                     $this.results = []
                     alert(t('cookbook', 'Failed to load category '+cat+' recipes'))
@@ -53,9 +111,11 @@ export default {
                 })
             } else {
                 // General search
+                let $this = this
                 let deferred = $.Deferred()
                 $.get(this.$window.baseUrl + '/api/search/'+this.$route.params.value).done((recipes) => {
-                    this.results = recipes
+                    $this.results = recipes
+                    $this.setKeywords($this.results)
                     deferred.resolve()
                 }).fail((jqXHR, textStatus, errorThrown) => {
                     this.results = []
@@ -68,9 +128,11 @@ export default {
                 this.$store.dispatch('setPage', { page: 'search' })
                 return deferred.promise()
             }
+
+            
             this.$store.dispatch('setPage', { page: 'search' })
         },
-    },
+    },   
     mounted () {
         this.setup()
     },
@@ -85,35 +147,43 @@ export default {
 
 <style scoped>
 
-ul {
+ul.keywords {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    width: 100%;
+    margin: .5rem 1rem .5rem;
+}
+
+ul.recipes {
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
     width: 100%;
 }
 
-    ul li {
+    ul.recipes li {
         width: 300px;
         max-width: 100%;
         margin: 0.5rem 1rem 1rem;
     }
-        ul li a {
+        ul.recipes li a {
             display: block;
             height: 105px;
             box-shadow: 0 0 3px #AAA;
             border-radius: 3px;
         }
-        ul li a:hover {
+        ul.recipes li a:hover {
             box-shadow: 0 0 5px #888;
         }
 
-        ul li img {
+        ul.recipes li img {
             float: left;
             height: 105px;
             border-radius: 3px 0 0 3px;
         }
 
-        ul li span {
+        ul.recipes li span {
             display: block;
             padding: 0.5rem 0.5em 0.5rem calc(105px + 0.5rem);
         }

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -51,7 +51,7 @@ export default {
         keywordContainedInVisibleRecipes: function(keyword) {
             for (let i=0; i<this.results.length; ++i) {
                 if (this.recipeVisible(i) 
-                    && this.recipes[i].keywords
+                    && this.results[i].keywords
                     && this.results[i].keywords.split(',').includes(keyword)) {
                     return true
                 }                

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -38,9 +38,9 @@ export default {
          * Callback for click on keyword
          */
         keywordClicked: function(keyword) {
-            const index = this.keywordFilter.indexOf(keyword);
+            const index = this.keywordFilter.indexOf(keyword)
             if (index > -1) {
-                this.keywordFilter.splice(index, 1);
+                this.keywordFilter.splice(index, 1)
             } else {
                 this.keywordFilter.push(keyword)
             }
@@ -64,11 +64,13 @@ export default {
          */
         recipeVisible: function(index) {     
             if (this.keywordFilter.length == 0) {
-                return true;
+                return true
             } else {
-                if (!this.results[index].keywords) return false;
-                let kw_array = this.results[index].keywords.split(',');
-                return this.keywordFilter.every(kw => kw_array.includes(kw));
+                if (!this.results[index].keywords) {
+                    return false
+                }
+                let kw_array = this.results[index].keywords.split(',')
+                return this.keywordFilter.every(kw => kw_array.includes(kw))
             }
         },
         /**
@@ -85,7 +87,7 @@ export default {
                             }
                         })
                     }
-                });
+                })
             }
         },
         setup: function() {


### PR DESCRIPTION
Regarding #188.

Added tag cloud between the breadcrumb nav and the recipe overview grid. What it currently does, is

- show all keywords of the displayed recipes
- keywords are selectable
- selecting one or multiple keywords shows only recipes in the current category/search that have all keywords attached

### Things to consider

- I changed the backend in such a way that not only the recipe name and id are returned anymore, but also a comma-separated string of keywords. The idea is to prevent querying the keywords of each recipe but only having a single database call.
- I wasn’t able to get a `GROUP_CONCAT` working with the QueryBuilder. This might be more efficient than my workaround, so if anyone knows how to get this working - feel free to contribute! 

Feedback, as always, welcome.

<img width="802" alt="Screenshot 2020-11-08 at 14 30 50" src="https://user-images.githubusercontent.com/7623143/98466318-1a697d80-21cf-11eb-9f57-1cc695bfd7b3.png">


