### PR TITLE
Enabled coverage checking using new xdebug 3

### DIFF
--- a/.github/actions/run-tests/tests/Dockerfile
+++ b/.github/actions/run-tests/tests/Dockerfile
@@ -7,6 +7,9 @@ ARG PHPVERSION
 COPY install.sh /install.sh
 RUN /install.sh ${PHPVERSION}
 
+COPY xdebug.config /tmp/xdebug.config
+RUN cat /tmp/xdebug.config >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
 RUN mkdir /workdir
 WORKDIR /workdir
 

--- a/.github/actions/run-tests/tests/xdebug.config
+++ b/.github/actions/run-tests/tests/xdebug.config
@@ -1,0 +1,2 @@
+
+xdebug.mode=coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
   [#343](https://github.com/nextcloud/cookbook/pull/343/) @christianlupus
 - Creating new recipe not possible due to null reference
   [#378](https://github.com/nextcloud/cookbook/pull/378/) @seyfeb
+- Reenabling CI testing with current xdebug 3
+  [#417](https://github.com/nextcloud/cookbook/pull/417/) @christianlupus
 
 ### Removed
 - Travis build system


### PR DESCRIPTION
Due to a new version in xdebug, we need to tweak CI settings a bit.