### PR TITLE
Added multiselection for categories and keywords to recipe editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   [#390](https://github.com/nextcloud/cookbook/pull/390) @christianlupus
 - Automatic deployment of new releases to the nextcloud app store
   [#433](https://github.com/nextcloud/cookbook/pull/433) @christianlupus
+- Category and keyword selection from list of existing ones in recipe editor
+  [#402](https://github.com/nextcloud/cookbook/pull/402/) @seyfeb
 
 ### Changed
 - Switch of project ownership to neextcloud organization in GitHub

--- a/src/components/EditMultiselect.vue
+++ b/src/components/EditMultiselect.vue
@@ -3,7 +3,6 @@
         <label>{{ fieldLabel }}</label>
         <Multiselect
             class="edit_ms"
-		    v-model="localValue"
             v-bind="$attrs"
             v-on="$listeners"
             />
@@ -16,35 +15,14 @@ export default {
     name: "EditMultiselect",
     components: {
         Multiselect
-    },
+    },   
     props: {
-		value: {
-			default() {
-				return []
-			},
-		},
         fieldLabel: String,
     },
     data () {
         return {
         }
-    },
-    computed: {
-        localValue: {
-			get() {
-				if (this.trackBy && this.options
-					&& typeof this.value !== 'object'
-					&& this.options[this.value]) {
-					return this.options[this.value]
-				}
-				return this.value
-			},
-			set(value) {
-				this.$emit('update:value', value)
-				this.$emit('change', value)
-			},
-		},
-    },
+    }
 }
 </script>
 

--- a/src/components/EditMultiselect.vue
+++ b/src/components/EditMultiselect.vue
@@ -1,0 +1,83 @@
+<template>
+    <fieldset>
+        <label>{{ fieldLabel }}</label>
+        <Multiselect
+            class="edit_ms"
+		    v-model="localValue"
+            v-bind="$attrs"
+            v-on="$listeners"
+            />
+    </fieldset>
+</template>
+
+<script>
+import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'
+export default {
+    name: "EditMultiselect",
+    components: {
+        Multiselect
+    },
+    props: {
+		value: {
+			default() {
+				return []
+			},
+		},
+        fieldLabel: String,
+    },
+    data () {
+        return {
+        }
+    },
+    computed: {
+        localValue: {
+			get() {
+				if (this.trackBy && this.options
+					&& typeof this.value !== 'object'
+					&& this.options[this.value]) {
+					return this.options[this.value]
+				}
+				return this.value
+			},
+			set(value) {
+				this.$emit('update:value', value)
+				this.$emit('change', value)
+			},
+		},
+    },
+}
+</script>
+
+<style scoped>
+
+fieldset {
+    margin-bottom: 1em;
+    width: 100%;
+}
+
+fieldset > * {
+    margin: 0;
+    float: left;
+}
+    @media(max-width:1199px) { fieldset > label {
+        display: block;
+        float: none;
+    }}
+fieldset > label {
+    display: inline-block;
+    width: 10em;
+    line-height: 18px;
+    font-weight: bold;
+    word-spacing: initial;
+    vertical-align: top;
+}
+
+.edit_ms {
+    width: calc(100% - 11em + 10px);
+}
+
+    @media(max-width:1199px) { .edit_ms {
+        width: 100%;
+    }}
+
+</style>

--- a/src/components/EditMultiselect.vue
+++ b/src/components/EditMultiselect.vue
@@ -2,7 +2,7 @@
     <fieldset>
         <label>{{ fieldLabel }}</label>
         <Multiselect
-            class="edit_ms"
+            class="edit-multiselect"
             v-bind="$attrs"
             v-on="$listeners"
             />
@@ -50,12 +50,38 @@ fieldset > label {
     vertical-align: top;
 }
 
-.edit_ms {
+.edit-multiselect {
     width: calc(100% - 11em + 10px);
 }
 
-    @media(max-width:1199px) { .edit_ms {
+    @media(max-width:1199px) { .edit-multiselect {
         width: 100%;
     }}
+</style>
 
+<style>
+#app
+.edit-multiselect
+.multiselect__tags {
+    height: auto;
+    min-height: 34px;
+}
+
+#app
+.edit-multiselect
+.multiselect__tags
+.multiselect__tags-wrap {
+    display: flex;
+    flex-wrap: wrap;
+    padding-bottom: 0px;
+}
+
+#app
+.edit-multiselect
+.multiselect__tags
+.multiselect__tags-wrap
+.multiselect__tag {
+    flex-basis: 50px;
+    margin-bottom: 3px;
+} 
 </style>


### PR DESCRIPTION
This PR adds a NC-styled `Multiselect` element for keywords and categories for faster insertion.

There is some collision with PR #386 but only for the keyword and category selection, which should be replaced by this one if accepted.

Closes #313 although for the future we might want to consider adding something similar for selecting ingredients, keywords, and tools as mentioned in the issue
