### PR TITLE
Correct fetching depth in action scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,6 +125,8 @@ jobs:
     steps:
       - name: Checkout the app
         uses: actions/checkout@v2
+        with:
+            fetch-depth: 2
       
       #- name: Docker Layer Caching
         #uses: satackey/action-docker-layer-caching@v0.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+- Correct handling of uploads to codecov
+  [#758](https://github.com/nextcloud/cookbook/pull/758) @christianlupus
+
 
 ## 0.9.0 - 2021-07-01
 


### PR DESCRIPTION
This should fix some issues with codecov reports. See https://github.com/codecov/codecov-action/issues/190.