### PR TITLE
Fix CI bugs

### DIFF
--- a/.github/actions/deploy/create-version.sh
+++ b/.github/actions/deploy/create-version.sh
@@ -12,7 +12,7 @@ minor=$(cat "$deploy_path/minor")
 patch=$(cat "$deploy_path/patch")
 
 # release
-message=$(git log HEAD~1...HEAD --format='%s%n%b')
+message=$(git log HEAD~1...HEAD --max-count=1 --format='%s%n%b')
 
 if echo "$message" | grep '%MAJOR%' > /dev/null ; then
         

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -93,5 +93,5 @@ jobs:
                     -H "Content-Type: application/json"
                     -d "{
                         \"download\":\"${{ steps.upload_asset.outputs.browser_download_url }}\",
-                        \"signature\": \"$(cat /tmp/signature | tr -d '\n')\"
+                        \"signature\": \"$(cat /tmp/signature)\"
                     }"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@
   [#434](https://github.com/nextcloud/cookbook/pull/434) @christianlupus
 - Update dependency on code style to version 0.4.x
   [#437](https://github.com/nextcloud/cookbook/pull/437) @christianlupus
+- Corrected bugs in CI system
+  [#447](https://github.com/nextcloud/cookbook/pull/447) @christianlupus
 
 ### Removed
 - Travis build system


### PR DESCRIPTION
The auto-release CI is non-functional for two reasons:

1. The test on version trigger is not only checked on the merge message but all messages involved.
2. Signature is rejected by the app store.

This PR should cover these issues.