### PR TITLE
Added explicit version of dependency as workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   [#647](https://github.com/nextcloud/cookbook/pull/647) @christianlupus
 - Update code styling to match with current version of php-cs-fixer
   [#668](https://github.com/nextcloud/cookbook/pull/668) @christianlupus
+- Fix version of `@nextcloud/capabilities` to `1.0.2`
+  [#672](https://github.com/nextcloud/cookbook/pull/672) @christianlupus
   
 ## 0.8.4 - 2021-03-08
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@nextcloud/auth": "^1.3.0",
     "@nextcloud/axios": "^1.6.0",
-    "@nextcloud/capabilities": "^1.0.2",
+    "@nextcloud/capabilities": "1.0.2",
     "@nextcloud/event-bus": "^1.2.0",
     "@nextcloud/moment": "^1.1.1",
     "@nextcloud/vue": "^3.5.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@nextcloud/auth": "^1.3.0",
     "@nextcloud/axios": "^1.6.0",
+    "@nextcloud/capabilities": "^1.0.2",
     "@nextcloud/event-bus": "^1.2.0",
     "@nextcloud/moment": "^1.1.1",
     "@nextcloud/vue": "^3.5.4",


### PR DESCRIPTION
The `@nextcloud/capabilities` in version `1.0.3` causes issues with the `@nextcloud/vue` library. This is a hotfix to keep the problem at bay for now. 