### PR TITLE
Removing tight coupling in recipe-editing vue components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@
   [#437](https://github.com/nextcloud/cookbook/pull/437) @christianlupus
 - Corrected bugs in CI system
   [#447](https://github.com/nextcloud/cookbook/pull/447) @christianlupus
+- Recipe-editing Vue components are not tightly coupled anymore
+  [#386](https://github.com/nextcloud/cookbook/pull/386/) @seyfeb
 
 ### Removed
 - Travis build system

--- a/src/components/EditImageField.vue
+++ b/src/components/EditImageField.vue
@@ -3,7 +3,7 @@
         <label>
             {{ fieldLabel }}
         </label>
-        <input type="text" v-model="$parent.recipe[fieldName]" />
+        <input type="text" v-model="content" />
         <button type="button" :title="t('cookbook', 'Pick a local image')" @click="pickImage"><span class="icon-category-multimedia"></span></button>
     </fieldset>
 </template>
@@ -11,20 +11,25 @@
 <script>
 export default {
     name: "EditImageField",
-    props: ['fieldName','fieldLabel'],
+    props: ['value','fieldLabel'],
     data () {
         return {
-
+            content: ''
+        }
+    },
+    watch: {
+        value: function() {
+            this.content = this.value
         }
     },
     methods: {
         pickImage: function(e) {
             e.preventDefault()
             let $this = this
-            OC.dialogs.filepicker(
+            OC.dialogs.filepicker (
                 t('cookbook', 'Path to your recipe image'),
                 function (path) {
-                    $this.$parent.recipe.image = path
+                    $this.$emit('input', path)
                 },
                 false,
                 ['image/jpeg', 'image/png'],

--- a/src/components/EditInputField.vue
+++ b/src/components/EditInputField.vue
@@ -3,20 +3,30 @@
         <label>
             {{ fieldLabel }}
         </label>
-        <input v-if="fieldType!=='textarea'" :type="fieldType" v-model="$parent.recipe[fieldName]" />
-        <textarea v-if="fieldType==='textarea'" v-model="$parent.recipe[fieldName]" />
+        <input v-if="fieldType!=='textarea'" :type="fieldType" v-model="content" @input="handleInput" />
+        <textarea v-if="fieldType==='textarea'" v-model="content" @input="handleInput" />
     </fieldset>
 </template>
 
 <script>
 export default {
     name: "EditInputField",
-    props: ['fieldType','fieldName','fieldLabel'],
+    props: ['value','fieldType','fieldLabel'],
     data () {
         return {
-
+            content: ''
         }
     },
+    watch: {
+        value: function() {
+            this.content = this.value
+        }
+    },
+    methods: {
+        handleInput (e) {
+            this.$emit('input', this.content)
+        },
+    }
 }
 </script>
 

--- a/src/components/EditTimeField.vue
+++ b/src/components/EditTimeField.vue
@@ -1,25 +1,53 @@
 <template>
     <fieldset>
         <label>{{ fieldLabel }}</label>
-        <input type="number" min="0" v-model="$parent[fieldName][0]" placeholder="00">
+        <input type="number" min="0" v-model="hours" placeholder="00" @input="handleInput">
         <span>:</span>
-        <input type="number" min="0" max="59" v-model="$parent[fieldName][1]" placeholder="00">
+        <input type="number" min="0" max="59" v-model="minutes" placeholder="00" @input="handleInput">
     </fieldset>
 </template>
 
 <script>
 export default {
     name: "EditTimeField",
-    props: ['fieldName','fieldLabel'],
+    props: {
+        value: {
+            type: Object,
+            required: true,
+            default: {
+                time: [null, null],
+                paddedTime: null
+            }
+        },
+        fieldLabel: String,
+    },
     data () {
         return {
+            minutes: null,
+            hours: null,
         }
     },
-    computed: {
+    watch: {
+        value: function() {
+            this.hours = this.value.time[0]
+            this.minutes = this.value.time[1]
+        }
     },
     methods: {
-    },
-    mounted () {
+
+        handleInput () {
+            this.minutes = this.minutes ? this.minutes : 0
+            this.hours = this.hours ? this.hours : 0
+
+            // create padded time string
+            let hours_p = this.hours.toString().padStart(2, '0')
+            let mins_p = this.minutes.toString().padStart(2, '0')
+            
+            this.$emit('input', {
+                time: [this.hours, this.minutes],
+                paddedTime:  'PT' + hours_p + 'H' + mins_p + 'M'
+                })
+        },
     },
 }
 </script>

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -1,15 +1,15 @@
 <template>
     <div class="wrapper">
-        <EditInputField :fieldName="'name'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Name')" />
-        <EditInputField :fieldName="'description'" :fieldType="'textarea'" :fieldLabel="t('cookbook', 'Description')" />
-        <EditInputField :fieldName="'url'" :fieldType="'url'" :fieldLabel="t('cookbook', 'URL')" />
+        <EditInputField :fieldType="'text'" :fieldLabel="t('cookbook', 'Name')" v-model="recipe['name']" />
+        <EditInputField :fieldType="'textarea'" :fieldLabel="t('cookbook', 'Description')" v-model="recipe['description']" />
+        <EditInputField :fieldType="'url'" :fieldLabel="t('cookbook', 'URL')" v-model="recipe['url']" />
         <EditImageField :fieldName="'image'" :fieldLabel="t('cookbook', 'Image')" />
         <EditTimeField :fieldName="'prepTime'" :fieldLabel="t('cookbook', 'Preparation time')" />
         <EditTimeField :fieldName="'cookTime'" :fieldLabel="t('cookbook', 'Cooking time')" />
         <EditTimeField :fieldName="'totalTime'" :fieldLabel="t('cookbook', 'Total time')" />
         <EditMultiselect :fieldLabel="t('cookbook', 'Category')" :placeholder="t('cookbook', 'Choose category')" v-model="recipe['recipeCategory']" :options="allCategories" :taggable="true" :multiple="false" :loading="isFetchingCategories" @tag="addCategory" />
         <EditMultiselect :fieldLabel="t('cookbook', 'Keywords')" :placeholder="t('cookbook', 'Choose keywords')" v-model="selectedKeywords" :options="allKeywords" :taggable="true" :multiple="true" :tagWidth="60" :loading="isFetchingKeywords" @tag="addKeyword" />
-        <EditInputField :fieldName="'recipeYield'" :fieldType="'number'" :fieldLabel="t('cookbook', 'Servings')" />
+        <EditInputField :fieldType="'number'" :fieldLabel="t('cookbook', 'Servings')" v-model="recipe['recipeYield']" />
         <EditMultiselectInputGroup :fieldLabel="t('cookbook', 'Nutrition Information')" v-model="recipe['nutrition']" :options="availableNutritionFields" />
         <EditInputGroup :fieldName="'tool'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Tools')"  v-model="recipe['tool']" v-bind:createFieldsOnNewlines="true" />
         <EditInputGroup :fieldName="'recipeIngredient'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Ingredients')" v-model="recipe['recipeIngredient']" v-bind:createFieldsOnNewlines="true" />

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -291,14 +291,34 @@ export default {
                 // Always set the active page last!
                 this.$store.dispatch('setPage', { page: 'edit' })
             } else {
-                this.prepTime = [0, 0]
-                this.cookTime = [0, 0]
-                this.totalTime = [0, 0]
-                this.nutrition = {}
+                this.initEmptyRecipe()
                 this.$store.dispatch('setPage', { page: 'create' })
             }
             this.recipeInit = this.recipe
         },
+        initEmptyRecipe: function() {
+            this.prepTime = { time: [0, 0], paddedTime: '' }
+            this.cookTime = { time: [0, 0], paddedTime: '' }
+            this.totalTime = { time: [0, 0], paddedTime: '' }
+            this.nutrition = {}
+            this.recipe = {
+                id: 0,
+                name: null,
+                description: '',
+                url: '',
+                image: '',
+                prepTime: '',
+                cookTime: '',
+                totalTime: '',
+                recipeCategory: '',
+                keywords: '',
+                recipeYield: '',
+                tool: [],
+                recipeIngredient: [],
+                recipeInstructions: [],
+                nutrition: {}
+            }
+        }
     },
     mounted () {
         // Store the initial recipe configuration for possible later use

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -4,9 +4,9 @@
         <EditInputField :fieldType="'textarea'" :fieldLabel="t('cookbook', 'Description')" v-model="recipe['description']" />
         <EditInputField :fieldType="'url'" :fieldLabel="t('cookbook', 'URL')" v-model="recipe['url']" />
         <EditImageField :fieldLabel="t('cookbook', 'Image')" v-model="recipe['image']" />
-        <EditTimeField :fieldName="'prepTime'" :fieldLabel="t('cookbook', 'Preparation time')" />
-        <EditTimeField :fieldName="'cookTime'" :fieldLabel="t('cookbook', 'Cooking time')" />
-        <EditTimeField :fieldName="'totalTime'" :fieldLabel="t('cookbook', 'Total time')" />
+        <EditTimeField :fieldLabel="t('cookbook', 'Preparation time')" v-model="prepTime" />
+        <EditTimeField :fieldLabel="t('cookbook', 'Cooking time')" v-model="cookTime" />
+        <EditTimeField :fieldLabel="t('cookbook', 'Total time')" v-model="totalTime" />
         <EditMultiselect :fieldLabel="t('cookbook', 'Category')" :placeholder="t('cookbook', 'Choose category')" v-model="recipe['recipeCategory']" :options="allCategories" :taggable="true" :multiple="false" :loading="isFetchingCategories" @tag="addCategory" />
         <EditMultiselect :fieldLabel="t('cookbook', 'Keywords')" :placeholder="t('cookbook', 'Choose keywords')" v-model="selectedKeywords" :options="allKeywords" :taggable="true" :multiple="true" :tagWidth="60" :loading="isFetchingKeywords" @tag="addKeyword" />
         <EditInputField :fieldType="'number'" :fieldLabel="t('cookbook', 'Servings')" v-model="recipe['recipeYield']" />
@@ -58,10 +58,11 @@ export default {
             // This will hold the above configuration after recipe is loaded, so we don't have to
             // keep it up to date in multiple places if it changes later
             recipeInit: null,
+
             // These are helper variables
-            prepTime: [0, 0],
-            cookTime: [0, 0],
-            totalTime: [0, 0],
+            prepTime: { time: [0, 0], paddedTime: '' },
+            cookTime: { time: [0, 0], paddedTime: '' },
+            totalTime: { time: [0, 0], paddedTime: '' },
             allCategories: [],
             isFetchingCategories: true,
             isFetchingKeywords: true,
@@ -83,20 +84,23 @@ export default {
         }
     },
     watch: {
-        prepTime () {
-            let hours = this.prepTime[0].toString().padStart(2, '0')
-            let mins = this.prepTime[1].toString().padStart(2, '0')
-            this.recipe.prepTime = 'PT' + hours + 'H' + mins + 'M'
+        prepTime: {
+            handler () {
+                this.recipe.prepTime = this.prepTime.paddedTime
+            },
+            deep: true
         },
-        cookTime () {
-            let hours = this.cookTime[0].toString().padStart(2, '0')
-            let mins = this.cookTime[1].toString().padStart(2, '0')
-            this.recipe.cookTime = 'PT' + hours + 'H' + mins + 'M'
+        cookTime: {
+            handler () {
+                this.recipe.cookTime = this.cookTime.paddedTime
+            },
+            deep: true,
         },
-        totalTime () {
-            let hours = this.totalTime[0].toString().padStart(2, '0')
-            let mins = this.totalTime[1].toString().padStart(2, '0')
-            this.recipe.totalTime = 'PT' + hours + 'H' + mins + 'M'
+        totalTime: {
+            handler () {
+                this.recipe.totalTime = this.totalTime.paddedTime
+            },
+            deep: true
         },
         selectedKeywords: {
             deep: true,
@@ -250,17 +254,21 @@ export default {
                 this.recipe = { ...this.$store.state.recipe }
                 // Parse time values
                 let timeComps = this.recipe.prepTime ? this.recipe.prepTime.match(/PT(\d+?)H(\d+?)M/) : null
-                if (timeComps) {
-                    this.prepTime = [timeComps[1], timeComps[2]]
-                }
+                this.prepTime = {
+                    time: timeComps ? [timeComps[1], timeComps[2]] : [0 , 0],
+                    paddedTime: this.recipe.prepTime }
+
                 timeComps = this.recipe.cookTime ? this.recipe.cookTime.match(/PT(\d+?)H(\d+?)M/) : null
-                if (timeComps) {
-                    this.cookTime = [timeComps[1], timeComps[2]]
-                }
+                this.cookTime = {
+                    time: timeComps ? [timeComps[1], timeComps[2]] : [0 , 0],
+                    cookTime: this.recipe.cookTime }
+
                 timeComps = this.recipe.totalTime ? this.recipe.totalTime.match(/PT(\d+?)H(\d+?)M/) : null
-                if (timeComps) {
-                    this.totalTime = [timeComps[1], timeComps[2]]
-                }
+
+                this.totalTime = {
+                    time: timeComps ? [timeComps[1], timeComps[2]] : [0 , 0],
+                    paddedTime: this.recipe.totalTime }
+
                 this.selectedKeywords = this.recipe['keywords'].split(',')
                 
                 // fallback if fetching all keywords fails

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -3,7 +3,7 @@
         <EditInputField :fieldType="'text'" :fieldLabel="t('cookbook', 'Name')" v-model="recipe['name']" />
         <EditInputField :fieldType="'textarea'" :fieldLabel="t('cookbook', 'Description')" v-model="recipe['description']" />
         <EditInputField :fieldType="'url'" :fieldLabel="t('cookbook', 'URL')" v-model="recipe['url']" />
-        <EditImageField :fieldName="'image'" :fieldLabel="t('cookbook', 'Image')" />
+        <EditImageField :fieldLabel="t('cookbook', 'Image')" v-model="recipe['image']" />
         <EditTimeField :fieldName="'prepTime'" :fieldLabel="t('cookbook', 'Preparation time')" />
         <EditTimeField :fieldName="'cookTime'" :fieldLabel="t('cookbook', 'Cooking time')" />
         <EditTimeField :fieldName="'totalTime'" :fieldLabel="t('cookbook', 'Total time')" />

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -54,6 +54,7 @@ export default {
                 tool: [],
                 recipeIngredient: [],
                 recipeInstructions: [],
+                nutrition: {}
             },
             // This will hold the above configuration after recipe is loaded, so we don't have to
             // keep it up to date in multiple places if it changes later
@@ -197,6 +198,9 @@ export default {
                 method: 'GET',
                 data: null,
             }).done(function (recipe) {
+                if ('nutrition' in recipe && recipe.nutrition instanceof Array) {
+                    recipe.nutrition = {}
+                }
                 $this.$store.dispatch('setRecipe', { recipe: recipe })
                 $this.setup()
             }).fail(function(e) {
@@ -283,12 +287,14 @@ export default {
                     this.allCategories.push(this.recipe['recipeCategory'])
                 }
 
+
                 // Always set the active page last!
                 this.$store.dispatch('setPage', { page: 'edit' })
             } else {
                 this.prepTime = [0, 0]
                 this.cookTime = [0, 0]
                 this.totalTime = [0, 0]
+                this.nutrition = {}
                 this.$store.dispatch('setPage', { page: 'create' })
             }
             this.recipeInit = this.recipe

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -11,9 +11,9 @@
         <EditMultiselect :fieldLabel="t('cookbook', 'Keywords')" :placeholder="t('cookbook', 'Choose keywords')" v-model="selectedKeywords" :options="allKeywords" :taggable="true" :multiple="true" :tagWidth="60" :loading="isFetchingKeywords" @tag="addKeyword" />
         <EditInputField :fieldName="'recipeYield'" :fieldType="'number'" :fieldLabel="t('cookbook', 'Servings')" />
         <EditMultiselectInputGroup :fieldLabel="t('cookbook', 'Nutrition Information')" v-model="recipe['nutrition']" :options="availableNutritionFields" />
-        <EditInputGroup :fieldName="'tool'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Tools')"  v-bind:createFieldsOnNewlines="true" />
-        <EditInputGroup :fieldName="'recipeIngredient'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Ingredients')" v-bind:createFieldsOnNewlines="true" />
-        <EditInputGroup :fieldName="'recipeInstructions'" :fieldType="'textarea'" :fieldLabel="t('cookbook', 'Instructions')"  v-bind:createFieldsOnNewlines="true" />
+        <EditInputGroup :fieldName="'tool'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Tools')"  v-model="recipe['tool']" v-bind:createFieldsOnNewlines="true" />
+        <EditInputGroup :fieldName="'recipeIngredient'" :fieldType="'text'" :fieldLabel="t('cookbook', 'Ingredients')" v-model="recipe['recipeIngredient']" v-bind:createFieldsOnNewlines="true" />
+        <EditInputGroup :fieldName="'recipeInstructions'" :fieldType="'textarea'" :fieldLabel="t('cookbook', 'Instructions')"  v-model="recipe['recipeInstructions']" v-bind:createFieldsOnNewlines="true" v-bind:showStepNumber="true" />
     </div>
 </template>
 
@@ -206,26 +206,6 @@ export default {
                 // Browse to new recipe creation
                 $this.$window.goTo('/recipe/create')
             })
-        },
-        moveEntryDown: function(field, index) {
-            if (index >= this.recipe[field].length - 1) {
-                // Already at the send of array
-                return
-            }
-            let entry = this.recipe[field].splice(index, 1)[0]
-            if (index + 1 < this.recipe[field].length) {
-                this.recipe[field].splice(index + 1, 0, entry)
-            } else {
-                this.recipe[field].push(entry)
-            }
-        },
-        moveEntryUp: function(field, index) {
-            if (index < 1) {
-                // Already at the start of array
-                return
-            }
-            let entry = this.recipe[field].splice(index, 1)[0]
-            this.recipe[field].splice(index - 1, 0, entry)
         },
         save: function() {
             this.$store.dispatch('setSavingRecipe', { saving: true })

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -141,7 +141,7 @@ export default {
             }
             return true
         },
-        showNutritions: function() { return this.nutrition && !(this.nutrition instanceof Array) }
+        showNutritions: function() { return this.nutrition && !(this.nutrition instanceof Array) && Object.keys(this.nutrition).length > 0 }
     },
     methods: {
         isNullOrEmpty: function(str) {
@@ -234,9 +234,14 @@ export default {
                     $this.dateModified = (date != null ? date.format('L, LT').toString() : null)
                 }
                 if ($this.$store.state.recipe.nutrition) {
-                    $this.nutrition = $this.$store.state.recipe.nutrition
+                    if ( $this.$store.state.recipe.nutrition instanceof Array) {
+                        $this.$store.state.recipe.nutrition = {}
+                    }
+                } else {
+                    $this.$store.state.recipe.nutrition = {}
                 }
-
+                $this.nutrition = $this.$store.state.recipe.nutrition
+                
                 // Always set the active page last!
                 $this.$store.dispatch('setPage', { page: 'recipe' })
 


### PR DESCRIPTION
I noticed that the editing components (`EditInputField`, `EditInputGroup`, etc.) are tightly coupled with `RecipeEdit` due to the references from the child to the parent component. As an example, look at the `EditInputField` component which sets a field in the `$parent`.

In this PR I removed the tight coupling which should allow/lead to

- a clear one-way dependency of those components
- more flexible ways of data binding
- v-model can be used on those components
- components can be reused in different places.

@sam-19 Could you have a look at this?