### PR TITLE
Add Cookbook-flutter FDroid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The app works generally in any modern browser. Additionally, there are some more
 The currently available clients are
 
 - Nextcloud Cookbook (by MicMun) ([Google Play](https://play.google.com/store/apps/details?id=de.micmun.android.nextcloudcookbook&hl=en_US&gl=US), [FDroid](https://f-droid.org/en/packages/de.micmun.android.nextcloudcookbook/), [homepage](https://micmun.de/nextcloud-cookbook-english/))
-- [Nextcloud Cookbook](https://github.com/Teifun2/nextcloud-cookbook-flutter) (by Teifun2) ([Google Play](https://play.google.com/store/apps/details?id=com.nextcloud_cookbook_flutter&hl=en_US&gl=US))
+- [Nextcloud Cookbook](https://github.com/Teifun2/nextcloud-cookbook-flutter) (by Teifun2) ([Google Play](https://play.google.com/store/apps/details?id=com.nextcloud_cookbook_flutter&hl=en_US&gl=US), [FDroid](https://f-droid.org/en/packages/com.nextcloud_cookbook_flutter/))
 
 ### Browser plugins/scripts
 


### PR DESCRIPTION
This is a very small PR that just adds nextcloud-cookbook-flutter F-Droid link in README