### PR TITLE
Update phpunit framework to most recent version

### DIFF
--- a/.github/actions/run-tests/tests/install.sh
+++ b/.github/actions/run-tests/tests/install.sh
@@ -18,7 +18,7 @@ function configure_gd_without ()
 
 function configure_gd()
 {
-	if [ "$1" = "7.2" ]; then
+	if [ "$1" = "7.2" -o "$1" = "7.3" ]; then
 		configure_gd_without
 		return $?
 	else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - Changes to `.gitignore` file
 - Translation issues
 - Added available Android apps to README
+- Update dev dependencies to recent phpunit to avoid warnings and issues
+  [#376](https://github.com/nextcloud/cookbook/pull/376) @christianlupus
 
 ### Fixed
 - Add a min PHP restriction in the metadata

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
       "ext-libxml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=9.0",
+        "phpunit/phpunit": ">=8.0",
         "nikic/php-parser": "4.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
       "ext-libxml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.4"
+        "phpunit/phpunit": ">=9.0",
+        "nikic/php-parser": "4.2"
     }
 }


### PR DESCRIPTION
We have to be compatible with the phpunit framework version chosen by the NC server. Otherwise we get warnings and other issues during code testing.