### PR TITLE
Removed obsolete dependency @nextcloud/capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   [#676](https://github.com/nextcloud/cookbook/pull/676) @seyfeb
 - Correct styling of PHP files accoring to php-cs-fixer
   [#692](https://github.com/nextcloud/cookbook/pull/692) @christianlupus
+- Removed explicit dependency of @nextcloud/capabilities
+  [#693](https://github.com/nextcloud/cookbook/pull/693) @christianlupus
   
 ## 0.8.4 - 2021-03-08
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@nextcloud/auth": "^1.3.0",
     "@nextcloud/axios": "^1.6.0",
-    "@nextcloud/capabilities": "1.0.2",
     "@nextcloud/event-bus": "^1.2.0",
     "@nextcloud/moment": "^1.1.1",
     "@nextcloud/vue": "^3.5.4",


### PR DESCRIPTION
The dependency was merged only as a workaround for a bug in the dependency. This should revert that change.