### PR TITLE
Use var(--header-height) not hard-coded 50px for breadcrums sticky position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   [#888](https://github.com/nextcloud/cookbook/pull/888) @MarcelRobitaille
 - Cleanup code related to pasting
   [#886](https://github.com/nextcloud/cookbook/pull/886) @MarcelRobitaille
+- Make height of control header dependant on server CSS variable
+  [#897](https://github.com/nextcloud/cookbook/pull/897) @MarcelRobitaille
 
 ### Documentation
 - Added clarification between categories and keywords for users

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -352,7 +352,7 @@ export default {
     z-index: 2;
 
     /* The height of the nextcloud header */
-    top: 50px;
+    top: var(--header-height);
     width: 100%;
     padding-left: 4px;
     border-bottom: 1px solid var(--color-border);


### PR DESCRIPTION
Fix #888 where the appcontrol breadcrums were given a position based on the hard-coded value `50px`. Instead, use the variable `--header-height` so that this code is adapted if the header height changes..