### PR TITLE
Remove the common prefix from pasted lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+- Remove prefix of pasted content for better formatting
+  [#887](https://github.com/nextcloud/cookbook/pull/887) @MarcelRobitaille
+
 ### Fixed
 - Added app info XML back to allow automatic translations
   [#878](https://github.com/nextcloud/cookbook/pull/878) @christianlupus

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -213,7 +213,7 @@ export default {
             // For example, if many lines start with the same word, keep that
             // This is more robust than filtering our [a-zA-Z] in the prefix
             // as it should work for any alphabet
-            const re = /[^\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]/g
+            const re = /[^\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]/g
             const prefixLength = re.test(prefix)
                 ? prefix.search(re)
                 : prefix.length

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -58,6 +58,20 @@
 </template>
 
 <script>
+const findCommonPrefix = lines => {
+    // Find the substring common to the array of strings
+    // Inspired from https://stackoverflow.com/questions/68702774/longest-common-prefix-in-javascript
+
+    // Check border cases size 1 array and empty first word)
+    if (!lines[0] || lines.length ===  1) return lines[0] || ""
+
+    // While all lines have the same character at position i, increment i
+    for (let i = 0; lines[0][i] && lines.every(w => w[i] === lines[0][i]); i++) {}
+
+    // prefix is the substring from the beginning to the last successfully checked i
+    return lines[0].substr(0, i)
+}
+
 export default {
     name: "EditInputGroup",
     props: {
@@ -189,6 +203,24 @@ export default {
                 $ul.childNodes,
                 $li
             )
+
+            // Remove the common prefix from each line of the pasted text
+            // For example, if the pasted text uses - for a bullet list
+            let prefix = findCommonPrefix(inputLinesArray)
+
+            // Inspired from https://stackoverflow.com/a/25575009
+            // Ensure that we are only removing common punctuation
+            // For example, if many lines start with the same word, keep that
+            // This is more robust than filtering our [a-zA-Z] in the prefix
+            // as it should work for any alphabet
+            const re = /[^\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]/g
+            const prefixLength = re.test(prefix)
+                ? prefix.search(re)
+                : prefix.length
+
+            for (let i = 0; i < inputLinesArray.length; ++i) {
+                inputLinesArray[i] = inputLinesArray[i].slice(prefixLength)
+            }
 
             for (let i = 0; i < inputLinesArray.length; ++i) {
                 this.addNewEntry(

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -206,7 +206,7 @@ export default {
 
             // Remove the common prefix from each line of the pasted text
             // For example, if the pasted text uses - for a bullet list
-            let prefix = findCommonPrefix(inputLinesArray)
+            const prefix = findCommonPrefix(inputLinesArray)
 
             // Inspired from https://stackoverflow.com/a/25575009
             // Ensure that we are only removing common punctuation

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -58,6 +58,7 @@
 </template>
 
 <script>
+const linesMatchAtPosition = (lines, i) => lines.every((line) => line[i] === lines[0][i])
 const findCommonPrefix = lines => {
     // Find the substring common to the array of strings
     // Inspired from https://stackoverflow.com/questions/68702774/longest-common-prefix-in-javascript
@@ -65,11 +66,15 @@ const findCommonPrefix = lines => {
     // Check border cases size 1 array and empty first word)
     if (!lines[0] || lines.length ===  1) return lines[0] || ""
 
-    // While all lines have the same character at position i, increment i
-    for (let i = 0; lines[0][i] && lines.every(w => w[i] === lines[0][i]); i++) {}
-
-    // prefix is the substring from the beginning to the last successfully checked i
-    return lines[0].substr(0, i)
+    // Loop up index until the characters do not match
+    for (let i = 0; ; i++) {
+        // If first line has fewer than i characters
+        // or the character of each line at position i is not identical
+        if (!lines[0][i] || !linesMatchAtPosition(lines, i)) {
+            // Then the desired prefix is the substring from the beginning to i
+            return lines[0].substr(0, i)
+        }
+    }
 }
 
 export default {

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -58,13 +58,14 @@
 </template>
 
 <script>
-const linesMatchAtPosition = (lines, i) => lines.every((line) => line[i] === lines[0][i])
-const findCommonPrefix = lines => {
+const linesMatchAtPosition = (lines, i) =>
+    lines.every((line) => line[i] === lines[0][i])
+const findCommonPrefix = (lines) => {
     // Find the substring common to the array of strings
     // Inspired from https://stackoverflow.com/questions/68702774/longest-common-prefix-in-javascript
 
     // Check border cases size 1 array and empty first word)
-    if (!lines[0] || lines.length ===  1) return lines[0] || ""
+    if (!lines[0] || lines.length === 1) return lines[0] || ""
 
     // Loop up index until the characters do not match
     for (let i = 0; ; i++) {
@@ -218,7 +219,8 @@ export default {
             // For example, if many lines start with the same word, keep that
             // This is more robust than filtering our [a-zA-Z] in the prefix
             // as it should work for any alphabet
-            const re = /[^\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]/g
+            const re =
+                /[^\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~]/g
             const prefixLength = re.test(prefix)
                 ? prefix.search(re)
                 : prefix.length


### PR DESCRIPTION
I was recently sent a recipe from a relative by email. Each instruction from the recipe started with ` -  ` (space hyphen space space). When I pasted this into Cookbook, I was very impressed when my clipboard was split by newline and multiple steps were inserted, but each line started with ` -  `. 

This pull request removes this common prefix when pasting multiple lines. First, the common prefix is found. Then, I disregard the rest of the prefix if I detect anything that is not punctuation or whitespace. This is because I do not want to remove anything that is not actual text. For example, if each line starts with `Step 1 is to ...`. Finally, the prefix is removed from each line.

Here are some examples:

These lines:
```
 -   Put the frying pan on the stove
 -   Add the oil to the frying pan
```
will become:
```js
[
    "Put the frying pan on the stove",
    "Add the oil to the frying pan"
]
```

This will not be changed:
```
Step 1 is to ...
Step 2 is to ...
Step 3 is to ...
```

This will also not be changed, even if each word starts with `th`:
```
The frying pan goes on the stove.
Then, add the oil.
```


I do not see any unit tests for the javascript in this repository. I have written some simple tests just using `console.assert` (no testing framework). It should be quite easy to convert these to any framework (the functions will have to be imported properly, obviously).

```js
const findCommonPrefix = lines => {
    // Find the substring common to the array of strings
    // Inspired from https://stackoverflow.com/questions/68702774/longest-common-prefix-in-javascript

    // Check border cases size 1 array and empty first word)
    if (!lines[0] || lines.length ===  1) return lines[0] || ""

    // While all lines have the same character at position i, increment i
    let i = 0
    for (; lines[0][i] && lines.every(w => w[i] === lines[0][i]); i++) {}

    // prefix is the substring from the beginning to the last successfully checked i
    return lines[0].substr(0, i)
}

const removeCommonPrefix = input => {
    const inputLinesArray = input.split(/\r\n|\r|\n/g)
        // Remove empty lines
        .filter(line => line.trim() !== "")

    let prefix = findCommonPrefix(inputLinesArray)

    // Inspired from https://stackoverflow.com/a/25575009
    // Ensure that we are only removing common punctuation
    // For example, if many lines start with the same word, keep that
    // This is more robust than filtering our [a-zA-Z] in the prefix
    // as it should work for any alphabet
    const re = /[^\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]/g
    const prefixLength = re.test(prefix)
        ? prefix.search(re)
        : prefix.length

    for (let i = 0; i < inputLinesArray.length; ++i) {
        inputLinesArray[i] = inputLinesArray[i].slice(prefixLength)
    }

    return inputLinesArray
}

// It should not change anything that's actually text
console.assert(JSON.stringify(removeCommonPrefix(`this is a test
the second line`)) === JSON.stringify([ 'this is a test', 'the second line' ]))
console.assert(JSON.stringify(removeCommonPrefix(`
Step 1 is to ...
Step 2 is to ...
Step 3 is to ...
`)) === JSON.stringify([
    'Step 1 is to ...',
    'Step 2 is to ...',
    'Step 3 is to ...',
]))

// It should remove common whitespace and punctuation at the start
console.assert(JSON.stringify(removeCommonPrefix(`
 -  line one
 -  line two
 -  line three
`)) === JSON.stringify([ 'line one', 'line two', 'line three' ]))

// It should still work with empty lines
console.assert(JSON.stringify(removeCommonPrefix(`
 -  line one
 -  line two
       
 -  line three
`)) === JSON.stringify([ 'line one', 'line two', 'line three' ]))

// It should work with unicode bullet points
console.assert(JSON.stringify(removeCommonPrefix(`
 •  line one
 •  line two
 •  line three
`)) === JSON.stringify([ 'line one', 'line two', 'line three' ]))

```