### PR TITLE
Filter empty pasted lines before single line check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   [#883](https://github.com/nextcloud/cookbook/pull/883) @christianlupus
 - Make the controls sticky on top
   [#888](https://github.com/nextcloud/cookbook/pull/888) @MarcelRobitaille
+- Cleanup code related to pasting
+  [#886](https://github.com/nextcloud/cookbook/pull/886) @MarcelRobitaille
 
 ### Documentation
 - Added clarification between categories and keywords for users

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -171,6 +171,8 @@ export default {
             const clipboardData = e.clipboardData || window.clipboardData
             const pastedData = clipboardData.getData("Text")
             const inputLinesArray = pastedData.split(/\r\n|\r|\n/g)
+                // Remove empty lines
+                .filter(line => line.trim() !== "")
 
             if (inputLinesArray.length === 1) {
                 this.singleLinePasted = true
@@ -187,12 +189,6 @@ export default {
                 $li
             )
 
-            // Remove empty lines
-            for (let i = inputLinesArray.length - 1; i >= 0; --i) {
-                if (inputLinesArray[i].trim() === "") {
-                    inputLinesArray.splice(i, 1)
-                }
-            }
             for (let i = 0; i < inputLinesArray.length; ++i) {
                 this.addNewEntry(
                     $insertedIndex + i + 1,

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -170,9 +170,10 @@ export default {
             // from the data pasted in the input field (e.target.value)
             const clipboardData = e.clipboardData || window.clipboardData
             const pastedData = clipboardData.getData("Text")
-            const inputLinesArray = pastedData.split(/\r\n|\r|\n/g)
+            const inputLinesArray = pastedData
+                .split(/\r\n|\r|\n/g)
                 // Remove empty lines
-                .filter(line => line.trim() !== "")
+                .filter((line) => line.trim() !== "")
 
             if (inputLinesArray.length === 1) {
                 this.singleLinePasted = true


### PR DESCRIPTION
I noticed this while trying to implement something else.

When pasting multiple lines, the empty lines should be filtered out before checking if only one line was pasted, shouldn't they?

For example, if the following is pasted: `"this is a test\n"`, this will be split into `["this is a test", ""]` and `this.singleLinePasted` will be false even though later the empty item will be filtered out and the array will contain a single element.

I also replaced the for loop with the filter method, I hope that's ok. I think it's more clear what is going on.