### PR TITLE
Fix empty Category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- Fix empty Category
+  [#805](https://github.com/nextcloud/cookbook/pull/805) @jotoeri
 
 ## 0.9.4 - 2021-09-29
 

--- a/lib/Service/DbCacheService.php
+++ b/lib/Service/DbCacheService.php
@@ -272,7 +272,7 @@ class DbCacheService {
 	 * @return string|null The category name of null if no category was found.
 	 */
 	private function getJSONCategory(array $json): ?string {
-		if (!isset($json['recipeCategory'])) {
+		if (!isset($json['recipeCategory']) || strlen(trim($json['recipeCategory'])) == 0) {
 			return null;
 		}
 


### PR DESCRIPTION
Adds a small part, that got lost in #797. Recipes without Category can have `"recipeCategory":""`, which means `$json['recipeCategory']` is set, but there is no proper Category.

Fixes #802 🙂 