### PR TITLE
Prevent newlines switching input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   [#892](https://github.com/nextcloud/cookbook/pull/892) @MarcelRobitaille
 - Allow switching to new instruction line with Enter key
   [#890](https://github.com/nextcloud/cookbook/pull/890) @MarcelRobitaille
+- Prevent inserting newline characters in instructions/ingredients/tools when pressing enter
+  [#900](https://github.com/nextcloud/cookbook/pull/900) @MarcelRobitaille
 
 ### Documentation
 - Added clarification between categories and keywords for users

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -271,54 +271,57 @@ export default {
                 return
             }
 
+            // Only do anything for enter or # keys
             if (
-                e.key === "Enter" ||
-                (this.referencePopupEnabled && e.key === "#")
+                e.key !== "Enter" &&
+                !(this.referencePopupEnabled && e.key === "#")
             ) {
-                e.preventDefault()
-                const $li = e.currentTarget.closest("li")
-                const $ul = $li.closest("ul")
-                const $pressedLiIndex = Array.prototype.indexOf.call(
-                    $ul.childNodes,
-                    $li
-                )
+                return
+            }
 
-                if (e.key === "Enter") {
-                    if (
-                        $pressedLiIndex >=
-                        this.$refs["list-field"].length - 1
-                    ) {
-                        this.addNewEntry()
-                    } else {
-                        // Focus the next input or textarea
-                        // We have to check for both, as inputs are used for
-                        // ingredients and textareas are used for instructions
-                        $ul.children[$pressedLiIndex + 1]
-                            .querySelector("input, textarea")
-                            .focus()
-                    }
-                } else if (this.referencePopupEnabled && e.key === "#") {
-                    e.preventDefault()
-                    const elm = this.$refs["list-field"][$pressedLiIndex]
-                    // Check if the letter before the hash
-                    const cursorPos = elm.selectionStart
-                    const content = elm.value
-                    const prevChar =
-                        cursorPos > 1 ? content.charAt(cursorPos - 2) : ""
+            // If it is one of those keys, prevent the browser's default action
+            e.preventDefault()
 
-                    if (
-                        cursorPos === 1 ||
-                        prevChar === " " ||
-                        prevChar === "\n" ||
-                        prevChar === "\r"
-                    ) {
-                        // Show dialog to select recipe
-                        this.$parent.$emit("showRecipeReferencesPopup", {
-                            context: this,
-                        })
-                        this.lastFocusedFieldIndex = $pressedLiIndex
-                        this.lastCursorPosition = cursorPos
-                    }
+            // Get the index of the pressed list item
+            const $li = e.currentTarget.closest("li")
+            const $ul = $li.closest("ul")
+            const $pressedLiIndex = Array.prototype.indexOf.call(
+                $ul.childNodes,
+                $li
+            )
+
+            if (e.key === "Enter") {
+                if ($pressedLiIndex >= this.$refs["list-field"].length - 1) {
+                    this.addNewEntry()
+                } else {
+                    // Focus the next input or textarea
+                    // We have to check for both, as inputs are used for
+                    // ingredients and textareas are used for instructions
+                    $ul.children[$pressedLiIndex + 1]
+                        .querySelector("input, textarea")
+                        .focus()
+                }
+            }
+            if (this.referencePopupEnabled && e.key === "#") {
+                const elm = this.$refs["list-field"][$pressedLiIndex]
+                // Check if the letter before the hash
+                const cursorPos = elm.selectionStart
+                const content = elm.value
+                const prevChar =
+                    cursorPos > 1 ? content.charAt(cursorPos - 2) : ""
+
+                if (
+                    cursorPos === 1 ||
+                    prevChar === " " ||
+                    prevChar === "\n" ||
+                    prevChar === "\r"
+                ) {
+                    // Show dialog to select recipe
+                    this.$parent.$emit("showRecipeReferencesPopup", {
+                        context: this,
+                    })
+                    this.lastFocusedFieldIndex = $pressedLiIndex
+                    this.lastCursorPosition = cursorPos
                 }
             }
         },

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -15,7 +15,7 @@
                     ref="list-field"
                     v-model="buffer[idx]"
                     type="text"
-                    @keyup="keyPressed"
+                    @keydown="keyDown"
                     @input="handleInput"
                     @paste="handlePaste"
                 />
@@ -23,7 +23,7 @@
                     v-else-if="fieldType === 'textarea'"
                     ref="list-field"
                     v-model="buffer[idx]"
-                    @keyup="keyPressed"
+                    @keydown="keyDown"
                     @input="handleInput"
                     @paste="handlePaste"
                 ></textarea>
@@ -252,7 +252,7 @@ export default {
         /**
          * Catches enter and key down presses and either adds a new row or focuses the one below
          */
-        keyPressed(e) {
+        keyDown(e) {
             // If, e.g., enter has been pressed in the multiselect popup to select an option,
             // ignore the following keyup event
             if (this.ignoreNextKeyUp) {

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -305,13 +305,17 @@ export default {
             if (this.referencePopupEnabled && e.key === "#") {
                 const elm = this.$refs["list-field"][$pressedLiIndex]
                 // Check if the letter before the hash
+                // This is a keydown event listener, so the `#` does not
+                // exist in the input yet
+                // `cursorPos` will be the index in the textfield before the #
+                // was pressed
                 const cursorPos = elm.selectionStart
                 const content = elm.value
                 const prevChar =
-                    cursorPos > 1 ? content.charAt(cursorPos - 2) : ""
+                    cursorPos > 0 ? content.charAt(cursorPos - 1) : ""
 
                 if (
-                    cursorPos === 1 ||
+                    cursorPos === 0 ||
                     prevChar === " " ||
                     prevChar === "\n" ||
                     prevChar === "\r"

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -261,7 +261,7 @@ export default {
             }
 
             // Allow new lines with shift key
-            if ((e.keyCode === 13 || e.keyCode === 10) && e.shiftKey) {
+            if (e.key === "Enter" && e.shiftKey) {
                 // Do nothing here, user wants a line break
                 return
             }
@@ -270,9 +270,9 @@ export default {
             if (e.repeat) {
                 return
             }
+
             if (
-                e.keyCode === 13 ||
-                e.keyCode === 10 ||
+                e.key === "Enter" ||
                 (this.referencePopupEnabled && e.key === "#")
             ) {
                 e.preventDefault()
@@ -283,7 +283,7 @@ export default {
                     $li
                 )
 
-                if (e.keyCode === 13 || e.keyCode === 10) {
+                if (e.key === "Enter") {
                     if (
                         $pressedLiIndex >=
                         this.$refs["list-field"].length - 1

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -279,9 +279,6 @@ export default {
                 return
             }
 
-            // If it is one of those keys, prevent the browser's default action
-            e.preventDefault()
-
             // Get the index of the pressed list item
             const $li = e.currentTarget.closest("li")
             const $ul = $li.closest("ul")
@@ -291,6 +288,8 @@ export default {
             )
 
             if (e.key === "Enter") {
+                e.preventDefault()
+
                 if ($pressedLiIndex >= this.$refs["list-field"].length - 1) {
                     this.addNewEntry()
                 } else {
@@ -318,6 +317,7 @@ export default {
                     cursorPos === 0 ||
                     /\s/.test(content.charAt(cursorPos - 1))
                 ) {
+                    e.preventDefault()
                     // Show dialog to select recipe
                     this.$parent.$emit("showRecipeReferencesPopup", {
                         context: this,

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -311,14 +311,12 @@ export default {
                 // was pressed
                 const cursorPos = elm.selectionStart
                 const content = elm.value
-                const prevChar =
-                    cursorPos > 0 ? content.charAt(cursorPos - 1) : ""
 
+                // Show the popup only if the # was inserted at the very
+                // beggining of the input or after any whitespace character
                 if (
                     cursorPos === 0 ||
-                    prevChar === " " ||
-                    prevChar === "\n" ||
-                    prevChar === "\r"
+                    /\s/.test(content.charAt(cursorPos - 1))
                 ) {
                     // Show dialog to select recipe
                     this.$parent.$emit("showRecipeReferencesPopup", {

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -266,7 +266,10 @@ export default {
                 return
             }
 
-            // Using keyup for trigger will prevent repeat triggering if key is held down
+            // Repeat events should be ignored
+            if (e.repeat) {
+                return
+            }
             if (
                 e.keyCode === 13 ||
                 e.keyCode === 10 ||


### PR DESCRIPTION
Fixes #881.

Use a `keydown` event listener rather than a `keyup` event lister. This allows us to use `event.preventDefault()` when enter is pressed to go to the next textarea without adding a `\n` to the current textarea.

I believe the reason to use `keyup` previously was to not get repeat events. In order to make sure that repeat events are still not considered, we exit early if `event.repeat` is true.

I also took this opportunity to clean up some parts of the code.
First, I replaced `event.keyCode === 13` with `event.key === 'Enter'`. This was done for many reasons.
1. [`event.keyCode` is deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)
2. `event.key === 'Enter'` is more readable than `event.keyCode === 13`. You do not have to lookup what 13 means.
3. `event.keyCode === 10` was removed. I am not sure what this check comes from. I cannot find keycode 10 in any table.

The last change was to remove the nested if statements.
Instead of checking if the key is <kbd>enter</kbd> or <kbd>#</kbd> to prevent default
and then handling each individually,
I exit early if the key is neither.

Previous behaviour (when I hit enter with my cursor before `test`, the current input becomes `\ntest` before a new textarea is created):

https://user-images.githubusercontent.com/8503756/156021618-7c62da26-6a40-45ac-b5b3-30472eecdd84.mp4

New behaviour (hitting enter before `test` or inside of `test` does not add `\n`):


https://user-images.githubusercontent.com/8503756/156021637-b0542746-6d0b-4333-abcb-7ba69f1dc2d2.mp4

Repeat events are still ignored (I am holding the enter key):


https://user-images.githubusercontent.com/8503756/156021875-45ffc874-e2b1-4790-a3ec-dc0d70f1168f.mp4


