### PR TITLE
Enable stylelint to keep CSS codes clean and tight

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,22 +16,29 @@ jobs:
         -   name: Get PHP version
             shell: bash
             run: php -v
+        
         -   name: Install Composer
             shell: bash
             run: >-
                 wget https://github.com/composer/getcomposer.org/raw/master/web/installer -O - -q |
                 php -- --quiet
-        -   name: Install packages
+        
+        -   name: Install PHP packages
             shell: bash
             run: composer install
-        -   name: Run linter
+        -   name: Install Node packages
+            shell: bash
+            run: npm -q install
+        
+        -   name: Run PHP linter
             shell: bash
             run: composer lint:lint
-        -   name: Run code style checker
+        -   name: Run PHP code style checker
             shell: bash
             env:
                 PHP_CS_FIXER_IGNORE_ENV: 1
             run: composer cs:check
+            
         -   name: Check for formatting issues with vue files (prettier)
             shell: bash
             run: npm run prettier

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,10 +41,20 @@ jobs:
             
         -   name: Check for formatting issues with vue files (prettier)
             shell: bash
-            run: npm run prettier
+            run: >-
+                npm run prettier || {
+                echo '::error ::The prettier style checker failed.
+                Please run `npm run prettier-fix` in order to correct this.';
+                exit 1;
+                }
         -   name: Check for formatting issues with CSS files (stylelint)
             shell: bash
-            run: npm run stylelint
+            run: >-
+                npm run stylelint || {
+                echo '::error ::The stylelint checker failed.
+                Please run `npm run stylelint-fix` to help solving these issues if possible.';
+                exit 1;
+                }
         
   
   unit-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,9 +32,12 @@ jobs:
             env:
                 PHP_CS_FIXER_IGNORE_ENV: 1
             run: composer cs:check
-        -   name: Check for formatting issues with vue files
+        -   name: Check for formatting issues with vue files (prettier)
             shell: bash
             run: npm run prettier
+        -   name: Check for formatting issues with CSS files (stylelint)
+            shell: bash
+            run: npm run stylelint
         
   
   unit-tests:

--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -10,6 +10,7 @@ rules:
             - attribute
     "selector-max-id": 1
     "max-nesting-depth": 2
+    "selector-max-compound-selectors": 4
 
 extends:
     - stylelint-config-standard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   [#603](https://github.com/nextcloud/cookbook/pull/603) @christianlupus
 - Enforce basic code styling using prettier in vue files
   [#607](https://github.com/nextcloud/cookbook/pull/607) @christianlupus
+- Enforce CSS styling using stylelint
+  [#608](https://github.com/nextcloud/cookbook/pull/608) @christianlupus
 
 ## Deprecated
 - Obsolete routes to old user interface, see `appinfo/routes.php`

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -374,8 +374,8 @@ export default {
 }
 
 .active {
-    font-weight: bold;
     cursor: default !important;
+    font-weight: bold;
 }
 
 .breadcrumbs {

--- a/src/components/AppInvalidGuest.vue
+++ b/src/components/AppInvalidGuest.vue
@@ -56,29 +56,28 @@ export default {
 
 <style lang="scss" scoped>
 div.main {
-    height: 100%;
     display: flex;
+    height: 100%;
     flex-direction: colummn;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
 
     div.dialog {
         width: 50%;
+        padding: 20px;
+        border: 1px solid;
+        border-radius: 15px;
 
         @media screen and (max-width: 800px) {
             width: 90%;
         }
 
-        padding: 20px;
-        border: 1px solid;
-        border-radius: 15px;
-
         div {
             margin: 20px 5px;
         }
         div.message {
-            font-weight: bold;
             font-size: x-large;
+            font-weight: bold;
         }
     }
 }

--- a/src/components/AppInvalidGuest.vue
+++ b/src/components/AppInvalidGuest.vue
@@ -55,14 +55,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-div.main {
+.main {
     display: flex;
     height: 100%;
     flex-direction: colummn;
     align-items: center;
     justify-content: center;
 
-    div.dialog {
+    .dialog {
         width: 50%;
         padding: 20px;
         border: 1px solid;
@@ -75,7 +75,7 @@ div.main {
         div {
             margin: 20px 5px;
         }
-        div.message {
+        .message {
             font-size: x-large;
             font-weight: bold;
         }

--- a/src/components/AppMain.vue
+++ b/src/components/AppMain.vue
@@ -37,8 +37,8 @@ export default {
 @media print {
     #app-content-vue {
         display: block !important;
-        padding: 0 !important;
         overflow: visible !important;
+        padding: 0 !important;
         margin-left: 0 !important;
     }
     #app-navigation-vue {
@@ -47,8 +47,8 @@ export default {
     #header {
         display: none !important;
     }
-    a:link:after,
-    a:visited:after {
+    a:link::after,
+    a:visited::after {
         content: " [" attr(href) "] ";
     }
 }

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -416,14 +416,16 @@ export default {
     padding-left: 0;
 }
 
+/* stylelint-disable selector-class-pattern */
 >>> .app-navigation-entry
     .app-navigation-entry__children
     .app-navigation-entry {
     /* Let's not waste space in front of the recipe if we're only using the icon to show loading */
     padding-left: 0;
 }
+/* stylelint-enable selector-class-pattern */
 
-.app-navigation-entry:hover li.recipe {
+.app-navigation-entry:hover .recipe {
     box-shadow: inset 4px 0 rgba(255, 255, 255, 1);
 }
 

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -413,14 +413,14 @@ export default {
 
 >>> .app-navigation-entry.recipe {
     /* Let's not waste space in front of the recipe if we're only using the icon to show loading */
-    padding-left: 0px;
+    padding-left: 0;
 }
 
 >>> .app-navigation-entry
     .app-navigation-entry__children
     .app-navigation-entry {
     /* Let's not waste space in front of the recipe if we're only using the icon to show loading */
-    padding-left: 0px;
+    padding-left: 0;
 }
 
 .app-navigation-entry:hover li.recipe {
@@ -429,13 +429,13 @@ export default {
 
 >>> .app-navigation-entry.recipe:hover,
 >>> .app-navigation-entry.router-link-exact-active {
-    opacity: 1;
     box-shadow: inset 4px 0 var(--color-primary);
+    opacity: 1;
 }
 
 #hide-navigation {
-    height: 44px;
     display: none;
+    height: 44px;
 }
 #hide-navigation .action-button {
     padding-right: 0 !important;

--- a/src/components/AppNavigationCaption.vue
+++ b/src/components/AppNavigationCaption.vue
@@ -178,7 +178,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+/* stylelint-disable scss/at-import-partial-extension-blacklist */
 @import "@nextcloud/vue/src/assets/variables.scss";
+/* stylelint-enable scss/at-import-partial-extension-blacklist */
 
 .app-navigation-caption-mod {
     display: flex;
@@ -220,6 +222,7 @@ export default {
         justify-content: center;
         background-size: $icon-size $icon-size;
     }
+    /* stylelint-disable selector-class-pattern */
     .app-navigation-caption__title {
         overflow: hidden;
         max-width: 100%;
@@ -227,9 +230,11 @@ export default {
         white-space: nowrap;
         // padding-left: 6px;
     }
+    /* stylelint-enable selector-class-pattern */
 }
 
 /* counter and actions */
+/* stylelint-disable selector-class-pattern */
 .app-navigation-entry__utils {
     display: flex;
     flex: 0 1 auto;
@@ -240,4 +245,5 @@ export default {
         margin-right: 2px;
     }
 }
+/* stylelint-enable selector-class-pattern */
 </style>

--- a/src/components/AppNavigationCaption.vue
+++ b/src/components/AppNavigationCaption.vue
@@ -182,9 +182,9 @@ export default {
 
 .app-navigation-caption-mod {
     display: flex;
+    overflow: hidden;
     flex: 0 0 auto;
     order: 1;
-    overflow: hidden;
     opacity: 0.7;
 }
 
@@ -195,37 +195,36 @@ export default {
 
 // Main entry link
 .app-navigation-caption-div {
-    z-index: 100; /* above the bullet to allow click*/
+    z-index: 100; /* above the bullet to allow click */
     display: flex;
     overflow: hidden;
-    flex: 1 1 0;
-    box-sizing: border-box;
     min-height: $clickable-area;
+    box-sizing: border-box;
+    flex: 1 1 0;
     padding: 0;
-    white-space: nowrap;
+    background-position: $icon-margin center;
+    background-repeat: no-repeat;
+    background-size: $icon-size $icon-size;
+    box-shadow: none !important;
     color: var(--color-text-maxcontrast);
     font-weight: bold;
-
-    background-repeat: no-repeat;
-    background-position: $icon-margin center;
-    background-size: $icon-size $icon-size;
     line-height: $clickable-area;
-    box-shadow: none !important;
+    white-space: nowrap;
 
     .app-navigation-caption-icon {
         display: flex;
-        align-items: center;
-        flex: 0 0 $clickable-area;
-        justify-content: center;
         width: $clickable-area;
         height: $clickable-area;
+        flex: 0 0 $clickable-area;
+        align-items: center;
+        justify-content: center;
         background-size: $icon-size $icon-size;
     }
     .app-navigation-caption__title {
         overflow: hidden;
         max-width: 100%;
-        white-space: nowrap;
         text-overflow: ellipsis;
+        white-space: nowrap;
         // padding-left: 6px;
     }
 }
@@ -233,8 +232,8 @@ export default {
 /* counter and actions */
 .app-navigation-entry__utils {
     display: flex;
-    align-items: center;
     flex: 0 1 auto;
+    align-items: center;
     // visually balance the menu so it's not
     // stuck to the scrollbar
     .action-item {

--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -198,15 +198,15 @@ export default {
 #app-settings input[type="text"],
 #app-settings input[type="number"],
 #app-settings .button {
-    width: 100%;
     display: block;
+    width: 100%;
 }
 
 #app-settings .button {
-    padding: 0;
-    height: 44px;
-    border-radius: var(--border-radius);
     z-index: 2;
+    height: 44px;
+    padding: 0;
+    border-radius: var(--border-radius);
 }
 #app-settings .button p {
     margin: auto;

--- a/src/components/EditImageField.vue
+++ b/src/components/EditImageField.vue
@@ -52,12 +52,12 @@ fieldset > * {
 }
 
 fieldset > label {
-    vertical-align: top;
     display: inline-block;
     width: 10em;
     height: 34px;
-    line-height: 17px;
     font-weight: bold;
+    line-height: 17px;
+    vertical-align: top;
 }
 @media (max-width: 1199px) {
     fieldset > label {
@@ -68,9 +68,9 @@ fieldset > label {
 
 fieldset > input {
     width: calc(100% - 14em);
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
     border-right: 0;
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
 }
 @media (max-width: 1199px) {
     fieldset > input {
@@ -79,11 +79,11 @@ fieldset > input {
 }
 
 fieldset > input + button {
-    border-top-right-radius: var(--border-radius);
+    width: 3em;
+    border-bottom-left-radius: 0;
     border-bottom-right-radius: var(--border-radius);
     border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-    width: 3em;
+    border-top-right-radius: var(--border-radius);
 }
 
 fieldset > input + button > * {

--- a/src/components/EditInputField.vue
+++ b/src/components/EditInputField.vue
@@ -188,12 +188,12 @@ fieldset > * {
 }
 
 fieldset > label {
-    vertical-align: top;
     display: inline-block;
     width: 10em;
     height: 34px;
-    line-height: 17px;
     font-weight: bold;
+    line-height: 17px;
+    vertical-align: top;
 }
 @media (max-width: 1199px) {
     fieldset > label {
@@ -218,8 +218,8 @@ fieldset > .editor {
 
 fieldset > .editor {
     min-height: 10em;
-    resize: vertical;
     border-radius: 2;
+    resize: vertical;
 }
 
 @media (max-width: 1199px) {

--- a/src/components/EditInputField.vue
+++ b/src/components/EditInputField.vue
@@ -214,9 +214,6 @@ fieldset > textarea {
 
 fieldset > .editor {
     width: calc(100% - 11em);
-}
-
-fieldset > .editor {
     min-height: 10em;
     border-radius: 2;
     resize: vertical;

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -335,6 +335,11 @@ export default {
 </script>
 
 <style scoped>
+button {
+    width: auto !important;
+    padding: 0 1rem 0 0.75rem !important;
+}
+
 fieldset {
     width: 100%;
     margin-bottom: 1em;
@@ -366,7 +371,7 @@ fieldset > ul > li {
     margin: 0 0 1em;
 }
 
-li.text > input {
+.text > input {
     width: 100%;
     margin: 0;
     border-bottom-right-radius: 0;
@@ -396,14 +401,14 @@ li .controls > button:last-child:not(:hover):not(:focus) {
     border-right-color: var(--color-border-dark);
 }
 
-li.textarea {
+.textarea {
     position: relative;
     z-index: 1;
     top: 1px;
     float: right;
 }
 
-li.textarea > textarea {
+.textarea > textarea {
     width: calc(100% - 44px);
     min-height: 10em;
     margin: 0 0 0 44px;
@@ -411,7 +416,7 @@ li.textarea > textarea {
     resize: vertical;
 }
 
-li.textarea::after {
+.textarea::after {
     display: table;
     clear: both;
     content: "";
@@ -438,10 +443,5 @@ li.textarea::after {
 
 .icon-arrow-down {
     background-image: var(--icon-triangle-s-000);
-}
-
-button {
-    width: auto !important;
-    padding: 0 1rem 0 0.75rem !important;
 }
 </style>

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -336,15 +336,15 @@ export default {
 
 <style scoped>
 fieldset {
-    margin-bottom: 1em;
     width: 100%;
+    margin-bottom: 1em;
 }
 
 fieldset > label {
     display: inline-block;
     width: 10em;
-    line-height: 18px;
     font-weight: bold;
+    line-height: 18px;
     word-spacing: initial;
 }
 
@@ -354,23 +354,23 @@ fieldset > ul {
 
 fieldset > ul + button {
     width: 36px;
-    text-align: center;
     padding: 0;
     float: right;
+    text-align: center;
 }
 
 fieldset > ul > li {
     display: flex;
     width: 100%;
-    margin: 0 0 1em 0;
     padding-right: 0.25em;
+    margin: 0 0 1em;
 }
 
 li.text > input {
     width: 100%;
     margin: 0;
-    border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
 }
 
 li .controls {
@@ -378,57 +378,57 @@ li .controls {
 }
 
 li .controls > button {
-    padding: 0;
-    margin: 0;
     width: 34px;
     height: 34px;
-    border-radius: 0;
-    border-left-color: transparent;
+    padding: 0;
     border-right-color: transparent;
+    border-left-color: transparent;
+    margin: 0;
+    border-radius: 0;
 }
 
 li .controls > button:last-child {
-    border-top-right-radius: var(--border-radius);
-    border-bottom-right-radius: var(--border-radius);
     border-right-width: 1px;
+    border-bottom-right-radius: var(--border-radius);
+    border-top-right-radius: var(--border-radius);
 }
 li .controls > button:last-child:not(:hover):not(:focus) {
     border-right-color: var(--color-border-dark);
 }
 
 li.textarea {
-    float: right;
     position: relative;
-    top: 1px;
     z-index: 1;
+    top: 1px;
+    float: right;
 }
 
 li.textarea > textarea {
-    min-height: 10em;
-    resize: vertical;
     width: calc(100% - 44px);
+    min-height: 10em;
     margin: 0 0 0 44px;
     border-top-right-radius: 0;
+    resize: vertical;
 }
 
 li.textarea::after {
     display: table;
-    content: "";
     clear: both;
+    content: "";
 }
 .step-number {
     position: absolute;
-    left: 0;
     top: 0;
-    height: 36px;
+    left: 0;
     width: 36px;
-    border-radius: 50%;
+    height: 36px;
     border: 1px solid var(--color-border-dark);
-    outline: none;
-    background-repeat: no-repeat;
-    background-position: center;
     background-color: var(--color-background-dark);
+    background-position: center;
+    background-repeat: no-repeat;
+    border-radius: 50%;
     line-height: 36px;
+    outline: none;
     text-align: center;
 }
 

--- a/src/components/EditMultiselect.vue
+++ b/src/components/EditMultiselect.vue
@@ -27,8 +27,8 @@ export default {
 
 <style scoped>
 fieldset {
-    margin-bottom: 1em;
     width: 100%;
+    margin-bottom: 1em;
 }
 
 fieldset > * {
@@ -44,10 +44,10 @@ fieldset > * {
 fieldset > label {
     display: inline-block;
     width: 10em;
-    line-height: 18px;
     font-weight: bold;
-    word-spacing: initial;
+    line-height: 18px;
     vertical-align: top;
+    word-spacing: initial;
 }
 
 .edit-multiselect {
@@ -70,7 +70,7 @@ fieldset > label {
 #app .edit-multiselect .multiselect__tags .multiselect__tags-wrap {
     display: flex;
     flex-wrap: wrap;
-    padding-bottom: 0px;
+    padding-bottom: 0;
 }
 
 #app

--- a/src/components/EditMultiselect.vue
+++ b/src/components/EditMultiselect.vue
@@ -62,17 +62,22 @@ fieldset > label {
 </style>
 
 <style>
+/* stylelint-disable selector-class-pattern */
 #app .edit-multiselect .multiselect__tags {
     height: auto;
     min-height: 34px;
 }
+/* stylelint-enable selector-class-pattern */
 
+/* stylelint-disable selector-class-pattern */
 #app .edit-multiselect .multiselect__tags .multiselect__tags-wrap {
     display: flex;
     flex-wrap: wrap;
     padding-bottom: 0;
 }
+/* stylelint-enable selector-class-pattern */
 
+/* stylelint-disable selector-class-pattern,selector-max-compound-selectors */
 #app
     .edit-multiselect
     .multiselect__tags
@@ -81,4 +86,5 @@ fieldset > label {
     flex-basis: 50px;
     margin-bottom: 3px;
 }
+/* stylelint-enable selector-class-pattern,selector-max-compound-selectors */
 </style>

--- a/src/components/EditMultiselectInputGroup.vue
+++ b/src/components/EditMultiselectInputGroup.vue
@@ -219,8 +219,8 @@ export default {
 
 <style scoped>
 fieldset {
-    margin-bottom: 1em;
     width: 100%;
+    margin-bottom: 1em;
 }
 
 fieldset > * {
@@ -236,11 +236,11 @@ fieldset > * {
 fieldset > label {
     display: inline-block;
     width: 16em;
-    line-height: 18px;
-    font-weight: bold;
-    word-spacing: initial;
-    vertical-align: top;
     margin-bottom: 1rem;
+    font-weight: bold;
+    line-height: 18px;
+    vertical-align: top;
+    word-spacing: initial;
 }
 
 fieldset > ul {
@@ -257,8 +257,8 @@ fieldset > ul > li .key {
 }
 
 fieldset > ul > li .val {
-    margin: 0px;
     width: 100%;
+    margin: 0;
 }
 
 .ms {

--- a/src/components/EditMultiselectPopup.vue
+++ b/src/components/EditMultiselectPopup.vue
@@ -62,11 +62,11 @@ export default {
 
 <style scoped>
 .multiselect-popup-container {
-    display: flex;
     position: absolute;
     z-index: 1100;
-    left: 0px;
     top: 50px;
+    left: 0;
+    display: flex;
     width: 100%;
     height: calc(100% - 50px - 44px);
     padding: 0.5em;
@@ -75,12 +75,12 @@ export default {
 
 @media (min-width: 768px) {
     .multiselect-popup-container {
+        top: 50%;
+        left: 50%;
         width: 500px;
         height: 300px;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
         border-radius: 5px;
+        transform: translate(-50%, -50%);
     }
 }
 
@@ -89,11 +89,11 @@ export default {
 }
 
 .multiselect-popup-container__close-button {
-    height: 44px;
-    width: 100%;
     position: fixed;
-    bottom: 0px;
-    left: 0px;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 44px;
     background: var(--color-main-background);
 }
 @media (min-width: 768px) {
@@ -103,11 +103,11 @@ export default {
 }
 
 .multiselect-popup-container__close-button > button {
-    height: 44px;
-    width: calc(100vw - 10px);
-    margin: 5px;
     position: fixed;
-    bottom: 0px;
+    bottom: 0;
+    width: calc(100vw - 10px);
+    height: 44px;
+    margin: 5px;
     background: var(--color-main-background);
 }
 </style>

--- a/src/components/EditMultiselectPopup.vue
+++ b/src/components/EditMultiselectPopup.vue
@@ -84,10 +84,13 @@ export default {
     }
 }
 
+/* stylelint-disable selector-class-pattern */
 .multiselect-popup-container__multiselect {
     width: 100%;
 }
+/* stylelint-enable selector-class-pattern */
 
+/* stylelint-disable selector-class-pattern */
 .multiselect-popup-container__close-button {
     position: fixed;
     bottom: 0;
@@ -96,12 +99,17 @@ export default {
     height: 44px;
     background: var(--color-main-background);
 }
+/* stylelint-enable selector-class-pattern */
+
 @media (min-width: 768px) {
+    /* stylelint-disable selector-class-pattern */
     .multiselect-popup-container__close-button {
         display: none;
     }
+    /* stylelint-enable selector-class-pattern */
 }
 
+/* stylelint-disable selector-class-pattern */
 .multiselect-popup-container__close-button > button {
     position: fixed;
     bottom: 0;
@@ -110,12 +118,15 @@ export default {
     margin: 5px;
     background: var(--color-main-background);
 }
+/* stylelint-enable selector-class-pattern */
 </style>
 
 <style>
 @media (max-width: 767px) {
-    .multiselect-popup-container .multiselect div.multiselect__content-wrapper {
+    /* stylelint-disable selector-class-pattern */
+    .multiselect-popup-container .multiselect .multiselect__content-wrapper {
         max-height: calc(100vh - 145px) !important;
     }
+    /* stylelint-enable selector-class-pattern */
 }
 </style>

--- a/src/components/EditTimeField.vue
+++ b/src/components/EditTimeField.vue
@@ -75,11 +75,11 @@ fieldset > * {
 }
 
 fieldset > label {
-    vertical-align: top;
     display: inline-block;
     width: 10em;
-    line-height: 18px;
     font-weight: bold;
+    line-height: 18px;
+    vertical-align: top;
 }
 @media (max-width: 1199px) {
     fieldset > label {

--- a/src/components/LazyPicture.vue
+++ b/src/components/LazyPicture.vue
@@ -131,25 +131,25 @@ export default {
 
 <style scoped>
 .lazy-img {
+    overflow: hidden;
     max-width: 100%;
     max-height: 100%;
     vertical-align: middle;
-    overflow: hidden;
 }
 
 picture .loading-indicator {
-    align-content: center;
     display: contents;
+    align-content: center;
 }
 
 picture img.blurred {
     filter: blur(0.5rem);
-    -webkit-filter: blur(0.5rem);
+    filter: blur(0.5rem);
 }
 
 picture img.low-resolution.previewLoaded {
     display: inline;
-    -webkit-animation: fadeIn 1s linear 0s;
+    animation: fadeIn 1s linear 0s;
     animation: fadeIn 1s linear 0s;
 }
 
@@ -159,7 +159,7 @@ picture img.full-resolution {
 
 picture img.full-resolution.imageLoaded {
     display: inline;
-    -webkit-animation: unblur 1s linear 0s;
+    animation: unblur 1s linear 0s;
     animation: unblur 1s linear 0s;
 }
 
@@ -177,7 +177,7 @@ picture img.full-resolution.imageLoaded {
         filter: blur(0.5rem);
     }
     to {
-        filter: blur(0rem);
+        filter: blur(0);
     }
 }
 </style>

--- a/src/components/LazyPicture.vue
+++ b/src/components/LazyPicture.vue
@@ -8,14 +8,14 @@
         <span v-if="isPreviewLoading" class="loading-indicator icon-loading" />
         <img
             class="low-resolution blurred"
-            :class="{ previewLoaded: !isPreviewLoading }"
+            :class="{ 'preview-loaded': !isPreviewLoading }"
             :width="width ? width + 'px' : ''"
             :height="height ? height + 'px' : ''"
         />
         <img
             class="full-resolution"
             imageLoaded
-            :class="{ imageLoaded: !isLoading }"
+            :class="{ 'image-loaded': !isLoading }"
             :width="width ? width + 'px' : ''"
             :height="height ? height + 'px' : ''"
         />
@@ -142,24 +142,21 @@ picture .loading-indicator {
     align-content: center;
 }
 
-picture img.blurred {
-    filter: blur(0.5rem);
+picture .blurred {
     filter: blur(0.5rem);
 }
 
-picture img.low-resolution.previewLoaded {
+picture .low-resolution.preview-loaded {
     display: inline;
     animation: fadeIn 1s linear 0s;
-    animation: fadeIn 1s linear 0s;
 }
 
-picture img.full-resolution {
+picture .full-resolution {
     display: none;
 }
 
-picture img.full-resolution.imageLoaded {
+picture .full-resolution.image-loaded {
     display: inline;
-    animation: unblur 1s linear 0s;
     animation: unblur 1s linear 0s;
 }
 

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -693,15 +693,15 @@ export default {
 }
 
 .overlay {
-    display: block;
     position: absolute;
+    z-index: 1000;
+    top: 0;
+    left: 0;
+    display: block;
     width: 100%;
     height: 100%;
-    left: 0;
-    top: 0;
     background-color: var(--color-main-background);
     opacity: 0.75;
-    z-index: 1000;
 }
 .overlay.hidden {
     display: none;

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -92,7 +92,7 @@
         />
         <edit-multiselect-popup
             ref="referencesPopup"
-            class="referencesPopup"
+            class="references-popup"
             :class="{ visible: referencesPopupFocused }"
             :options="allrecipeOptions"
             track-by="recipe_id"
@@ -714,12 +714,12 @@ form fieldset ul label input[type="checkbox"] {
     cursor: pointer;
 } */
 
-.referencesPopup {
+.references-popup {
     position: fixed;
     display: none;
 }
 
-.referencesPopup.visible {
+.references-popup.visible {
     display: block;
 }
 </style>

--- a/src/components/RecipeImages.vue
+++ b/src/components/RecipeImages.vue
@@ -31,24 +31,24 @@ export default {
 div {
     display: block;
     width: 100%;
-    text-align: center;
     margin-bottom: 1rem;
+    text-align: center;
 }
 img {
-    cursor: pointer;
     width: 100%;
     max-width: 950px;
     background-color: #bebdbd;
+    cursor: pointer;
 }
 div.collapsed {
-    height: 40vh;
     overflow: hidden;
+    height: 40vh;
 }
 div.collapsed img {
+    display: block;
     margin: 0 auto;
     margin-top: 20vh;
     transform: translateY(-50%);
-    display: block;
 }
 
 @media print {

--- a/src/components/RecipeImages.vue
+++ b/src/components/RecipeImages.vue
@@ -40,11 +40,11 @@ img {
     background-color: #bebdbd;
     cursor: pointer;
 }
-div.collapsed {
+.collapsed {
     overflow: hidden;
     height: 40vh;
 }
-div.collapsed img {
+.collapsed img {
     display: block;
     margin: 0 auto;
     margin-top: 20vh;

--- a/src/components/RecipeIngredient.vue
+++ b/src/components/RecipeIngredient.vue
@@ -47,7 +47,8 @@ export default {
 li {
     display: flex;
 }
-li.header {
+
+.header {
     position: relative;
     left: -1.25em;
     margin-top: 0.25em;
@@ -55,27 +56,27 @@ li.header {
     list-style-type: none;
 }
 
-li.unindented {
+.unindented {
     position: relative;
     left: -1.25em;
 }
 
-li > div.checkmark {
+li > .checkmark {
     display: inline;
     visibility: hidden;
 }
 
-li > div.done {
+li > .done {
     visibility: visible;
 }
 
-li:hover > div.checkmark {
+li:hover > .checkmark {
     color: var(--color-primary-element);
     opacity: 0.5;
     visibility: visible;
 }
 
-li > div.ingredient {
+li > .ingredient {
     display: inline;
     padding-left: 1em;
     margin-left: 0.3em;

--- a/src/components/RecipeIngredient.vue
+++ b/src/components/RecipeIngredient.vue
@@ -51,8 +51,8 @@ li.header {
     position: relative;
     left: -1.25em;
     margin-top: 0.25em;
-    list-style-type: none;
     font-variant: small-caps;
+    list-style-type: none;
 }
 
 li.unindented {
@@ -70,15 +70,15 @@ li > div.done {
 }
 
 li:hover > div.checkmark {
-    visibility: visible;
-    opacity: 0.5;
     color: var(--color-primary-element);
+    opacity: 0.5;
+    visibility: visible;
 }
 
 li > div.ingredient {
     display: inline;
-    margin-left: 0.3em;
     padding-left: 1em;
+    margin-left: 0.3em;
     text-indent: -1em;
 }
 </style>

--- a/src/components/RecipeInstruction.vue
+++ b/src/components/RecipeInstruction.vue
@@ -48,7 +48,7 @@ li::before {
 li:hover::before {
     border-color: var(--color-primary-element);
 }
-li.done::before {
+.done::before {
     content: "✔";
 }
 li span,

--- a/src/components/RecipeInstruction.vue
+++ b/src/components/RecipeInstruction.vue
@@ -21,28 +21,28 @@ export default {
 
 <style scoped>
 li {
-    cursor: pointer;
-    counter-increment: instruction-counter;
-    clear: both;
-    margin-bottom: 2rem;
-    white-space: pre-line;
     position: relative;
     padding-left: calc(36px + 1rem);
+    margin-bottom: 2rem;
+    clear: both;
+    counter-increment: instruction-counter;
+    cursor: pointer;
+    white-space: pre-line;
 }
-li:before {
-    content: counter(instruction-counter);
+li::before {
     position: absolute;
-    left: 0;
     top: 0;
-    height: 36px;
+    left: 0;
     width: 36px;
-    border-radius: 50%;
+    height: 36px;
     border: 1px solid var(--color-border-dark);
-    outline: none;
-    background-repeat: no-repeat;
-    background-position: center;
     background-color: var(--color-background-dark);
+    background-position: center;
+    background-repeat: no-repeat;
+    border-radius: 50%;
+    content: counter(instruction-counter);
     line-height: 36px;
+    outline: none;
     text-align: center;
 }
 li:hover::before {
@@ -53,12 +53,12 @@ li.done::before {
 }
 li span,
 li input[type="checkbox"] {
-    line-height: 1rem;
-    margin: 0 0.5rem 0 0;
-    padding: 0;
-    height: auto;
-    width: 1rem;
     display: inline-block;
+    width: 1rem;
+    height: auto;
+    padding: 0;
+    margin: 0 0.5rem 0 0;
+    line-height: 1rem;
     vertical-align: middle;
 }
 </style>

--- a/src/components/RecipeKeyword.vue
+++ b/src/components/RecipeKeyword.vue
@@ -44,9 +44,6 @@ li {
     border-radius: var(--border-radius-pill);
 
     /* prevent text selection - doesn't look good */
-    user-select: none; /* Safari */
-    user-select: none; /* Firefox */
-    user-select: none; /* IE10+/Edge */
     user-select: none; /* Standard */
 }
 
@@ -75,6 +72,11 @@ li .count {
     color: var(--color-border);
 }
 
+li:hover,
+.active li:hover {
+    border: 1px solid var(--color-primary);
+}
+
 .disabled li:hover {
     border-color: var(--color-border);
     cursor: default;
@@ -82,10 +84,5 @@ li .count {
 
 .disabled :hover {
     cursor: default;
-}
-
-li:hover,
-.active li:hover {
-    border: 1px solid var(--color-primary);
 }
 </style>

--- a/src/components/RecipeKeyword.vue
+++ b/src/components/RecipeKeyword.vue
@@ -37,23 +37,23 @@ export default {
 <style scoped>
 li {
     display: inline-block;
+    padding: 0 0.5em;
+    border: 1px solid var(--color-border-dark);
     margin-right: 0.3em;
     margin-bottom: 0.3em;
-    padding: 0px 0.5em;
-    border: 1px solid var(--color-border-dark);
     border-radius: var(--border-radius-pill);
 
     /* prevent text selection - doesn't look good */
-    -webkit-user-select: none; /* Safari */
-    -moz-user-select: none; /* Firefox */
-    -ms-user-select: none; /* IE10+/Edge */
+    user-select: none; /* Safari */
+    user-select: none; /* Firefox */
+    user-select: none; /* IE10+/Edge */
     user-select: none; /* Standard */
 }
 
 li .count {
     margin-left: 0.35em;
-    font-size: 0.8em;
     color: var(--color-text-light);
+    font-size: 0.8em;
 }
 
 .active li {
@@ -66,8 +66,8 @@ li .count {
 }
 
 .disabled li {
-    background-color: #fff;
     border-color: var(--color-border);
+    background-color: #fff;
     color: var(--color-border);
 }
 

--- a/src/components/RecipeList.vue
+++ b/src/components/RecipeList.vue
@@ -258,17 +258,17 @@ export default {
 div.kw {
     width: 100%;
     max-height: 6.7em;
+    padding: 0.1em;
+    margin-bottom: 1em;
     overflow-x: hidden;
     overflow-y: scroll;
-    margin-bottom: 1em;
-    padding: 0.1em;
 }
 
 ul.keywords {
     display: flex;
-    flex-wrap: wrap;
     flex-direction: row;
-    padding: 0.5rem 1rem 0.5rem;
+    flex-wrap: wrap;
+    padding: 0.5rem 1rem;
 }
 
 .keyword {
@@ -281,9 +281,9 @@ ul.keywords {
 
 ul.recipes {
     display: flex;
-    flex-wrap: wrap;
-    flex-direction: row;
     width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
 }
 
 ul.recipes li {
@@ -294,8 +294,8 @@ ul.recipes li {
 ul.recipes li a {
     display: block;
     height: 105px;
-    box-shadow: 0 0 3px #aaa;
     border-radius: 3px;
+    box-shadow: 0 0 3px #aaa;
 }
 ul.recipes li a:hover {
     box-shadow: 0 0 5px #888;
@@ -303,12 +303,12 @@ ul.recipes li a:hover {
 
 ul.recipes li .recipe-thumbnail {
     position: relative;
-    float: left;
-    height: 105px;
-    width: 105px;
-    border-radius: 3px 0 0 3px;
-    background-color: #bebdbd;
     overflow: hidden;
+    width: 105px;
+    height: 105px;
+    background-color: #bebdbd;
+    border-radius: 3px 0 0 3px;
+    float: left;
 }
 
 ul.recipes li span {

--- a/src/components/RecipeList.vue
+++ b/src/components/RecipeList.vue
@@ -255,7 +255,7 @@ export default {
 </script>
 
 <style scoped>
-div.kw {
+.kw {
     width: 100%;
     max-height: 6.7em;
     padding: 0.1em;
@@ -264,7 +264,7 @@ div.kw {
     overflow-y: scroll;
 }
 
-ul.keywords {
+.keywords {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -279,29 +279,29 @@ ul.keywords {
     transition: transform 0.5s;
 }
 
-ul.recipes {
+.recipes {
     display: flex;
     width: 100%;
     flex-direction: row;
     flex-wrap: wrap;
 }
 
-ul.recipes li {
+.recipes li {
     width: 300px;
     max-width: 100%;
     margin: 0.5rem 1rem 1rem;
 }
-ul.recipes li a {
+.recipes li a {
     display: block;
     height: 105px;
     border-radius: 3px;
     box-shadow: 0 0 3px #aaa;
 }
-ul.recipes li a:hover {
+.recipes li a:hover {
     box-shadow: 0 0 5px #888;
 }
 
-ul.recipes li .recipe-thumbnail {
+.recipes li .recipe-thumbnail {
     position: relative;
     overflow: hidden;
     width: 105px;
@@ -311,7 +311,7 @@ ul.recipes li .recipe-thumbnail {
     float: left;
 }
 
-ul.recipes li span {
+.recipes li span {
     display: block;
     padding: 0.5rem 0.5em 0.5rem calc(105px + 0.5rem);
 }

--- a/src/components/RecipeNutritionInfoItem.vue
+++ b/src/components/RecipeNutritionInfoItem.vue
@@ -27,12 +27,12 @@ export default {
 
 <style scoped>
 li {
-    margin-left: 1.25em;
     margin-bottom: 0.5em;
+    margin-left: 1.25em;
 }
 
 li .title {
-    margin-bottom: 0em;
+    margin-bottom: 0;
     color: var(--color-main-text);
     font-weight: bolder;
 }

--- a/src/components/RecipeTimer.vue
+++ b/src/components/RecipeTimer.vue
@@ -117,24 +117,24 @@ export default {
     position: relative;
     flex-grow: 1;
     border: 1px solid var(--color-border-dark);
-    border-radius: 3px;
     margin: 1rem 2rem;
-    text-align: center;
+    border-radius: 3px;
     font-size: 1.2rem;
+    text-align: center;
 }
 .time button {
     position: absolute;
     top: 0;
     left: 0;
-    transform: translate(-50%, -50%);
-    height: 36px;
     width: 36px;
+    height: 36px;
+    transform: translate(-50%, -50%);
 }
 .time h4 {
-    font-weight: bold;
+    padding: 0.5rem;
     border-bottom: 1px solid var(--color-border-dark);
     background-color: var(--color-background-dark);
-    padding: 0.5rem;
+    font-weight: bold;
 }
 
 .time p {

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -616,10 +616,10 @@ div.meta {
 }
 .date-icon {
     display: inline-block;
-    background-size: 1em;
     margin-right: 0.2em;
-    vertical-align: middle;
     margin-bottom: 0.2em;
+    background-size: 1em;
+    vertical-align: middle;
 }
 .date-text {
     vertical-align: middle;
@@ -657,24 +657,24 @@ div.times > div {
     position: relative;
     flex-grow: 1;
     border: 1px solid var(--color-border-dark);
-    border-radius: 3px;
     margin: 1rem 2rem;
-    text-align: center;
+    border-radius: 3px;
     font-size: 1.2rem;
+    text-align: center;
 }
 .times .time button {
     position: absolute;
     top: 0;
     left: 0;
-    transform: translate(-50%, -50%);
-    height: 36px;
     width: 36px;
+    height: 36px;
+    transform: translate(-50%, -50%);
 }
 .times .time h4 {
-    font-weight: bold;
+    padding: 0.5rem;
     border-bottom: 1px solid var(--color-border-dark);
     background-color: var(--color-background-dark);
-    padding: 0.5rem;
+    font-weight: bold;
 }
 
 .times .time p {
@@ -685,15 +685,15 @@ section {
     margin-bottom: 1rem;
 }
 section::after {
-    content: "";
     display: table;
     clear: both;
+    content: "";
 }
 
 .content {
     width: 100%;
-    padding: 1rem;
     flex-basis: 100%;
+    padding: 1rem;
 }
 .content aside {
     width: 30%;
@@ -714,18 +714,18 @@ aside ul {
     list-style-type: none;
 }
 aside ul li {
+    margin-bottom: 0.75ex;
     margin-left: 1em;
     line-height: 2.5ex;
-    margin-bottom: 0.75ex;
 }
 aside ul li span,
 aside ul li input[type="checkbox"] {
-    line-height: 1rem;
-    margin: 0 0.5rem 0 0;
-    padding: 0;
-    height: auto;
-    width: 1rem;
     display: inline-block;
+    width: 1rem;
+    height: auto;
+    padding: 0;
+    margin: 0 0.5rem 0 0;
+    line-height: 1rem;
     vertical-align: middle;
 }
 
@@ -755,47 +755,47 @@ div.meta {
 }
 
 main {
-    flex-basis: calc(100% - 22rem);
     width: 70%;
+    flex-basis: calc(100% - 22rem);
     float: left;
     text-align: justify;
 }
 
 @media screen and (max-width: 1199px) {
     main {
-        flex-basis: 100%;
         width: 100%;
+        flex-basis: 100%;
     }
 }
 
 .instructions {
-    list-style: none;
     padding: 0;
-    counter-reset: instruction-counter;
     margin-top: 2rem;
+    counter-reset: instruction-counter;
+    list-style: none;
 }
 .instructions .instruction {
-    cursor: pointer;
-    counter-increment: instruction-counter;
-    clear: both;
     margin-bottom: 2rem;
+    clear: both;
+    counter-increment: instruction-counter;
+    cursor: pointer;
 }
 .instructions .instruction::before {
-    content: counter(instruction-counter);
     display: block;
-    float: left;
-    margin: 0 1rem 1rem 0;
-    height: 36px;
     width: 36px;
-    border-radius: 50%;
+    height: 36px;
     border: 1px solid var(--color-border-dark);
-    outline: none;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-color: var(--color-background-dark);
-    line-height: 36px;
-    text-align: center;
+    margin: 0 1rem 1rem 0;
     margin-top: -6px;
+    background-color: var(--color-background-dark);
+    background-position: center;
+    background-repeat: no-repeat;
+    border-radius: 50%;
+    content: counter(instruction-counter);
+    float: left;
+    line-height: 36px;
+    outline: none;
+    text-align: center;
 }
 .instructions .instruction:hover::before {
     border-color: var(--color-primary-element);

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -580,32 +580,32 @@ export default {
 }
 
 @media print {
-    div.header {
+    .header {
         display: flex;
         flex-wrap: wrap;
     }
-    div.header > div.image {
+    .header > .image {
         flex: 600px 0 0;
     }
-    div.header > div.meta {
+    .header > .meta {
         margin: 0 10px;
     }
-    div.header a::after {
+    .header a::after {
         content: "";
     }
 }
 
 @media only screen and (min-width: 1500px) {
-    div.header.responsive {
+    .header.responsive {
         display: flex;
     }
 
-    div.header.responsive > div.image {
+    .header.responsive > .image {
         flex: 700px 0 0;
     }
 }
 
-div.meta {
+.meta {
     margin: 0 1rem;
 }
 .dates {
@@ -649,7 +649,7 @@ div.meta {
     }
 }
 
-div.times > div {
+.times > div {
     margin: 1rem 0.75rem;
 }
 
@@ -695,6 +695,12 @@ section::after {
     flex-basis: 100%;
     padding: 1rem;
 }
+
+aside {
+    flex-basis: 20rem;
+    padding-right: 2rem;
+}
+
 .content aside {
     width: 30%;
     float: left;
@@ -706,10 +712,6 @@ section::after {
     }
 }
 
-aside {
-    flex-basis: 20rem;
-    padding-right: 2rem;
-}
 aside ul {
     list-style-type: none;
 }
@@ -727,10 +729,6 @@ aside ul li input[type="checkbox"] {
     margin: 0 0.5rem 0 0;
     line-height: 1rem;
     vertical-align: middle;
-}
-
-div.meta {
-    margin: 0 1rem;
 }
 
 .markdown-description >>> ol > li {


### PR DESCRIPTION
This should enforce a stricter CSS styling using stylelint.

Most of the changes are automatically generated but few manual adjustments were needed to make the style linter happy.