### PR TITLE
Parse multiline ingredients and tools into separate fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   [#366](https://github.com/nextcloud/cookbook/pull/366/) @christianlupus
 - Keyword cloud is displayed in recipe
   [#373](https://github.com/nextcloud/cookbook/pull/373/) @seyfeb
+- Pasted content with newlines creates new input fields automatically for tools and ingredients in recipe editor
+  [#379](https://github.com/nextcloud/cookbook/pull/379/) @seyfeb
 
 ### Changed
 - Switch of project ownership to neextcloud organization in GitHub

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -4,8 +4,8 @@
         <ul ref="list">
             <li :class="fieldType" v-for="(entry,idx) in $parent.recipe[fieldName]" :key="fieldName+idx">
                 <div v-if="fieldName==='recipeInstructions'" class="step-number">{{ parseInt(idx) + 1 }}</div>
-                <input v-if="fieldType==='text'" type="text" @keyup="keyPressed" :value="$parent.recipe[fieldName][idx]" v-on:input="inputFieldChange" @paste="handlePaste" />
-                <textarea v-else-if="fieldType==='textarea'" :value="$parent.recipe[fieldName][idx]" v-on:input="inputFieldChange" @paste="handlePaste"></textarea>
+                <input v-if="fieldType==='text'" type="text" @keyup="keyPressed" :value="$parent.recipe[fieldName][idx]" v-on:input="handleFieldChange" @paste="handlePaste" />
+                <textarea v-else-if="fieldType==='textarea'" :value="$parent.recipe[fieldName][idx]" v-on:input="handleFieldChange" @paste="handlePaste"></textarea>
                 <div class="controls">
                     <button class="icon-arrow-up" @click="moveUp(idx)"></button>
                     <button class="icon-arrow-down" @click="moveDown(idx)"></button>
@@ -70,7 +70,7 @@ export default {
         /** 
          * Handle typing in input or field or textarea
          */
-        inputFieldChange: function(e) {  
+        handleFieldChange: function(e) {  
             // wait a tick to check if content was typed or pasted
             this.$nextTick(function() {
                 if (this.contentPasted) {
@@ -105,12 +105,11 @@ export default {
             let $inserted_index = $li.index()
             let $ul = $li.parents('ul')
 
-            if (this.fieldType === 'textarea') {
-                for (let i = input_lines_array.length-1; i >= 0; --i)
-                {
-                    if (input_lines_array[i].trim() == '') {
-                        input_lines_array.splice(i, 1)
-                    }
+            // Remove empty lines
+            for (let i = input_lines_array.length-1; i >= 0; --i)
+            {
+                if (input_lines_array[i].trim() == '') {
+                    input_lines_array.splice(i, 1)
                 }
             }
             for (let i = 0; i < input_lines_array.length; ++i)

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -4,7 +4,7 @@
         <ul ref="list">
             <li :class="fieldType" v-for="(entry,idx) in $parent.recipe[fieldName]" :key="fieldName+idx">
                 <div v-if="fieldName==='recipeInstructions'" class="step-number">{{ parseInt(idx) + 1 }}</div>
-                <input v-if="fieldType==='text'" type="text" v-model="$parent.recipe[fieldName][idx]" @keyup="keyPressed" />
+                <input v-if="fieldType==='text'" type="text" @keyup="keyPressed" :value="$parent.recipe[fieldName][idx]" v-on:input="inputFieldChange" @paste="inputFieldPaste" />
                 <textarea v-else-if="fieldType==='textarea'" v-model="$parent.recipe[fieldName][idx]"></textarea>
                 <div class="controls">
                     <button class="icon-arrow-up" @click="moveUp(idx)"></button>
@@ -19,41 +19,111 @@
 
 <script>
 export default {
-    name: "EditInputGroup",
-    props: ['fieldType','fieldName','fieldLabel'],
+    name: "EditInputGroup",  
+    props: {
+        fieldType: String,
+        fieldName: String,
+        fieldLabel: String,
+        // Add new fields, for newlines in pasted data
+        createFieldsOnNewlines: {
+            type: Boolean,
+            default: false
+        },
+    },
     data () {
         return {
+            // helper variables
+            contentPasted: false
         }
     },
     methods: {
-        addNew: function() {
+        /* if index = -1, element is added at the end
+         * if focusAfterInsert=true, the element is focussed after inserting
+         * the content is inserted into the newly created field
+         **/
+        addNew: function(index = -1, focusAfterInsert = true, content = '') {
             // This is a dirty hack, but Vue components update with a slight delay so you
             // can't just straight up go and set focus here
-            let nextFocus = this.$parent.recipe[this.fieldName].length
-            this.$parent.addEntry(this.fieldName)
-            let failSafe = 2500
-            let $ul = $(this.$refs['list'])
-            let $this = this
-            let focusMonitor = window.setInterval(function() {
-                if ($ul.children('li').length > nextFocus) {
-                    if ($this.fieldType === 'text') {
-                        $ul.children('li').eq(nextFocus).find('input').focus()
-                    } else if ($this.fieldType === 'textarea') {
-                        $ul.children('li').eq(nextFocus).find('textarea').focus()
+            let nextFocus = index
+            if (nextFocus === -1) {
+                nextFocus = this.$parent.recipe[this.fieldName].length
+            }
+            this.$parent.addEntry(this.fieldName, nextFocus, content)
+
+            if (focusAfterInsert) {
+                let failSafe = 2500
+                let $ul = $(this.$refs['list'])
+                let $this = this
+                let focusMonitor = window.setInterval(function() {
+                    if ($ul.children('li').length > nextFocus) {
+                        if ($this.fieldType === 'text') {
+                            $ul.children('li').eq(nextFocus).find('input').focus()
+                        } else if ($this.fieldType === 'textarea') {
+                            $ul.children('li').eq(nextFocus).find('textarea').focus()
+                        }
+                        window.clearInterval(focusMonitor)
                     }
-                    window.clearInterval(focusMonitor)
-                }
-                failSafe -= 100
-                if (!failSafe) {
-                    window.clearInterval(focusMonitor)
-                }
-            }, 100)
+                    failSafe -= 100
+                    if (!failSafe) {
+                        window.clearInterval(focusMonitor)
+                    }
+                }, 100)
+            }
         },
         /**
          * Delete an entry from the list
          */
         deleteEntry: function(idx) {
             this.$parent.deleteEntry(this.fieldName, idx)
+        },
+        /** 
+         * Handle typing in input field 
+         */
+        inputFieldChange: function(e) {  
+            // wait a tick to check if content was typed or pasted
+            this.$nextTick(function() {
+                if (this.contentPasted) {
+                    this.contentPasted = false
+                    return
+                }
+                let $li = $(e.currentTarget).parents('li')
+                this.$parent.recipe[this.fieldName][$li.index()] = e.target.value
+            })
+        },
+        /** 
+         * Handle paste in input field 
+         */
+        inputFieldPaste: function(e) {
+            this.contentPasted = true
+            if (!this.createFieldsOnNewlines) {
+                return
+            }
+            e.preventDefault();
+
+            // get data from clipboard to keep newline characters, which are stripped
+            // from the data pasted in the input field (e.target.value)
+            var clipboardData = e.clipboardData || window.clipboardData;
+            var pastedData = clipboardData.getData('Text');
+
+            let $li = $(e.currentTarget).parents('li')
+            let $inserted_index = $li.index()
+            let $ul = $li.parents('ul')
+
+            let input_lines_array = pastedData.split(/\r\n|\r|\n/g)
+            for (let i = 0; i < input_lines_array.length; ++i)
+            {
+                this.addNew($inserted_index+i+1, false, input_lines_array[i])
+            }
+            this.$nextTick(function() {
+                let indexToFocus = $inserted_index+input_lines_array.length
+                // Delete field if it's empty
+                if (this.$parent.recipe[this.fieldName][$inserted_index].trim() == "" ) {
+                    this.deleteEntry($inserted_index)
+                    indexToFocus--
+                }
+                $ul.children('li').eq(indexToFocus).find('input').focus()
+                this.contentPasted = false
+            })
         },
         /**
          * Catches enter and key down presses and either adds a new row or focuses the one below

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -92,14 +92,14 @@ export default {
 
             // get data from clipboard to keep newline characters, which are stripped
             // from the data pasted in the input field (e.target.value)
-            var clipboardData = e.clipboardData || window.clipboardData;
-            var pastedData = clipboardData.getData('Text');
+            var clipboardData = e.clipboardData || window.clipboardData
+            var pastedData = clipboardData.getData('Text')
 
             let input_lines_array = pastedData.split(/\r\n|\r|\n/g)
             if ( input_lines_array.length == 1) {
                 return
             }
-            e.preventDefault();
+            e.preventDefault()
 
             let $li = $(e.currentTarget).parents('li')
             let $inserted_index = $li.index()

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -4,8 +4,8 @@
         <ul ref="list">
             <li :class="fieldType" v-for="(entry,idx) in $parent.recipe[fieldName]" :key="fieldName+idx">
                 <div v-if="fieldName==='recipeInstructions'" class="step-number">{{ parseInt(idx) + 1 }}</div>
-                <input v-if="fieldType==='text'" type="text" @keyup="keyPressed" :value="$parent.recipe[fieldName][idx]" v-on:input="inputFieldChange" @paste="inputFieldPaste" />
-                <textarea v-else-if="fieldType==='textarea'" v-model="$parent.recipe[fieldName][idx]"></textarea>
+                <input v-if="fieldType==='text'" type="text" @keyup="keyPressed" :value="$parent.recipe[fieldName][idx]" v-on:input="inputFieldChange" @paste="handlePaste" />
+                <textarea v-else-if="fieldType==='textarea'" :value="$parent.recipe[fieldName][idx]" v-on:input="inputFieldChange" @paste="handlePaste"></textarea>
                 <div class="controls">
                     <button class="icon-arrow-up" @click="moveUp(idx)"></button>
                     <button class="icon-arrow-down" @click="moveDown(idx)"></button>
@@ -24,7 +24,7 @@ export default {
         fieldType: String,
         fieldName: String,
         fieldLabel: String,
-        // Add new fields, for newlines in pasted data
+        // If true, add new fields, for newlines in pasted data
         createFieldsOnNewlines: {
             type: Boolean,
             default: false
@@ -68,7 +68,7 @@ export default {
             this.$parent.deleteEntry(this.fieldName, idx)
         },
         /** 
-         * Handle typing in input field 
+         * Handle typing in input or field or textarea
          */
         inputFieldChange: function(e) {  
             // wait a tick to check if content was typed or pasted
@@ -82,25 +82,37 @@ export default {
             })
         },
         /** 
-         * Handle paste in input field 
+         * Handle paste in input field or textarea
          */
-        inputFieldPaste: function(e) {
+        handlePaste: function(e) {
             this.contentPasted = true
             if (!this.createFieldsOnNewlines) {
                 return
             }
-            e.preventDefault();
 
             // get data from clipboard to keep newline characters, which are stripped
             // from the data pasted in the input field (e.target.value)
             var clipboardData = e.clipboardData || window.clipboardData;
             var pastedData = clipboardData.getData('Text');
 
+            let input_lines_array = pastedData.split(/\r\n|\r|\n/g)
+            if ( input_lines_array.length == 1) {
+                return
+            }
+            e.preventDefault();
+
             let $li = $(e.currentTarget).parents('li')
             let $inserted_index = $li.index()
             let $ul = $li.parents('ul')
 
-            let input_lines_array = pastedData.split(/\r\n|\r|\n/g)
+            if (this.fieldType === 'textarea') {
+                for (let i = input_lines_array.length-1; i >= 0; --i)
+                {
+                    if (input_lines_array[i].trim() == '') {
+                        input_lines_array.splice(i, 1)
+                    }
+                }
+            }
             for (let i = 0; i < input_lines_array.length; ++i)
             {
                 this.addNew($inserted_index+i+1, false, input_lines_array[i])

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -42,32 +42,23 @@ export default {
          * the content is inserted into the newly created field
          **/
         addNew: function(index = -1, focusAfterInsert = true, content = '') {
-            // This is a dirty hack, but Vue components update with a slight delay so you
-            // can't just straight up go and set focus here
-            let nextFocus = index
-            if (nextFocus === -1) {
-                nextFocus = this.$parent.recipe[this.fieldName].length
+            if (index === -1) {
+                index = this.$parent.recipe[this.fieldName].length
             }
-            this.$parent.addEntry(this.fieldName, nextFocus, content)
+            this.$parent.addEntry(this.fieldName, index, content)
 
             if (focusAfterInsert) {
-                let failSafe = 2500
                 let $ul = $(this.$refs['list'])
                 let $this = this
-                let focusMonitor = window.setInterval(function() {
-                    if ($ul.children('li').length > nextFocus) {
+                this.$nextTick(function() {
+                    if ($ul.children('li').length > index) {
                         if ($this.fieldType === 'text') {
-                            $ul.children('li').eq(nextFocus).find('input').focus()
+                            $ul.children('li').eq(index).find('input').focus()
                         } else if ($this.fieldType === 'textarea') {
-                            $ul.children('li').eq(nextFocus).find('textarea').focus()
+                            $ul.children('li').eq(index).find('textarea').focus()
                         }
-                        window.clearInterval(focusMonitor)
                     }
-                    failSafe -= 100
-                    if (!failSafe) {
-                        window.clearInterval(focusMonitor)
-                    }
-                }, 100)
+                })
             }
         },
         /**

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -8,10 +8,10 @@
         <EditTimeField :fieldName="'cookTime'" :fieldLabel="t('cookbook', 'Cooking time')" />
         <EditTimeField :fieldName="'totalTime'" :fieldLabel="t('cookbook', 'Total time')" />
         <EditInputField :fieldName="'recipeCategory'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Category')" />
-        <EditInputField :fieldName="'keywords'" :fieldType="'rext'" :fieldLabel="t('cookbook', 'Keywords (comma separated)')" />
+        <EditInputField :fieldName="'keywords'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Keywords (comma separated)')" />
         <EditInputField :fieldName="'recipeYield'" :fieldType="'number'" :fieldLabel="t('cookbook', 'Servings')" />
-        <EditInputGroup :fieldName="'tool'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Tools')" />
-        <EditInputGroup :fieldName="'recipeIngredient'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Ingredients')" />
+        <EditInputGroup :fieldName="'tool'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Tools')"  v-bind:createFieldsOnNewlines="true" />
+        <EditInputGroup :fieldName="'recipeIngredient'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Ingredients')" v-bind:createFieldsOnNewlines="true" />
         <EditInputGroup :fieldName="'recipeInstructions'" :fieldType="'textarea'" :fieldLabel="t('cookbook', 'Instructions')" />
     </div>
 </template>
@@ -77,8 +77,8 @@ export default {
         },
     },
     methods: {
-        addEntry: function(field) {
-            this.recipe[field].push('')
+        addEntry: function(field, index, content='') {
+            this.recipe[field].splice(index, 0, content)
         },
         deleteEntry: function(field, index) {
             this.recipe[field].splice(index, 1)

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -195,6 +195,7 @@ export default {
                 this.totalTime = [0, 0]
                 this.$store.dispatch('setPage', { page: 'create' })
             }
+            this.recipeInit = this.recipe
         },
     },
     mounted () {

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -12,7 +12,7 @@
         <EditInputField :fieldName="'recipeYield'" :fieldType="'number'" :fieldLabel="t('cookbook', 'Servings')" />
         <EditInputGroup :fieldName="'tool'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Tools')"  v-bind:createFieldsOnNewlines="true" />
         <EditInputGroup :fieldName="'recipeIngredient'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Ingredients')" v-bind:createFieldsOnNewlines="true" />
-        <EditInputGroup :fieldName="'recipeInstructions'" :fieldType="'textarea'" :fieldLabel="t('cookbook', 'Instructions')" />
+        <EditInputGroup :fieldName="'recipeInstructions'" :fieldType="'textarea'" :fieldLabel="t('cookbook', 'Instructions')"  v-bind:createFieldsOnNewlines="true" />
     </div>
 </template>
 


### PR DESCRIPTION
In the recipe editor, pasting content with newlines in a tools or ingredients field automatically creates new fields.

For textareas (recipe steps) this is not done.


Closes #325.