### PR TITLE
Fix the UI glitch when keywords are empty (#857)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   [#886](https://github.com/nextcloud/cookbook/pull/886) @MarcelRobitaille
 - Make height of control header dependant on server CSS variable
   [#897](https://github.com/nextcloud/cookbook/pull/897) @MarcelRobitaille
+- Fix UI glitch when keyword list is empty
+  [#892](https://github.com/nextcloud/cookbook/pull/892) @MarcelRobitaille
 
 ### Documentation
 - Added clarification between categories and keywords for users

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -669,12 +669,12 @@ export default {
 
                 this.selectedKeywords = this.recipe.keywords
                     .split(",")
-                    .map(kw => kw.trim())
+                    .map((kw) => kw.trim())
                     // Remove any empty keywords
                     // If the response from the server is just an empty
                     // string, split will create an array of a single empty
                     // string
-                    .filter(kw => kw !== "")
+                    .filter((kw) => kw !== "")
 
                 // fallback if fetching all keywords fails
                 this.selectedKeywords.forEach((kw) => {

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -667,7 +667,14 @@ export default {
                     paddedTime: this.recipe.totalTime,
                 }
 
-                this.selectedKeywords = this.recipe.keywords.split(",")
+                this.selectedKeywords = this.recipe.keywords
+                    .split(",")
+                    .map(kw => kw.trim())
+                    // Remove any empty keywords
+                    // If the response from the server is just an empty
+                    // string, split will create an array of a single empty
+                    // string
+                    .filter(kw => kw !== "")
 
                 // fallback if fetching all keywords fails
                 this.selectedKeywords.forEach((kw) => {


### PR DESCRIPTION
Fix the UI glitch with a tiny blob in the keywords field when loading a recipe with empty keywords. The bug was caused by `keywords.split(',')` when `keywords` is an empty string. This will create an array of a single element: an empty string. Rendering this empty string as a keyword results in this little blob. The solution is to filter out empty strings after the call to `.split()`.