### PR TITLE
Make AppControls breadcrums sticky (#834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@
   [#880](https://github.com/nextcloud/cookbook/pull/880) @christianlupus
 - Usage of caches for NPM speedup
   [#883](https://github.com/nextcloud/cookbook/pull/883) @christianlupus
+- Make the controls sticky on top
+  [#888](https://github.com/nextcloud/cookbook/pull/888) @MarcelRobitaille
 
 ### Documentation
 - Added clarification between categories and keywords for users
   [#889](https://github.com/nextcloud/cookbook/pull/889) @MarcelRobitaille
+
 
 ## 0.9.9 - 2022-01-13
 

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -346,6 +346,15 @@ export default {
 .wrapper {
     width: 100%;
     padding-left: 4px;
+    /* Sticky is better than fixed because fixed takes the element out of flow,
+     which breaks the height, putting elements underneath */
+    position: sticky;
+    /* The height of the nextcloud header */
+    top: 50px;
+    /* This is competing with the recipe instructions which have z-index: 1 */
+    z-index: 2;
+    background-color: var(--color-main-background);
+    border-bottom: 1px solid var(--color-border);
 }
 
 .active {

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -344,17 +344,19 @@ export default {
 
 <style scoped>
 .wrapper {
-    width: 100%;
-    padding-left: 4px;
     /* Sticky is better than fixed because fixed takes the element out of flow,
      which breaks the height, putting elements underneath */
     position: sticky;
-    /* The height of the nextcloud header */
-    top: 50px;
+
     /* This is competing with the recipe instructions which have z-index: 1 */
     z-index: 2;
-    background-color: var(--color-main-background);
+
+    /* The height of the nextcloud header */
+    top: 50px;
+    width: 100%;
+    padding-left: 4px;
     border-bottom: 1px solid var(--color-border);
+    background-color: var(--color-main-background);
 }
 
 .active {


### PR DESCRIPTION
Make the buttons always visible so that they are accessible even when
scrolled halfway down a recipe.

This is consistent with the "Open navigation" / "Close navigation" button and gives more information and controls than making the bottom save button sticky.

![image](https://user-images.githubusercontent.com/8503756/153256490-ce29f38d-963f-4fa5-afa7-f0452cfd5df4.png)