### PR TITLE
Added scripts to prepare the Vue code styler

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,9 @@
+/build/
+/vendor/
+/.git/
+/.github/
+/docs/
+/l10n/
+/node_modules/
+/tests/
+/translationfiles/

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,9 @@ plugins:
 extends:
     - airbnb-base
     - "plugin:vue/base"
+    - "plugin:vue/essential"
+    - "plugin:vue/strongly-recommended"
+    - "plugin:vue/recommended"
     - prettier
     #- prettier/babel
     - prettier/vue

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,10 @@
+
+plugins:
+    - vue
+
+extends:
+    - airbnb-base
+    - "plugin:vue/base"
+    - prettier
+    #- prettier/babel
+    - prettier/vue

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+/.git/
+/.github/
+/vendor/
+/docs/
+/build/
+/l10n/
+/node_modules/
+/tests/
+/translationfiles/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+	"semi": false,
+	"tabWidth": 4
+}

--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -8,8 +8,11 @@ rules:
         - true
         - ignore:
             - attribute
+    "selector-max-id": 1
+    "max-nesting-depth": 2
 
 extends:
     - stylelint-config-standard
     - stylelint-config-sass-guidelines
+    - stylelint-config-idiomatic-order
     - stylelint-config-prettier

--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -1,0 +1,15 @@
+
+plugins:
+    - stylelint-scss
+
+rules:
+    "order/properties-alphabetical-order": null
+    "selector-no-qualifying-type":
+        - true
+        - ignore:
+            - attribute
+
+extends:
+    - stylelint-config-standard
+    - stylelint-config-sass-guidelines
+    - stylelint-config-prettier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+- Code style checker in Vue files
+  [#581](https://github.com/nextcloud/cookbook/pull/581) @christianlupus
+
 ### Fixed
 - Remove look-behind to support Safari users as well
   [#591](https://github.com/nextcloud/cookbook/pull/591) @christianlupus

--- a/package.json
+++ b/package.json
@@ -6,7 +6,13 @@
   "scripts": {
     "build": "node node_modules/webpack/bin/webpack.js --progress --config webpack.build.js",
     "dev": "node node_modules/webpack/bin/webpack.js --progress --watch --config webpack.devel.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prettier": "npx prettier --check src",
+    "prettier-fix": "npx prettier --write src",
+    "stylelint": "npx stylelint src",
+    "stylelint-fix": "npx stylelint --fix src",
+    "eslint": "npx eslint src",
+    "eslint-fix": "npx eslint --fix src"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,22 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "babel-loader": "^8.1.0",
+    "compression-webpack-plugin": "^6.1.1",
     "css-loader": "^5.0.2",
+    "eslint": "^7.20.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-config-prettier": "^7.2.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-vue": "^7.5.0",
     "file-loader": "^6.0.0",
     "lodash-webpack-plugin": "^0.11.5",
+    "prettier": "^2.2.1",
+    "stylelint": "^13.10.0",
+    "stylelint-config-idiomatic-order": "^8.1.0",
+    "stylelint-config-prettier": "^8.0.2",
+    "stylelint-config-sass-guidelines": "^8.0.0",
+    "stylelint-config-standard": "^20.0.0",
+    "stylelint-scss": "^3.19.0",
     "svg-inline-loader": "^0.8.2",
     "url-loader": "^4.1.0",
     "vue-loader": "^15.9.1",
@@ -49,7 +62,6 @@
     "webpack": "^4.42.1",
     "webpack-bundle-analyzer": "^4.1.0",
     "webpack-cli": "^4.5.0",
-    "webpack-merge": "^5.7.3",
-    "compression-webpack-plugin": "^6.1.1"
+    "webpack-merge": "^5.7.3"
   }
 }


### PR DESCRIPTION
Currently, this only inserts a code styler in NPM scripts and registers the corresponding packages in the `package.json`. The CI is **not** affected as the changes would be quite big.