### PR TITLE
Half the work done in github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,13 @@
 
-name: CI-tests
+name: Continuous integration testing
 
 on:
   push:
-  pull_request:
 
 jobs:
   
-  php-lint:
-    name: Run PHP Linter and Code Style checker
+  lint:
+    name: Run Linter and Code Style checker
     runs-on: ubuntu-latest
     steps:
         -   name: Checkout the project

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,7 +179,7 @@ jobs:
     name: Create source code artifacts
     needs:
         - unit-tests
-        - php-lint
+        - lint
     runs-on: ubuntu-latest
     
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   [#699](https://github.com/nextcloud/cookbook/pull/699) @christianlupus
 - Enable stalebot
   [#700](https://github.com/nextcloud/cookbook/pull/700) @christianlupus
+- Reduce automated work for PR merges
+  [#718](https://github.com/nextcloud/cookbook/pull/718) @christianlupus
   
 ## 0.8.4 - 2021-03-08
 


### PR DESCRIPTION
Currently, all tests are run twice, once in the pull request and once for the push itself. This should fix this and speed up PR tweaking a bit.