### PR TITLE
Remove unneeded dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@
   [#747](https://github.com/nextcloud/cookbook/pull/747) @mMuck
 - Fix visual issues at device width of 1024px #689
   [#751](https://github.com/nextcloud/cookbook/pull/751) @christianlupus
-
+- Removed obsolete dependency on @nextcloud/event-bus
+  [#719](https://github.com/nextcloud/cookbook/pull/719) @christianlupus
+  
 
 ## 0.8.4 - 2021-03-08
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@nextcloud/auth": "^1.3.0",
     "@nextcloud/axios": "^1.6.0",
-    "@nextcloud/event-bus": "^1.2.0",
     "@nextcloud/moment": "^1.1.1",
     "@nextcloud/vue": "^3.5.4",
     "lozad": "^1.16.0",


### PR DESCRIPTION
This will remove an unneeded NPM dependency as far as I can see.

This dependency seems to be a leftover of the original implementation work and (currently) is references nowhere in the codebase.