### PR TITLE
Enable enter to go to next instructions step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   [#897](https://github.com/nextcloud/cookbook/pull/897) @MarcelRobitaille
 - Fix UI glitch when keyword list is empty
   [#892](https://github.com/nextcloud/cookbook/pull/892) @MarcelRobitaille
+- Allow switching to new instruction line with Enter key
+  [#890](https://github.com/nextcloud/cookbook/pull/890) @MarcelRobitaille
 
 ### Documentation
 - Added clarification between categories and keywords for users

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -287,8 +287,11 @@ export default {
                     ) {
                         this.addNewEntry()
                     } else {
+                        // Focus the next input or textarea
+                        // We have to check for both, as inputs are used for
+                        // ingredients and textareas are used for instructions
                         $ul.children[$pressedLiIndex + 1]
-                            .getElementsByTagName("input")[0]
+                            .querySelector("input, textarea")
                             .focus()
                     }
                 } else if (this.referencePopupEnabled && e.key === "#") {


### PR DESCRIPTION
This is a fix for #882.

When enter is pressed in `EditInputGroup`, there is an attempt to select the next input field. This works for ingredients, which use inputs, but not for instructions, which use `textareas`. Now, both are searched for using `querySelector`.
