### PR TITLE
Fixes null when creating new recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
   [#371](https://github.com/nextcloud/cookbook/pull/371) @christianlupus
 - Hide tooltips in printouts
   [#343](https://github.com/nextcloud/cookbook/pull/343/) @christianlupus
+- Creating new recipe not possible due to null reference
+  [#378](https://github.com/nextcloud/cookbook/pull/378/) @seyfeb
 
 ### Removed
 - Travis build system

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -190,7 +190,6 @@ export default {
                 // Always set the active page last!
                 this.$store.dispatch('setPage', { page: 'edit' })
             } else {
-                this.recipe = this.recipeInit
                 this.prepTime = [0, 0]
                 this.cookTime = [0, 0]
                 this.totalTime = [0, 0]


### PR DESCRIPTION
Creating new recipes is currently not working since the `recipe` variable is null. This PR should fix it.