### PR TITLE
Update ingredient list visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Changed
+- Indentation of ingredients depends on existence of subgroups
+  [#512](https://github.com/nextcloud/cookbook/pull/512/) @seyfeb
+
+
 ### Fixed
 - Fixed keywords of shared recipes counted multiple times, fixes #491
   [#493](https://github.com/nextcloud/cookbook/pull/493/) @seyfeb

--- a/src/components/RecipeIngredient.vue
+++ b/src/components/RecipeIngredient.vue
@@ -67,8 +67,8 @@ li {
 
     li:hover > div.checkmark {
         visibility: visible;
-    	opacity: 0.5;
-    	color: var(--color-primary-element);
+        opacity: 0.5;
+        color: var(--color-primary-element);
     }
 
     li > div.ingredient {

--- a/src/components/RecipeIngredient.vue
+++ b/src/components/RecipeIngredient.vue
@@ -1,14 +1,14 @@
 <template>
-    <li :class="{ 'header': isHeader() }" @click="toggleDone">
+    <li :class="{ 'header': isHeader(), 'unindented': !recipeIngredientsHaveSubgroups}" @click="toggleDone">
     	<div class="checkmark" :class="{ 'done': isDone }">✔</div>
-    	{{ displayIngredient }}
+    	<div class="ingredient">{{ displayIngredient }}</div>
 	</li>
 </template>
 
 <script>
 export default {
     name: 'RecipeIngredient',
-    props: ['ingredient'],
+    props: ['ingredient','recipeIngredientsHaveSubgroups'],
     data () {
         return {
             headerPrefix: "## ",
@@ -41,7 +41,7 @@ export default {
 <style scoped>
 
 li {
-    margin-left: 1.25em;
+    display: flex;
 }
     li.header {
         position: relative;
@@ -50,19 +50,32 @@ li {
         list-style-type: none;
         font-variant: small-caps;
     }
-    
+
+    li.unindented {
+        position: relative;
+        left: -1.25em;
+    }
+
     li > div.checkmark {
     	display: inline;
     	visibility: hidden;
     }
+
     li > div.done {
-    	visibility: visible;
+        visibility: visible;
     }
-    
+
     li:hover > div.checkmark {
-    	visibility: visible;
+        visibility: visible;
     	opacity: 0.5;
     	color: var(--color-primary-element);
     }
-    
+
+    li > div.ingredient {
+        display: inline;
+        margin-left: .3em;
+        padding-left: 1em;
+        text-indent: -1em;
+    }
+
 </style>

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -45,7 +45,7 @@
                     <section>
                         <h3 v-if="ingredients.length">{{ t('cookbook', 'Ingredients') }}</h3>
                         <ul v-if="ingredients.length">
-                            <RecipeIngredient v-for="(ingredient,idx) in ingredients" :key="'ingr'+idx" :ingredient="ingredient" />
+                            <RecipeIngredient v-for="(ingredient,idx) in ingredients" :key="'ingr'+idx" :ingredient="ingredient" :recipeIngredientsHaveSubgroups="recipeIngredientsHaveSubgroups" />
                         </ul>
                     </section>
 
@@ -110,6 +110,7 @@ export default {
     },
     data () {
         return {
+            headerPrefix: "## ",
             // Own properties
             ingredients: [],
             instructions: [],
@@ -124,6 +125,16 @@ export default {
         }
     },
     computed: {
+        recipeIngredientsHaveSubgroups: function() {
+            if (this.ingredients && this.ingredients.length > 0) {
+                for (let idx = 0; idx < this.ingredients.length; ++idx) {
+                    if (this.ingredients[idx].startsWith(this.headerPrefix)) {
+                        return true
+                    }
+                }
+            }
+            return false
+        },
         showModifiedDate: function() {
             if (!this.dateModified) {  
                 return false


### PR DESCRIPTION
Depending on the existence of subgroups in the ingredient list (starting with ##) the ingredients are more or less indented. 

The vertical overlap of checkmark and ingredient text, that appeared when there was a line break in the text, is removed.

Also a hanging indent is introduced to make it visually clear when there is a line break within a single ingredient.

Previously:
<img width="257" alt="Screenshot 2021-01-14 at 22 23 38" src="https://user-images.githubusercontent.com/7623143/104651055-6943ff80-56b7-11eb-89ee-b4b08c558fdc.png">

With subgroup:
<img width="269" alt="Screenshot 2021-01-14 at 22 09 06" src="https://user-images.githubusercontent.com/7623143/104651098-78c34880-56b7-11eb-8b41-5fb4e247bfcd.png">

Without subgroup:
<img width="276" alt="Screenshot 2021-01-14 at 22 09 45" src="https://user-images.githubusercontent.com/7623143/104651074-6fd27700-56b7-11eb-9860-163551cf4fbb.png">

