### PR TITLE
Trim multiple whitespace characters when pasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   [#915](https://github.com/nextcloud/cookbook/pull/915) @MarcelRobitaille
 - Fix regression in #900 to allow inserting links to other recipes again
   [#914](https://github.com/nextcloud/cookbook/pull/914) @MarcelRobitaille
+- Replace multiple spaces with a single one when pasting
+  [#924](https://github.com/nextcloud/cookbook/pull/924) @MarcelRobitaille
 
 ### Documentation
 - Introduction about how to start coding
@@ -256,7 +258,7 @@
   [#751](https://github.com/nextcloud/cookbook/pull/751) @christianlupus
 - Removed obsolete dependency on @nextcloud/event-bus
   [#719](https://github.com/nextcloud/cookbook/pull/719) @christianlupus
-  
+
 
 ## 0.8.4 - 2021-03-08
 

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -233,7 +233,9 @@ export default {
             // to accidentally replace all newlines with spaces before splitting
             // Fixes #713
             for (let i = 0; i < inputLinesArray.length; ++i) {
-                inputLinesArray[i] = inputLinesArray[i].replaceAll(/\s+/g, " ")
+                inputLinesArray[i] = inputLinesArray[i]
+                    .trim()
+                    .replaceAll(/\s+/g, " ")
             }
 
             for (let i = 0; i < inputLinesArray.length; ++i) {

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -228,6 +228,10 @@ export default {
                 inputLinesArray[i] = inputLinesArray[i].slice(prefixLength)
             }
 
+            // Replace multiple whitespace characters with a single space
+            // This has to be applied to each item in the list if we don't want
+            // to accidentally replace all newlines with spaces before splitting
+            // Fixes #713
             for (let i = 0; i < inputLinesArray.length; ++i) {
                 inputLinesArray[i] = inputLinesArray[i].replaceAll(/\s+/g, " ")
             }

--- a/src/components/EditInputGroup.vue
+++ b/src/components/EditInputGroup.vue
@@ -229,6 +229,10 @@ export default {
             }
 
             for (let i = 0; i < inputLinesArray.length; ++i) {
+                inputLinesArray[i] = inputLinesArray[i].replaceAll(/\s+/g, " ")
+            }
+
+            for (let i = 0; i < inputLinesArray.length; ++i) {
                 this.addNewEntry(
                     $insertedIndex + i + 1,
                     false,


### PR DESCRIPTION
Fixes #713 

Now, when multiple whitespace characters appear when pasting recipe ingredients, instructions, etc. they are replace by a single space.

![image](https://user-images.githubusercontent.com/8503756/159152438-71498459-064f-427c-9e08-6f5d21b7de3f.png)
