### PR TITLE
Deprecate some routes by comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Updated dependency of eslint-config-prettier
   [#603](https://github.com/nextcloud/cookbook/pull/603) @christianlupus
 
+## Deprecated
+- Obsolete routes to old user interface, see `appinfo/routes.php`
+  [#580](https://github.com/nextcloud/cookbook/pull/580) @christianlupus
+
 ## 0.8.1 - 2021-02-15
 
 ### Added

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -29,9 +29,9 @@ return [
 		['name' => 'main#tags', 'url' => '/api/tags/{keywords}', 'verb' => 'GET'],
 		['name' => 'main#search', 'url' => '/api/search/{query}', 'verb' => 'GET'],
 		/* Unknown usage */
+		/* Deprecated routes */
 		['name' => 'main#new', 'url' => '/recipes/create', 'verb' => 'POST'],
 		['name' => 'main#update', 'url' => '/recipes/{id}/edit', 'verb' => 'PUT', 'requirements' => ['id' => '\d+']],
-		/* Deprecated routes */
 		['name' => 'main#home', 'url' => '/home', 'verb' => 'GET'],
 		['name' => 'main#error', 'url' => '/error', 'verb' => 'GET'],
 		['name' => 'main#create', 'url' => '/recipes/create', 'verb' => 'GET'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -16,16 +16,9 @@ return [
 		 */
 		['name' => 'main#getApiVersion', 'url' => '/api/version', 'verb' => 'GET'],
 		['name' => 'main#index', 'url' => '/', 'verb' => 'GET'],
-		['name' => 'main#home', 'url' => '/home', 'verb' => 'GET'],
 		['name' => 'main#keywords', 'url' => '/keywords', 'verb' => 'GET'],
 		['name' => 'main#categories', 'url' => '/categories', 'verb' => 'GET'],
-		['name' => 'main#error', 'url' => '/error', 'verb' => 'GET'],
-		['name' => 'main#create', 'url' => '/recipes/create', 'verb' => 'GET'],
-		['name' => 'main#new', 'url' => '/recipes/create', 'verb' => 'POST'],
 		['name' => 'main#import', 'url' => '/import', 'verb' => 'POST'],
-		['name' => 'main#edit', 'url' => '/recipes/{id}/edit', 'verb' => 'GET', 'requirements' => ['id' => '\d+']],
-		['name' => 'main#update', 'url' => '/recipes/{id}/edit', 'verb' => 'PUT', 'requirements' => ['id' => '\d+']],
-		['name' => 'main#recipe', 'url' => '/recipes/{id}', 'verb' => 'GET', 'requirements' => ['id' => '\d+']],
 		['name' => 'recipe#image', 'url' => '/recipes/{id}/image', 'verb' => 'GET', 'requirements' => ['id' => '\d+']],
 		['name' => 'config#reindex', 'url' => '/reindex', 'verb' => 'POST'],
 		['name' => 'config#list', 'url' => '/config', 'verb' => 'GET'],
@@ -35,6 +28,15 @@ return [
 		['name' => 'main#categoryUpdate', 'url' => '/api/category/{category}', 'verb' => 'PUT'],
 		['name' => 'main#tags', 'url' => '/api/tags/{keywords}', 'verb' => 'GET'],
 		['name' => 'main#search', 'url' => '/api/search/{query}', 'verb' => 'GET'],
+		/* Unknown usage */
+		['name' => 'main#new', 'url' => '/recipes/create', 'verb' => 'POST'],
+		['name' => 'main#update', 'url' => '/recipes/{id}/edit', 'verb' => 'PUT', 'requirements' => ['id' => '\d+']],
+		/* Deprecated routes */
+		['name' => 'main#home', 'url' => '/home', 'verb' => 'GET'],
+		['name' => 'main#error', 'url' => '/error', 'verb' => 'GET'],
+		['name' => 'main#create', 'url' => '/recipes/create', 'verb' => 'GET'],
+		['name' => 'main#edit', 'url' => '/recipes/{id}/edit', 'verb' => 'GET', 'requirements' => ['id' => '\d+']],
+		['name' => 'main#recipe', 'url' => '/recipes/{id}', 'verb' => 'GET', 'requirements' => ['id' => '\d+']],
 	],
 
 	/* API resources */

--- a/lib/Controller/MainController.php
+++ b/lib/Controller/MainController.php
@@ -105,6 +105,7 @@ class MainController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @deprecated
 	 */
 	public function home() {
 		$this->dbCacheService->triggerCheck();
@@ -135,6 +136,7 @@ class MainController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @deprecated
 	 */
 	public function error() {
 		$this->dbCacheService->triggerCheck();
@@ -286,6 +288,7 @@ class MainController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @deprecated
 	 */
 	public function recipe($id) {
 		$this->dbCacheService->triggerCheck();
@@ -314,6 +317,7 @@ class MainController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @deprecated
 	 */
 	public function create() {
 		$this->dbCacheService->triggerCheck();
@@ -375,6 +379,7 @@ class MainController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @deprecated
 	 */
 	public function edit($id) {
 		$this->dbCacheService->triggerCheck();


### PR DESCRIPTION
We have still some old API endpoints that should be cleaned up. This PR should clean up no longer used routes and structure the code better.