### PR TITLE
Create an API endpoint to get the API version

### DIFF
--- a/.github/actions/deploy/fill-in-data.sh
+++ b/.github/actions/deploy/fill-in-data.sh
@@ -1,9 +1,15 @@
 #! /bin/bash
 
 version="$1"
+major="$2"
+minor="$3"
+patch="$4"
 
 echo "Updating info.xml"
 cat .github/actions/deploy/appinfo/info.xml.dist | sed "s/%%VERSION%%/$version/g" > appinfo/info.xml
 
 echo "Updating package.json"
 sed "s/\"version\": \\?\"[^\"]*\"/\"version\": \"$version\"/g" -i package.json
+
+echo "Updating version in main controller"
+sed "/VERSION_TAG/s@[[].*[]]@[$major, $minor, $patch]@" -i lib/Controller/MainController.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
   [#416](https://github.com/nextcloud/cookbook/pull/416/) @seyfeb
 - Asking user for confirmation when leaving recipe-editor form with changes
   [#464](https://github.com/nextcloud/cookbook/pull/464/) @seyfeb
+- Exporting the maximal API endpoint version
+  [#487](https://github.com/nextcloud/cookbook/pull/487) @christianlupus
 
 ### Changed
 - Switch of project ownership to nextcloud organization in GitHub

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -9,6 +9,7 @@
  */
 return [
 	'routes' => [
+		['name' => 'main#getApiVersion', 'url' => '/api/version', 'verb' => 'GET'],
 		['name' => 'main#index', 'url' => '/', 'verb' => 'GET'],
 		['name' => 'main#home', 'url' => '/home', 'verb' => 'GET'],
 		['name' => 'main#keywords', 'url' => '/keywords', 'verb' => 'GET'],

--- a/lib/Controller/MainController.php
+++ b/lib/Controller/MainController.php
@@ -63,7 +63,7 @@ class MainController extends Controller {
 	 */
 	public function getApiVersion(): DataResponse {
 		$response = [
-			'cookbook_version' => [0,7,7], /* VERSION_TAG */
+			'cookbook_version' => [0,7,7], /* VERSION_TAG do not change this line manually */
 			'api_version' => [
 				'major' => 0,
 				'minor' => 1

--- a/lib/Controller/MainController.php
+++ b/lib/Controller/MainController.php
@@ -55,6 +55,22 @@ class MainController extends Controller {
 
 		return new TemplateResponse($this->appName, 'index', $view_data);  // templates/index.php
 	}
+	
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 * @return DataResponse
+	 */
+	public function getApiVersion(): DataResponse {
+		$response = [
+			'cookbook_version' => [0,7,7], /* VERSION_TAG */
+			'api_version' => [
+				'major' => 0,
+				'minor' => 1
+			]
+		];
+		return new DataResponse($response, 200, ['Content-Type' => 'application/json']);
+	}
 
 	/**
 	 * @NoAdminRequired


### PR DESCRIPTION
Especially for 3rd party integrations, it is required to define an API version to clear the possible API endpoints.