### PR TITLE
Fix SASS deprecations, replace / with math.div

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
   [#909](https://github.com/nextcloud/cookbook/pull/909) @christianlupus
 - Remove some packages from the dependencies to keep the footprint smaller
   [#912](https://github.com/nextcloud/cookbook/pull/912) @christianlupus
-
+- Remove deprecation in preparation for Sass 2.0.0
+  [#915](https://github.com/nextcloud/cookbook/pull/915) @MarcelRobitaille
 
 ### Documentation
 - Introduction about how to start coding

--- a/src/components/AppNavigationCaption.vue
+++ b/src/components/AppNavigationCaption.vue
@@ -178,6 +178,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@use "sass:math";
+
 // Taken from @nextcloud/vue/src/assets/variables.scss
 // https://uxplanet.org/7-rules-for-mobile-ui-button-design-e9cf2ea54556
 // recommended is 48px
@@ -190,7 +192,7 @@ $icon-size: 16px;
 
 // icon padding for a $clickable-area width and a $icon-size icon
 // ( 44px - 16px ) / 2
-$icon-margin: ($clickable-area - $icon-size) / 2;
+$icon-margin: math.div($clickable-area - $icon-size, 2);
 
 .app-navigation-caption-mod {
     display: flex;
@@ -202,7 +204,7 @@ $icon-margin: ($clickable-area - $icon-size) / 2;
 
 // extra top space if it's not the first item on the list
 .app-navigation-caption-mod:not(:first-child) {
-    margin-top: $clickable-area / 2;
+    margin-top: math.div($clickable-area, 2);
 }
 
 // Main entry link

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -5,5 +5,8 @@ stylelintConfig.extends.push('stylelint-config-prettier', 'stylelint-config-idio
 stylelintConfig.rules.indentation = null
 stylelintConfig.rules['string-quotes'] = 'double'
 stylelintConfig.rules['selector-list-comma-newline-after'] = 'always-multi-line'
+stylelintConfig.rules['function-no-unknown'] = [true, {
+	'ignoreFunctions': ["math.div"]
+}]
 
 module.exports = stylelintConfig


### PR DESCRIPTION
Fixes #913 

This unfortunately adds two stylelint warnings:
```
WARNING in src/components/AppNavigationCaption.vue
 195:15  ✖  Unexpected unknown function "math.div"  function-no-unknown
 207:17  ✖  Unexpected unknown function "math.div"  function-no-unknown
```

See also: https://github.com/stylelint-scss/stylelint-config-recommended-scss/issues/92