### PR TITLE
Remove tight coupling between input and paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+- Reduce complex coupling between event handlers in EditInputGroup.vue
+  [#901](https://github.com/nextcloud/cookbook/pull/901) @MarcelRobitaille
+
 
 ## 0.9.10 - 2022-03-04
 


### PR DESCRIPTION
Fixes #898.

In `handleInput`, check if content was pasted using `event.inputType`. This uses the event as the source of truth, so that we don't need the call to `nextTick` nor to read attributes set by `handlePaste`.

In `handlePaste`, if a single line was pasted, emit just like `handleInput` was doing for a single line pasted.

Remove the attributes `contentPasted` and `singleLinePasted`.

All of this removes the tight coupling between `handleInput` and `handlePaste`. There is no longer a need for the two attributes
`singleLinePasted` or `contentPasted`.

I have tested it quickly, and everything seems to work as before.