### PR TITLE
Corrected path from l10n ignore file

### DIFF
--- a/.l10nignore
+++ b/.l10nignore
@@ -1,1 +1,1 @@
-docs/dev/api/0.0.2/
+docs/dev/api/


### PR DESCRIPTION
This is a fix for 6a520cb4 to get also future swagger JS files.