### PR TITLE
Improved Keyword filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@
   [#435](https://github.com/nextcloud/cookbook/pull/435) @christianlupus
 - Images in recipe list are lazily loaded
   [#413](https://github.com/nextcloud/cookbook/pull/413/) @seyfeb
+- Improved keyword filtering in recipe lists
+  [#408](https://github.com/nextcloud/cookbook/pull/408/) @seyfeb
 
 ### Fixed
 - Add a min PHP restriction in the metadata

--- a/lib/Db/RecipeDb.php
+++ b/lib/Db/RecipeDb.php
@@ -310,7 +310,7 @@ class RecipeDb {
 		$qb->setParameters($params, $types);
 		$qb->setParameter('user', $user_id, TYPE::STRING);
 
-		$qb->groupBy(['r.name', 'r.recipe_id']);
+		$qb->groupBy(['r.name', 'r.recipe_id', 'k.name']);
 		$qb->orderBy('r.name');
 
 		$cursor = $qb->execute();

--- a/src/components/AppIndex.vue
+++ b/src/components/AppIndex.vue
@@ -1,15 +1,16 @@
 <template>
     <div>
         <div class="kw">
-            <ul v-if="keywords.length" class="keywords">
-                <RecipeKeyword v-for="(keyword,idx) in keywords"
-                    :key="'kw.name'+idx"
+            <transition-group v-if="keywords.length" class="keywords" name="keyword-list" tag="ul">
+                <RecipeKeyword v-for="keyword in keywords"
+                    :key="keyword.name"
                     :name="keyword.name"
                     :count="keyword.count"
+                    :title="keywordContainedInVisibleRecipes(keyword) ? t('cookbook','Toggle keyword') : t('cookbook','Keyword not contained in visible recipes')"
                     v-on:keyword-clicked="keywordClicked(keyword)"
-                    :class="{active : keywordFilter.includes(keyword.name), disabled : !keywordContainedInVisibleRecipes(keyword)}"
+                    :class="{keyword, active : keywordFilter.includes(keyword.name), disabled : !keywordContainedInVisibleRecipes(keyword)}"
                     />
-            </ul>
+            </transition-group>
         </div>
         <ul class="recipes">
             <li v-for="(recipe, index) in filteredRecipes" :key="recipe.recipe_id" v-show="recipeVisible(index)">
@@ -164,7 +165,7 @@ export default {
                     }
                 }
             }
-            this.keywords = this.keywords.concat(tmp)
+            this.keywords = this.keywords.concat(tmp.reverse())
         },
     },
     mounted () {
@@ -192,8 +193,15 @@ ul.keywords {
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
-    width: 100%;
-    margin: .5rem 1rem .5rem;
+    padding: .5rem 1rem .5rem;
+}
+
+.keyword {
+  display: inline-block;
+}
+
+.keyword-list-move {
+  transition: transform .5s;
 }
 
 ul.recipes {

--- a/src/components/AppIndex.vue
+++ b/src/components/AppIndex.vue
@@ -153,6 +153,18 @@ export default {
         sortKeywords: function() {
             // Sort by number recipes
             this.keywords = this.keywords.sort((k1, k2) => k2.count - k1.count)
+
+            // Move unselectable keywords to the end
+            let tmp = []
+            for (let i=this.keywords.length-1; i>=0; --i) {
+                if (!this.keywordContainedInVisibleRecipes(this.keywords[i])) {
+                    let elm = this.keywords.splice(i, 1)[0]
+                    if (elm) {
+                        tmp.push(elm)
+                    }
+                }
+            }
+            this.keywords = this.keywords.concat(tmp)
         },
     },
     mounted () {

--- a/src/components/AppIndex.vue
+++ b/src/components/AppIndex.vue
@@ -136,9 +136,9 @@ export default {
                 recipes.forEach(recipe => {
                     if(recipe['keywords']) {
                         recipe['keywords'].split(',').forEach(kw => {
-                            const idx = this.keywords.findIndex(el  => el.name == kw);
+                            const idx = this.keywords.findIndex(el => el.name == kw)
                             if (idx > -1) {
-                                this.keywords[idx].count++;
+                                this.keywords[idx].count++
                             } else {
                                 this.keywords.push({name: kw, count: 1})
                             }
@@ -152,20 +152,23 @@ export default {
          * Sort keywords.
          */
         sortKeywords: function() {
-            // Sort by number recipes
+            // Sort by number of recipes containing keyword
             this.keywords = this.keywords.sort((k1, k2) => k2.count - k1.count)
 
-            // Move unselectable keywords to the end
-            let tmp = []
-            for (let i=this.keywords.length-1; i>=0; --i) {
-                if (!this.keywordContainedInVisibleRecipes(this.keywords[i])) {
-                    let elm = this.keywords.splice(i, 1)[0]
-                    if (elm) {
-                        tmp.push(elm)
-                    }
+            // Move selected keywords to the front and unselectable to the end
+            let selected_kw = [], selectable_kw = [], unavailable_kw = []
+            this.keywords.forEach(kw => {
+                if (this.keywordFilter.includes(kw.name)) {
+                    selected_kw.push(kw)
                 }
-            }
-            this.keywords = this.keywords.concat(tmp.reverse())
+                else if (this.keywordContainedInVisibleRecipes(kw)) {
+                    selectable_kw.push(kw)
+                }
+                else {
+                    unavailable_kw.push(kw)
+                }
+            })
+            this.keywords = selected_kw.concat(selectable_kw.concat(unavailable_kw))
         },
     },
     mounted () {

--- a/src/components/RecipeKeyword.vue
+++ b/src/components/RecipeKeyword.vue
@@ -84,6 +84,10 @@ li .count {
     cursor: default;
 }
 
+.disabled :hover {
+    cursor: default;
+}
+
 li:hover, .active li:hover {
     border: 1px solid var(--color-primary);
 }

--- a/src/components/RecipeKeyword.vue
+++ b/src/components/RecipeKeyword.vue
@@ -1,11 +1,25 @@
 <template>
-    <a v-on:click="clicked" ref="link"><li>{{ keyword }}</li></a>
+    <a v-on:click="clicked" ref="link">
+        <li>
+            <span>{{ name }}</span>
+            <span v-if="count != null" class="count">({{count}})</span>
+        </li>
+    </a>
 </template>
 
 <script>
 export default {
     name: 'RecipeKeyword',
-    props: ['keyword'],
+    props: {
+        name: {
+            type: String,
+            required: true
+        },
+        count: {
+            type: Number,
+            default: null
+        }
+    },
     data () {
         return {
         }
@@ -39,16 +53,31 @@ li {
     user-select: none; /* Standard */
 }
 
+
+li .count {
+    margin-left: .35em;
+    font-size: .8em;
+    color: var(--color-text-light);
+}
+
 .active li {
     background-color: var(--color-primary);
     color: var(--color-primary-text);
 }
+
+    .active li .count {
+        color: var(--color-primary-text);
+    }
 
 .disabled li {
     background-color: #FFF;
     border-color: var(--color-border);
     color: var(--color-border);
 }
+
+    .disabled li .count {
+        color: var(--color-border);
+    }
 
 .disabled li:hover {
     border-color: var(--color-border);
@@ -58,4 +87,5 @@ li {
 li:hover, .active li:hover {
     border: 1px solid var(--color-primary);
 }
+
 </style>

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -11,7 +11,7 @@
 	            <div class="details">
                 <p v-if="keywords.length">
                     <ul v-if="keywords.length">
-                        <RecipeKeyword v-for="(keyword,idx) in keywords" :key="'keyw'+idx" :keyword="keyword"  v-on:keyword-clicked="keywordClicked(keyword)" />
+                        <RecipeKeyword v-for="(keyword,idx) in keywords" :key="'keyw'+idx" :name="keyword"  v-on:keyword-clicked="keywordClicked(keyword)" />
                     </ul>
                 </p>
                 <p class="dates">

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -7,23 +7,24 @@
 
 	        <div class='meta'>
 	            <h2>{{ $store.state.recipe.name }}</h2>
-
 	            <div class="details">
-                <p v-if="keywords.length">
-                    <ul v-if="keywords.length">
-                        <RecipeKeyword v-for="(keyword,idx) in keywords" :key="'keyw'+idx" :name="keyword"  v-on:keyword-clicked="keywordClicked(keyword)" />
-                    </ul>
-                </p>
-                <p class="dates">
-                    <span v-if="showCreatedDate" class="date"  :title="t('cookbook', 'Date created')">
-                        <span class="icon-calendar-dark date-icon" />
-                        <span class="date-text">{{ dateCreated }}</span>
-                    </span>
-                    <span v-if="showModifiedDate" class="date" :title="t('cookbook', 'Last modified')">
-                        <span class="icon-rename date-icon" />
-                        <span class="date-text">{{ dateModified }}</span>
-                    </span>
-                </p>
+                    <p v-if="keywords.length">
+                        <ul v-if="keywords.length">
+                            <RecipeKeyword v-for="(keyword,idx) in keywords" :key="'keyw'+idx" :name="keyword" :title="t('cookbook', 'Search recipes with this keyword')" v-on:keyword-clicked="keywordClicked(keyword)" />
+                        </ul>
+                    </p>
+
+                    <p class="dates">
+                        <span v-if="showCreatedDate" class="date"  :title="t('cookbook', 'Date created')">
+                            <span class="icon-calendar-dark date-icon" />
+                            <span class="date-text">{{ dateCreated }}</span>
+                        </span>
+                        <span v-if="showModifiedDate" class="date" :title="t('cookbook', 'Last modified')">
+                            <span class="icon-rename date-icon" />
+                            <span class="date-text">{{ dateModified }}</span>
+                        </span>
+                    </p>
+
 	                <p class="description">{{ $store.state.recipe.description }}</p>
 	                <p v-if="$store.state.recipe.url">
 	                    <strong>{{ t('cookbook', 'Source') }}: </strong><a target="_blank" :href="$store.state.recipe.url" class='source-url'>{{ $store.state.recipe.url }}</a>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -1,15 +1,16 @@
 <template>
     <div>
         <div class="kw">
-            <ul v-if="keywords.length" class="keywords">
+            <transition-group v-if="keywords.length" class="keywords" name="keyword-list" tag="ul">
                 <RecipeKeyword v-for="(keyword,idx) in keywords"
                     :key="'kw.name'+idx"
                     :name="keyword.name"
                     :count="keyword.count"
+                    :title="keywordContainedInVisibleRecipes(keyword) ? t('cookbook','Toggle keyword') : t('cookbook','Keyword not contained in visible recipes')"
                     v-on:keyword-clicked="keywordClicked(keyword)"
                     :class="{active : keywordFilter.includes(keyword.name), disabled : !keywordContainedInVisibleRecipes(keyword)}"
                     />
-            </ul>
+            </transition-group>
         </div>
         <ul class="recipes">
             <li v-for="(result, index) in results" :key="result.recipe_id" v-show="recipeVisible(index)">
@@ -224,8 +225,15 @@ ul.keywords {
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
-    width: 100%;
-    margin: .5rem 1rem .5rem;
+    padding: .5rem 1rem .5rem;
+}
+
+.keyword {
+  display: inline-block;
+}
+
+.keyword-list-move {
+  transition: transform .5s;
 }
 
 ul.recipes {

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -2,13 +2,13 @@
     <div>
         <div class="kw">
             <transition-group v-if="keywords.length" class="keywords" name="keyword-list" tag="ul">
-                <RecipeKeyword v-for="(keyword,idx) in keywords"
-                    :key="'kw.name'+idx"
+                <RecipeKeyword v-for="keyword in keywords"
+                    :key="keyword.name"
                     :name="keyword.name"
                     :count="keyword.count"
                     :title="keywordContainedInVisibleRecipes(keyword) ? t('cookbook','Toggle keyword') : t('cookbook','Keyword not contained in visible recipes')"
                     v-on:keyword-clicked="keywordClicked(keyword)"
-                    :class="{active : keywordFilter.includes(keyword.name), disabled : !keywordContainedInVisibleRecipes(keyword)}"
+                    :class="{keyword, active : keywordFilter.includes(keyword.name), disabled : !keywordContainedInVisibleRecipes(keyword)}"
                     />
             </transition-group>
         </div>
@@ -20,6 +20,7 @@
                         :lazy-src="result.imageUrl"
                         :blurred-preview-src="result.imagePlaceholderUrl"
                         :width="105" :height="105"/>
+
                     <span>{{ result.name }}</span>
                 </router-link>
             </li>
@@ -108,9 +109,9 @@ export default {
                 results.forEach(recipe => {
                     if(recipe['keywords']) {
                         recipe['keywords'].split(',').forEach(kw => {
-                            const idx = this.keywords.findIndex(el => el.name == kw);
+                            const idx = this.keywords.findIndex(el => el.name == kw)
                             if (idx > -1) {
-                                this.keywords[idx].count++;
+                                this.keywords[idx].count++
                             } else {
                                 this.keywords.push({name: kw, count: 1})
                             }
@@ -182,22 +183,25 @@ export default {
          * Sort keywords.
          */
         sortKeywords: function() {
-            // Sort by number recipes
+            // Sort by number of recipes containing keyword
             this.keywords = this.keywords.sort((k1, k2) => k2.count - k1.count)
 
-            // Move unselectable keywords to the end
-            let tmp = []
-            for (let i=this.keywords.length-1; i>=0; --i) {
-                if (!this.keywordContainedInVisibleRecipes(this.keywords[i])) {
-                    let elm = this.keywords.splice(i, 1)[0]
-                    if (elm) {
-                        tmp.push(elm)
-                    }
+            // Move selected keywords to the front and unselectable to the end
+            let selected_kw = [], selectable_kw = [], unavailable_kw = []
+            this.keywords.forEach(kw => {
+                if (this.keywordFilter.includes(kw.name)) {
+                    selected_kw.push(kw)
                 }
-            }
-            this.keywords = this.keywords.concat(tmp)
+                else if (this.keywordContainedInVisibleRecipes(kw)) {
+                    selectable_kw.push(kw)
+                }
+                else {
+                    unavailable_kw.push(kw)
+                }
+            })
+            this.keywords = selected_kw.concat(selectable_kw.concat(unavailable_kw))
         },
-    },   
+    },
     mounted () {
         this.setup()
     },


### PR DESCRIPTION
I made some changes to improve the keyword filtering in the recipe-list view. With this PR

- keywords show number of recipes that have the keyword assigned
- keywords are ordered by the number
- when keywords are selected, non-selectable keywords are moved to the end of the list
- selected keyword are moved to the beginning of the list for easy discovery
- a maximum size for the keyword-selection area is defined to prevent the page getting cluttered with many keywords. The area can be scrolled vertically to allow access to all keywords.

@sam-19 maybe you can review this PR?