### PR TITLE
Allow access of guest accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
   [#565](https://github.com/nextcloud/cookbook/pull/565/)
 - Enhanced testing interface
   [#564](https://github.com/nextcloud/cookbook/pull/564) @christianlupus
+- Allow guest users to use the cookbook and avoid nextcloud exception handling
+  [#506](https://github.com/nextcloud/cookbook/pull/506) @christianlupus
 
 ### Fixed
 - Added some documentation how to install GH action generated builds

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -60,8 +60,6 @@ class ConfigController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	public function config() {
-		$this->dbCacheService->triggerCheck();
-		
 		$data = $this->restParser->getParameters();
 		
 		if (isset($data['folder'])) {
@@ -77,6 +75,8 @@ class ConfigController extends Controller {
 			$this->service->setPrintImage((bool)$data['print_image']);
 		}
 
+		$this->dbCacheService->triggerCheck();
+		
 		return new DataResponse('OK', Http::STATUS_OK);
 	}
 	

--- a/lib/Controller/MainController.php
+++ b/lib/Controller/MainController.php
@@ -11,6 +11,7 @@ use OCP\AppFramework\Controller;
 use OCA\Cookbook\Service\RecipeService;
 use OCA\Cookbook\Service\DbCacheService;
 use OCA\Cookbook\Helper\RestParameterParser;
+use OCA\Cookbook\Exception\UserFolderNotWritableException;
 
 class MainController extends Controller {
 	protected $appName;
@@ -50,6 +51,13 @@ class MainController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	public function index(): TemplateResponse {
+		try {
+			// Check if the user folder can be accessed
+			$this->service->getFolderForUser();
+		} catch (UserFolderNotWritableException $ex) {
+			return new TemplateResponse($this->appName, 'invalid_guest');
+		}
+		
 		$this->dbCacheService->triggerCheck();
 
 		return new TemplateResponse($this->appName, 'index');  // templates/index.php

--- a/lib/Exception/UserFolderNotWritableException.php
+++ b/lib/Exception/UserFolderNotWritableException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace OCA\Cookbook\Exception;
+
+class UserFolderNotWritableException extends \Exception {
+	public function __construct($message = null, $code = null, $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/src/components/AppInvalidGuest.vue
+++ b/src/components/AppInvalidGuest.vue
@@ -1,18 +1,17 @@
 <template>
     <Content app-name="cookbook">
-        <!-- <AppNavi class="app-navigation" /> -->
         <AppContent>
             <div class="main">
                 <div class="dialog">
                     <div class="message">
                         {{ t('cookbook', 'Cannot access recipe folder.') }}
                     </div>
-                    <div class="explanation">
+                    <div>
                         {{
-                            t('cookbook', 'You are logged in with a guest account. Therefore, you are not allowed to generate arbitrary files and folders on this nextcloud instance. To be able to use the cookbook app as a guest account, you need to specify a folder where all recipes are stored. You will need write permission to this folder.')
+                            t('cookbook', 'You are logged in with a guest account. Therefore, you are not allowed to generate arbitrary files and folders on this Nextcloud instance. To be able to use the Cookbook app as a guest, you need to specify a folder where all recipes are stored. You will need write permission to this folder.')
                         }}
                     </div>
-                    <div class="explanation">
+                    <div>
                         <button
                             @click.prevent="selectFolder"
                         >
@@ -68,7 +67,6 @@ div.main {
 
     div.dialog {
         width: 50%;
-        height: 40%;
 
         padding: 20px;
         border: 1px solid;

--- a/src/components/AppInvalidGuest.vue
+++ b/src/components/AppInvalidGuest.vue
@@ -1,0 +1,87 @@
+<template>
+    <Content app-name="cookbook">
+        <!-- <AppNavi class="app-navigation" /> -->
+        <AppContent>
+            <div class="main">
+                <div class="dialog">
+                    <div class="message">
+                        {{ t('cookbook', 'Cannot access recipe folder.') }}
+                    </div>
+                    <div class="explanation">
+                        {{
+                            t('cookbook', 'You are logged in with a guest account. Therefore, you are not allowed to generate arbitrary files and folders on this nextcloud instance. To be able to use the cookbook app as a guest account, you need to specify a folder where all recipes are stored. You will need write permission to this folder.')
+                        }}
+                    </div>
+                    <div class="explanation">
+                        <button
+                            @click.prevent="selectFolder"
+                        >
+                            {{ t('cookbook', 'Select recipe folder') }}
+                        </button>
+                    </div>
+
+                </div>
+            </div>
+        </AppContent>
+    </Content>
+</template>
+
+<script>
+
+import Content from '@nextcloud/vue/dist/Components/Content'
+import AppContent from '@nextcloud/vue/dist/Components/AppContent'
+import axios from '@nextcloud/axios'
+
+export default {
+    name: "InvalidGuest",
+    components: {
+        Content,
+        AppContent
+    },
+    methods: {
+        selectFolder: function (e){
+            OC.dialogs.filepicker(
+                t('cookbook', 'Path to your recipe collection'),
+                (path) => {
+                    this.$store
+                        .dispatch('updateRecipeDirectory', {dir: path})
+                        .then(function(){
+                            location.reload()
+                        })
+                },
+                false, // Single result
+                'httpd/unix-directory', // Desired MIME type
+                true // Make modal dialog
+            )
+        },
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+div.main {
+    height: 100%;
+    display: flex;
+    flex-direction: colummn;
+    justify-content: center;
+    align-items: center;
+
+    div.dialog {
+        width: 50%;
+        height: 40%;
+
+        padding: 20px;
+        border: 1px solid;
+        border-radius: 15px;
+        
+        div {
+            margin: 20px 5px;
+        }
+        div.message {
+            font-weight: bold;
+            font-size: x-large;
+        }
+
+    }
+}
+</style>

--- a/src/components/AppInvalidGuest.vue
+++ b/src/components/AppInvalidGuest.vue
@@ -68,6 +68,10 @@ div.main {
     div.dialog {
         width: 50%;
 
+        @media screen and (max-width: 800px) {
+            width: 90%;
+        }
+
         padding: 20px;
         border: 1px solid;
         border-radius: 15px;

--- a/src/guest.js
+++ b/src/guest.js
@@ -1,0 +1,37 @@
+/**
+ * Nextcloud Cookbook app
+ * Vue frontend entry file
+ * ---------------------------
+ * @license AGPL3 or later
+*/
+
+import Vue from 'vue'
+import store from './store'
+
+import AppInvalidGuest from './components/AppInvalidGuest'
+
+(function (OC, window) {
+    'use strict'
+
+    // Fetch Nextcloud nonce identifier for dynamic script loading
+    __webpack_nonce__ = btoa(OC.requestToken)
+
+    window.baseUrl = OC.generateUrl('apps/cookbook')
+
+
+    // Also make the injections available in Vue components
+    Vue.prototype.$window = window
+    Vue.prototype.OC = OC
+
+    // Pass translation engine to Vue
+    Vue.prototype.t = window.t
+
+    // Start the app once document is done loading
+    document.addEventListener("DOMContentLoaded", function(event) {
+        const App = Vue.extend(AppInvalidGuest)
+        new App({
+            store,
+            // router,
+        }).$mount("#content")
+    })
+})(OC, window)

--- a/templates/invalid_guest.php
+++ b/templates/invalid_guest.php
@@ -1,0 +1,6 @@
+<?php
+script('cookbook', 'guest');
+?>
+
+<div id="app">
+</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
 
     entry:{
         vue: path.join(__dirname, 'src', 'main.js'),
+        guest: path.join(__dirname, 'src', 'guest.js'),
     },
     output: {
         path: path.resolve(__dirname, './js'),


### PR DESCRIPTION
If the user folder is not writable as typically for a guest account, the cookbook app has hight probability of being non-functional. Yet, there are no useful error messages or ways to tackle the problem. Instead a stacktrace is generated.

This should get this issue covered.

Closes #468