### PR TITLE
Add placeholder text to image input field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+- Add placeholder text to make clear URLs can be used as image source
+  [#835](https://github.com/nextcloud/cookbook/pull/835) @seyfeb
+
 ### Fixed
 - CI build always builds docker images from scratch
   [#823](https://github.com/nextcloud/cookbook/pull/823) @christianlupus

--- a/src/components/EditImageField.vue
+++ b/src/components/EditImageField.vue
@@ -7,6 +7,12 @@
             <input
                 type="text"
                 :value="value"
+                :placeholder="
+                    t(
+                        'cookbook',
+                        'Enter URL or select from your Nextcloud instance on the right'
+                    )
+                "
                 @input="$emit('input', $event.target.value)"
             />
             <button


### PR DESCRIPTION
Indicate that URLs can be used as a source for images and not only the Nextcloud instance

Closes #771 