### PR TITLE
Clear keyword filter when switching route (e.g., between categories)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
   [#417](https://github.com/nextcloud/cookbook/pull/417/) @christianlupus
 - Corrected code style in appinfo path
   [#427](https://github.com/nextcloud/cookbook/pull/427) @christianlupus
+- Clear filtered keywords when changing the route, fixes #425
+  [#426](https://github.com/nextcloud/cookbook/pull/426/) @seyfeb
 
 ### Removed
 - Travis build system

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -32,7 +32,12 @@ export default {
         }
     },
     computed: {
-    },    
+    },
+    watch: {
+        $route(to, from) {
+            this.keywordFilter = [];
+        }
+    },
     methods: {
         /**
          * Callback for click on keyword


### PR DESCRIPTION
Hotfix for #425 . Keyword filter is reset on route update.