### PR TITLE
Fix/754 allow sharing with primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   [#758](https://github.com/nextcloud/cookbook/pull/758) @christianlupus
 - Added issue template and documentation regarding website support
   [#759](https://github.com/nextcloud/cookbook/pull/759) @christianlupus
+- Avoid sharing of recipes does break the database upgrade process
+  [#755](https://github.com/nextcloud/cookbook/pull/755) @christianlupus
 
 ### Removed
 - Obsolete API routes that are no longer working due to missing files

--- a/lib/Migration/Version000000Date20210427082010.php
+++ b/lib/Migration/Version000000Date20210427082010.php
@@ -26,11 +26,6 @@ class Version000000Date20210427082010 extends SimpleMigrationStep {
 		 */
 		$schema = $schemaClosure();
 		
-		$namesTable = $schema->getTable('cookbook_names');
-		if (! $namesTable->hasPrimaryKey()) {
-			$namesTable->setPrimaryKey(['recipe_id']);
-		}
-		
 		$categoriesTable = $schema->getTable('cookbook_categories');
 		if (! $categoriesTable->hasIndex('categories_recipe_idx')) {
 			$categoriesTable->addIndex([

--- a/lib/Migration/Version000000Date20210701093123.php
+++ b/lib/Migration/Version000000Date20210701093123.php
@@ -21,23 +21,22 @@ class Version000000Date20210701093123 extends SimpleMigrationStep {
 	 * @return null|ISchemaWrapper
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-	    /**
-	     * @var ISchemaWrapper $schema
-	     */
-	    $schema = $schemaClosure();
-	    
-	    $namesTable = $schema->getTable('cookbook_names');
-	    if ($namesTable->hasPrimaryKey()) {
-	        $namesTable->dropPrimaryKey();
-	    }
-	    if (! $namesTable->hasIndex('names_recipe_idx')) {
-	        $namesTable->addUniqueIndex([
-	            'recipe_id',
-	            'user_id'
-	        ], 'names_recipe_idx');
-	    }
-	    
-	    return $schema;
+		/**
+		 * @var ISchemaWrapper $schema
+		 */
+		$schema = $schemaClosure();
+		
+		$namesTable = $schema->getTable('cookbook_names');
+		if ($namesTable->hasPrimaryKey()) {
+			$namesTable->dropPrimaryKey();
+		}
+		if (! $namesTable->hasIndex('names_recipe_idx')) {
+			$namesTable->addUniqueIndex([
+				'recipe_id',
+				'user_id'
+			], 'names_recipe_idx');
+		}
+		
+		return $schema;
 	}
-
 }

--- a/lib/Migration/Version000000Date20210701093123.php
+++ b/lib/Migration/Version000000Date20210701093123.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Cookbook\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version000000Date20210701093123 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+	    /**
+	     * @var ISchemaWrapper $schema
+	     */
+	    $schema = $schemaClosure();
+	    
+	    $namesTable = $schema->getTable('cookbook_names');
+	    if ($namesTable->hasPrimaryKey()) {
+	        $namesTable->dropPrimaryKey();
+	    }
+	    if (! $namesTable->hasIndex('names_recipe_idx')) {
+	        $namesTable->addUniqueIndex([
+	            'recipe_id',
+	            'user_id'
+	        ], 'names_recipe_idx');
+	    }
+	    
+	    return $schema;
+	}
+
+}


### PR DESCRIPTION
Closes #754.

This should avoid constraint violations in the database when the recipe is shared and the same id (from the folder of the files app) is used multiple times as a primary key.