### PR TITLE
Revert Nextcloud core's contentedibtale styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Fixed
 - Reduce complex coupling between event handlers in EditInputGroup.vue
   [#901](https://github.com/nextcloud/cookbook/pull/901) @MarcelRobitaille
+- Fix bug in NC Vue config that switches input fields to be not full width on mobile
+  [#910](https://github.com/nextcloud/cookbook/pull/910) @MarcelRobitaille
 
 ### Documentation
 - Introduction about how to start coding

--- a/src/components/EditInputField.vue
+++ b/src/components/EditInputField.vue
@@ -207,6 +207,7 @@ fieldset > label {
 fieldset > input,
 fieldset > textarea {
     flex: 1;
+    width: revert;
 }
 
 fieldset > input[type="number"] {

--- a/src/components/EditInputField.vue
+++ b/src/components/EditInputField.vue
@@ -206,8 +206,8 @@ fieldset > label {
 
 fieldset > input,
 fieldset > textarea {
-    flex: 1;
     width: revert;
+    flex: 1;
 }
 
 fieldset > input[type="number"] {
@@ -237,14 +237,13 @@ Use /deep/ because >>> did not work for some reason
 .editor /deep/ div[contenteditable="true"] {
     width: revert;
     min-height: revert;
-    margin: revert;
     padding: revert;
-    font-size: revert;
-    background-color: revert;
-    color: revert;
     border: revert;
-    outline: revert;
+    margin: revert;
+    background-color: revert;
     border-radius: revert;
+    color: revert;
+    font-size: revert;
+    outline: revert;
 }
-
 </style>

--- a/src/components/EditInputField.vue
+++ b/src/components/EditInputField.vue
@@ -225,4 +225,25 @@ fieldset > .editor {
     border-radius: 2px;
     resize: vertical;
 }
+
+/*
+Hack to overwrite the heavy-handed global unscoped styles of Nextcloud core
+that cause our markdown editor CodeMirror to behave strangely on mobile
+See: https://github.com/nextcloud/cookbook/issues/908
+
+Use /deep/ because >>> did not work for some reason
+*/
+.editor /deep/ div[contenteditable="true"] {
+    width: revert;
+    min-height: revert;
+    margin: revert;
+    padding: revert;
+    font-size: revert;
+    background-color: revert;
+    color: revert;
+    border: revert;
+    outline: revert;
+    border-radius: revert;
+}
+
 </style>


### PR DESCRIPTION
Fixes #908 

Nextcloud core is setting global unscoped styles on any `div[contentedibtale]`. Such a div is used by our markdown editor:
CodeMirror. Fix this by overwritting Nextcloud core's heavy-handed global styles.

Now, adding `contenteditable="true"` does not change the style inside our markdown editor:

https://user-images.githubusercontent.com/8503756/157314618-a553dee7-6857-4f63-a949-9eb793d93201.mp4


