### PR TITLE
All NPM plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- Update NPM plugins to enhance build process
+  [#868](https://github.com/nextcloud/cookbook/pull/868) @christianlupus
 
 
 ## 0.9.8 - 2021-12-05

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"eslint-plugin-vue": "^8.0.3",
 		"file-loader": "^6.0.0",
 		"lodash-webpack-plugin": "^0.11.5",
+		"mini-css-extract-plugin": "^2.4.5",
 		"prettier": "^2.2.1",
 		"stylelint": "^13.12.0",
 		"stylelint-config-idiomatic-order": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.9.0",
 		"babel-loader": "^8.1.0",
+		"clean-webpack-plugin": "^4.0.0",
 		"compression-webpack-plugin": "^9.0.0",
 		"css-loader": "^6.0.0",
 		"eslint": "^8.2.0",

--- a/templates/index.php
+++ b/templates/index.php
@@ -1,5 +1,7 @@
 <?php
 script('cookbook', 'vue');
+// Import the css file from the built folder
+style('cookbook', '../js/vue');
 ?>
 
 <div id="app">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,8 @@
 const path = require('path')
 const { VueLoaderPlugin } = require('vue-loader')
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin')
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin')
+const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 
 module.exports = {
 
@@ -29,7 +30,10 @@ module.exports = {
             },
             {
                 test: /\.css$/,
-                use: [{ loader: 'vue-style-loader' }, 
+                use: [
+                    process.env.NODE_ENV !== 'production' ?
+                    MiniCssExtractPlugin.loader :
+                    { loader: 'vue-style-loader' },
                     {
                         loader: 'css-loader',
                         options: {
@@ -72,6 +76,8 @@ module.exports = {
             {
                 test: /\.scss$/,
                 use: [
+                    process.env.NODE_ENV !== 'production' ?
+                    MiniCssExtractPlugin.loader :
                     { loader: 'vue-style-loader' },
                     {
                         loader: 'css-loader',
@@ -86,8 +92,14 @@ module.exports = {
     },
     plugins: [
         new CleanWebpackPlugin(),
+        new MiniCssExtractPlugin({
+            // Options similar to the same options in webpackOptions.output
+            // both options are optional
+            filename: "[name].css",
+            // chunkFilename: "[id].css",
+          }),
         new VueLoaderPlugin(),
-        new LodashModuleReplacementPlugin
+        new LodashModuleReplacementPlugin,
     ],
     resolve: {
         extensions: ['*', '.js', '.vue', '.json'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,11 +6,12 @@
  */
 const path = require('path')
 const { VueLoaderPlugin } = require('vue-loader')
-var LodashModuleReplacementPlugin = require('lodash-webpack-plugin')
+const LodashModuleReplacementPlugin = require('lodash-webpack-plugin')
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 module.exports = {
 
-    entry:{
+    entry: {
         vue: path.join(__dirname, 'src', 'main.js'),
         guest: path.join(__dirname, 'src', 'guest.js'),
     },
@@ -84,6 +85,7 @@ module.exports = {
         ],
     },
     plugins: [
+        new CleanWebpackPlugin(),
         new VueLoaderPlugin(),
         new LodashModuleReplacementPlugin
     ],

--- a/webpack.devel.js
+++ b/webpack.devel.js
@@ -3,6 +3,7 @@ const base = require('./webpack.build-dev.js')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 
 module.exports = merge(base, {
+    mode: "development",
     plugins: [
         new BundleAnalyzerPlugin(
             {


### PR DESCRIPTION
This should add two plugins to the build chain.

- The clean plugin will tidy up the `js` folder on each build.
- The mini-css-extractor will build a dedicated CSS file to enhance load speed.