### PR TITLE
Implement unified search provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+- Make recipes searchable through unified search
+  [#611](https://github.com/nextcloud/cookbook/pull/611) @PFischbeck
+
 ### Fixed
 - Calling reindex
   [#653](https://github.com/nextcloud/cookbook/pull/653) @seyfeb

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OCA\Cookbook\AppInfo;
+
+use OCA\Cookbook\Search\Provider;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
+class Application extends App implements IBootstrap {
+	public const APP_ID = 'cookbook';
+	
+	public function __construct(array $urlParams = []) {
+		parent::__construct(self::APP_ID, $urlParams);
+	}
+
+	public function register(IRegistrationContext $context): void {
+		$context->registerSearchProvider(Provider::class);
+	}
+
+	public function boot(IBootContext $context): void {
+	}
+}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -26,4 +26,12 @@ if (Util::getVersion()[0] >= 20) {
 		public function boot(IBootContext $context): void {
 		}
 	}
+} else {
+	class Application extends App {
+		public const APP_ID = 'cookbook';
+		
+		public function __construct(array $urlParams = []) {
+			parent::__construct(self::APP_ID, $urlParams);
+		}
+	}
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -12,7 +12,8 @@ use OCP\Util;
 // IBootstrap requies NC >= 20
 // Remove conditional once we end support for NC 19
 if (Util::getVersion()[0] >= 20) {
-	class Application extends App implements IBootstrap {
+	class Application extends App implements IBootstrap
+{
 		public const APP_ID = 'cookbook';
 		
 		public function __construct(array $urlParams = []) {
@@ -27,7 +28,8 @@ if (Util::getVersion()[0] >= 20) {
 		}
 	}
 } else {
-	class Application extends App {
+	class Application extends App
+{
 		public const APP_ID = 'cookbook';
 		
 		public function __construct(array $urlParams = []) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -7,18 +7,23 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\Util;
 
-class Application extends App implements IBootstrap {
-	public const APP_ID = 'cookbook';
-	
-	public function __construct(array $urlParams = []) {
-		parent::__construct(self::APP_ID, $urlParams);
-	}
+// IBootstrap requies NC >= 20
+// Remove conditional once we end support for NC 19
+if (Util::getVersion()[0] >= 20) {
+	class Application extends App implements IBootstrap {
+		public const APP_ID = 'cookbook';
+		
+		public function __construct(array $urlParams = []) {
+			parent::__construct(self::APP_ID, $urlParams);
+		}
 
-	public function register(IRegistrationContext $context): void {
-		$context->registerSearchProvider(Provider::class);
-	}
+		public function register(IRegistrationContext $context): void {
+			$context->registerSearchProvider(Provider::class);
+		}
 
-	public function boot(IBootContext $context): void {
+		public function boot(IBootContext $context): void {
+		}
 	}
 }

--- a/lib/Search/Provider.php
+++ b/lib/Search/Provider.php
@@ -87,4 +87,7 @@ if (Util::getVersion()[0] >= 20) {
 			);
 		}
 	}
+} else {
+	class Provider {
+	}
 }

--- a/lib/Search/Provider.php
+++ b/lib/Search/Provider.php
@@ -17,7 +17,8 @@ use OCP\Util;
 // IProvider requies NC >= 20
 // Remove conditional once we end support for NC 19
 if (Util::getVersion()[0] >= 20) {
-	class Provider implements IProvider {
+	class Provider implements IProvider
+{
 
 		/** @var IL10N */
 		private $l;
@@ -89,6 +90,7 @@ if (Util::getVersion()[0] >= 20) {
 		}
 	}
 } else {
-	class Provider {
+	class Provider
+{
 	}
 }

--- a/lib/Search/Provider.php
+++ b/lib/Search/Provider.php
@@ -7,7 +7,7 @@ use OCA\Cookbook\Db\RecipeDb;
 use OCA\Cookbook\Service\RecipeService;
 use OCP\IL10N;
 use OCP\IUser;
-use OCP\IUrlGenerator;
+use OCP\IURLGenerator;
 use OCP\Search\IProvider;
 use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
@@ -22,7 +22,7 @@ if (Util::getVersion()[0] >= 20) {
 		/** @var IL10N */
 		private $l;
 
-		/** @var IUrlGenerator */
+		/** @var IURLGenerator */
 		private $urlGenerator;
 
 		/** @var RecipeDb */
@@ -31,7 +31,8 @@ if (Util::getVersion()[0] >= 20) {
 		/** @var RecipeService */
 		private $recipeService;
 
-		public function __construct(IL10n $il10n, IUrlGenerator $urlGenerator, RecipeDb $recipeDb, RecipeService $recipeService) {
+		public function __construct(IL10n $il10n, IURLGenerator $urlGenerator,
+			RecipeDb $recipeDb, RecipeService $recipeService) {
 			$this->l = $il10n;
 			$this->urlGenerator = $urlGenerator;
 			$this->recipeDb = $recipeDb;


### PR DESCRIPTION
This fixes #559 by implementing a search provider for a unified search. Matching recpies are listed with their thumbnail (if available) and title, as well as the category if applicable.

![search-image](https://user-images.githubusercontent.com/2820802/108999528-b8ac2100-76a2-11eb-8476-5035aaa3f313.png)

The subline listing the category could easily be replaced by the recipe description, I am open for suggestions here. But I want to note that the current category lookup is expensive, as we read it from the recipe JSON file. Is that okay, or should we handle it differently?