### PR TITLE
Disable testing in repos without secrets

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -17,8 +17,21 @@ jobs:
                     - "7.3"
                     - "8"
         steps:
+            - name: Check if secret is known
+              shell: bash
+              id: check
+              run: |
+                echo "::set-output name=skip::false"
+                if [ -z "${{ secrets.DOCKER_HUB_TOKEN }}" ]; then
+                    echo "::set-output name=skip::true"
+                fi
+                if [ -z "${{ secrets.DOCKER_HUB_USERNAME }}" ]; then
+                    echo "::set-output name=skip::true"
+                fi
+            
             - name: Checkout the app
               uses: actions/checkout@v2
+              if: ${{ steps.check.outputs.skip == 'false' }}
               
             - name: Build and push the image
               shell: bash
@@ -31,3 +44,4 @@ jobs:
                 export COMPOSE_DOCKER_CLI_BUILD=1 &&
                 PHP_VERSION=${{ matrix.phpVersion }}
                 ./run-locally.sh --pull --create-images --push-images
+              if: ${{ steps.check.outputs.skip == 'false' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   [#608](https://github.com/nextcloud/cookbook/pull/608) @christianlupus
 - More code styling, cleanup & minor bugfixes
   [#615](https://github.com/nextcloud/cookbook/pull/615) @seyfeb
+- Avoid daily issues in personal forks due to missing secrets
+  [#620](https://github.com/nextcloud/cookbook/pull/620) @christianlupus
 
 ## Deprecated
 - Obsolete routes to old user interface, see `appinfo/routes.php`


### PR DESCRIPTION
In private repositories the secrets are unknown and thus the nightly build fails. This extension should prevent the nightly build if any secret is missing or an empty string.