### PR TITLE
Do not only filter but exclude paths from search

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -10,13 +10,13 @@ $config = new Config();
 $config
 	->getFinder()
 	->ignoreVCSIgnored(true)
-	->notPath('build')
-	->notPath('l10n')
+	->exclude('build')
+	->exclude('l10n')
 //	->notPath('lib/Vendor')
-	->notPath('src')
-	->notPath('node_modules')
-	->notPath('vendor')
-	->notPath('.github')
+	->exclude('src')
+	->exclude('node_modules')
+	->exclude('vendor')
+	->exclude('.github')
 	->in(__DIR__);
 return $config;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   [#615](https://github.com/nextcloud/cookbook/pull/615) @seyfeb
 - Avoid daily issues in personal forks due to missing secrets
   [#620](https://github.com/nextcloud/cookbook/pull/620) @christianlupus
+- Avoid descending of CS_fixer into non-code folders
+  [#621](https://github.com/nextcloud/cookbook/pull/621) @christianlupus
 
 ## Deprecated
 - Obsolete routes to old user interface, see `appinfo/routes.php`


### PR DESCRIPTION
Currently, the CS fixer descends as well into some folders that are going to be filtered out later. This is not optimal from a performance perspective but as well causes issues when the permissions are not well set (in the testing environment).