### PR TITLE
Support dateCreated and dateModified fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
   [#402](https://github.com/nextcloud/cookbook/pull/402/) @seyfeb
 - Allow checking of ingredients in web UI
   [#393](https://github.com/nextcloud/cookbook/pull/393) @christianlupus
+- Support for dateCreated and dateModified field of schema.org Recipe
+  [#377](https://github.com/nextcloud/cookbook/pull/366/) @seyfeb
 
 ### Changed
 - Switch of project ownership to neextcloud organization in GitHub

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -64,6 +64,8 @@ OC.L10N.register(
     "Loading recipe failed" : "Laden des Rezepts fehlgeschlagen",
     "Recipe could not be saved" : "Rezept konnte nicht gespeichert werden",
     "Cooking time is up!" : "Die Kochzeit ist vorbei!",
-    "Source" : "Quelle"
+    "Source" : "Quelle",
+    "Date created" : "Erzeugt am",
+    "Last modified" : "Zuletzt geändert"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -62,6 +62,8 @@
     "Loading recipe failed" : "Laden des Rezepts fehlgeschlagen",
     "Recipe could not be saved" : "Rezept konnte nicht gespeichert werden",
     "Cooking time is up!" : "Die Kochzeit ist vorbei!",
-    "Source" : "Quelle"
+    "Source" : "Quelle",
+    "Date created" : "Erzeugt am",
+    "Last modified" : "Zuletzt geändert"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -64,6 +64,8 @@ OC.L10N.register(
     "Loading recipe failed" : "Laden des Rezepts fehlgeschlagen",
     "Recipe could not be saved" : "Rezept konnte nicht gespeichert werden",
     "Cooking time is up!" : "Die Kochzeit ist vorbei!",
-    "Source" : "Quelle"
+    "Source" : "Quelle",
+    "Date created" : "Erzeugt am",
+    "Last modified" : "Zuletzt geändert"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -62,6 +62,8 @@
     "Loading recipe failed" : "Laden des Rezepts fehlgeschlagen",
     "Recipe could not be saved" : "Rezept konnte nicht gespeichert werden",
     "Cooking time is up!" : "Die Kochzeit ist vorbei!",
-    "Source" : "Quelle"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+    "Source" : "Quelle",
+    "Date created" : "Erzeugt am",
+    "Last modified" : "Zuletzt geändert"
+    },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -64,6 +64,8 @@ OC.L10N.register(
     "Loading recipe failed" : "Loading recipe failed",
     "Recipe could not be saved" : "Recipe could not be saved",
     "Cooking time is up!" : "Cooking time is up!",
-    "Source" : "Source"
+    "Source" : "Source",
+    "Date created" : "Date created",
+    "Last modified" : "Last modified"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -62,6 +62,8 @@
     "Loading recipe failed" : "Loading recipe failed",
     "Recipe could not be saved" : "Recipe could not be saved",
     "Cooking time is up!" : "Cooking time is up!",
-    "Source" : "Source"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+    "Source" : "Source",
+    "Date created" : "Date created",
+    "Last modified" : "Last modified"
+    },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -657,8 +657,13 @@ class RecipeService {
 			throw new Exception('Recipe name not found');
 		}
 
+		$now = date(DATE_ISO8601);
+
 		// Sanity check
 		$json = $this->checkRecipe($json);
+
+		// Update modification date
+		$json['dateModified'] = $now;
 
 		// Create/move recipe folder
 		$user_folder = $this->getFolderForUser();
@@ -682,6 +687,8 @@ class RecipeService {
 
 			// This is a new recipe, create it
 		} else {
+			$json['dateCreated'] = $now;
+
 			if ($user_folder->nodeExists($json['name'])) {
 				throw new Exception('Another recipe with that name already exists');
 			}
@@ -1041,11 +1048,13 @@ class RecipeService {
 
 		$json['id'] = $file->getParent()->getId();
 
-		if (method_exists($file, 'getCreationTime')) {
+
+		if (!array_key_exists('dateCreated', $json) && method_exists($file, 'getCreationTime')) {
 			$json['dateCreated'] = $file->getCreationTime();
 		}
-		
-		$json['dateModified'] = $file->getMTime();
+		if (!array_key_exists('dateModified', $json)) {
+			$json['dateModified'] = $file->getMTime();
+		}
 
 		return $this->checkRecipe($json);
 	}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/mrzapp/nextcloud-cookbook#readme",
   "dependencies": {
     "@nextcloud/event-bus": "^1.1.4",
+    "@nextcloud/moment": "^1.1.1",
     "@nextcloud/vue": "^1.5.0",
     "lozad": "^1.16.0",
     "vue": "^2.6.11",

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -15,11 +15,11 @@
                     </ul>
                 </p>
                 <p class="dates">
-                    <span v-if="showCreatedDate" class="date" title="t('cookbook', 'Date created')">
+                    <span v-if="showCreatedDate" class="date"  :title="t('cookbook', 'Date created')">
                         <span class="icon-calendar-dark date-icon" />
                         <span class="date-text">{{ dateCreated }}</span>
                     </span>
-                    <span v-if="showModifiedDate" class="date" title="t('cookbook', 'Last modified')">
+                    <span v-if="showModifiedDate" class="date" :title="t('cookbook', 'Last modified')">
                         <span class="icon-rename date-icon" />
                         <span class="date-text">{{ dateModified }}</span>
                     </span>


### PR DESCRIPTION
Regarding #131, I added schema.org Recipe’s `dateCreated` and `dateModified` fields to the recipe view.

These also set/updated when creating or updating a recipe.

The recipe view 
- shows the created date if available
- shows the modified date if its
  - available
  - not the same as the dateCreated timestamp

Date & time are localized.

![Screenshot 2020-11-09 at 14 38 48](https://user-images.githubusercontent.com/7623143/98548016-49e4bc80-2299-11eb-95ce-dad049dad88b.png)