### PR TITLE
Update the stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,18 +15,18 @@ jobs:
             name: Close stale issues
             with:
                 days-before-stale: 45
-                stale-issue-message: <
+                stale-issue-message: >-
                     This issue was not updated for 45 days.
                     It is therefore marked as stale.
                     When no update occurs within the next 7 days, this issue will be closed automatically in the next 7 days.
-                stale-pr-message: <
+                stale-pr-message: >-
                     This pull request was not updated for 45 days.
                     It is therefore marked as stale.
                     When no update occurs within the next 7 days, this pull request will be closed automatically in the next 7 days.
-                close-issue-message: <
+                close-issue-message: >-
                     This issue was not updated since it was marked as stale.
                     It will be closed now.
-                close-pr-message: <
+                close-pr-message: >-
                     This pull request was not updated since it was marked as stale.
                     It will be closed now.
                 stale-issue-label: 'stale'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
   [#725](https://github.com/nextcloud/cookbook/pull/725) @christianlupus
 - Fix recipe-editor layout as in #729
   [#725](https://github.com/nextcloud/cookbook/pull/732) @seyfeb
+- Corrected style of stale bot messages
+  [#749](https://github.com/nextcloud/cookbook/pull/749) @christianlupus
 
 
 ## 0.8.4 - 2021-03-08


### PR DESCRIPTION
This should remove a wrong `<` symbol from the messages by the stale bot.