### PR TITLE
Don't prevent default event of inserting # when linking recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   [#912](https://github.com/nextcloud/cookbook/pull/912) @christianlupus
 - Remove deprecation in preparation for Sass 2.0.0
   [#915](https://github.com/nextcloud/cookbook/pull/915) @MarcelRobitaille
+- Fix regression in #900 to allow inserting links to other recipes again
+  [#914](https://github.com/nextcloud/cookbook/pull/914) @MarcelRobitaille
 
 ### Documentation
 - Introduction about how to start coding

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -313,7 +313,6 @@ export default {
                     cursorPos === 0 ||
                     /\s/.test(content.charAt(cursorPos - 1))
                 ) {
-                    e.preventDefault()
                     // Show dialog to select recipe
                     this.$parent.$emit("showRecipeReferencesPopup", {
                         context: this,


### PR DESCRIPTION
Fixes #905 

When refactoring they keydown handler of EditInputGroup, a regression was introduced where the # would not be inserted when linking to another recipe. This is because we previously had a keyup event listener, which cannot prevent the key from being insterted, but now we are using a keydown listener, which can. Therefore, the `e.preventDefault()` that was already present in the code now has unintended side effects. We can remove it, there is no reason to have it there.