### PR TITLE
Showing recipe-ref popup in input groups on # (keyboard-layout independent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   [#668](https://github.com/nextcloud/cookbook/pull/668) @christianlupus
 - Fix version of `@nextcloud/capabilities` to `1.0.2`
   [#672](https://github.com/nextcloud/cookbook/pull/672) @christianlupus
+- Really only show recipe-reference popup on '#'
+  [#676](https://github.com/nextcloud/cookbook/pull/676) @seyfeb
   
 ## 0.8.4 - 2021-03-08
 

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -227,7 +227,7 @@ export default {
             if (
                 e.keyCode === 13 ||
                 e.keyCode === 10 ||
-                (this.referencePopupEnabled && e.keyCode === 51)
+                (this.referencePopupEnabled && e.key === "#")
             ) {
                 e.preventDefault()
                 const $li = e.currentTarget.closest("li")
@@ -251,7 +251,7 @@ export default {
                             .getElementsByTagName("input")[0]
                             .focus()
                     }
-                } else if (this.referencePopupEnabled && e.keyCode === 51) {
+                } else if (this.referencePopupEnabled && e.key === "#") {
                     e.preventDefault()
                     const elm = this.$refs["list-field"][$pressed_li_index]
                     // Check if the letter before the hash


### PR DESCRIPTION
Fixes the missing part of #648.
 
Closes #670