### PR TITLE
Enhance the unit test script a bit

### DIFF
--- a/.github/actions/run-tests/run-locally.sh
+++ b/.github/actions/run-tests/run-locally.sh
@@ -25,6 +25,7 @@ Possible options:
   --run-unit-tests                  Run only the unit tests
   --run-integration-tests           Run only the integration tests
   --extract-code-coverage           Output the code coverage reports into the folder volumes/coverage/.
+  --keep-code-coverage				Normally, the last code coverage is removed to avoid filling up the disk. This flag keeps the old one.
   --install-composer-deps           Install composer dependencies
   --build-npm                       Install and build js packages
   -q / --quick                      Test in quick mode. This will not update the permissions on successive (local) test runs.
@@ -389,6 +390,12 @@ copy_environment() {
 	cp -a "volumes/dumps/$COPY_ENV_SRC" "volumes/dumps/$COPY_ENV_DST"
 }
 
+rotate_code_coverage() {
+	if [ $EXTRACT_CODE_COVERAGE = 'y' -a $KEEP_CODE_COVERAGE = 'n' ]; then
+		rm -rf "$(readlink -f volumes/coverage/latest)"
+	fi
+}
+
 run_tests() {
 	
 	PARAMS=''
@@ -472,6 +479,7 @@ RUN_CODE_CHECKER=n
 RUN_UNIT_TESTS=n
 RUN_INTEGRATION_TESTS=n
 EXTRACT_CODE_COVERAGE=n
+KEEP_CODE_COVERAGE=n
 INSTALL_COMPOSER_DEPS=n
 BUILD_NPM=n
 QUICK_MODE=n
@@ -585,6 +593,9 @@ do
 			;;
 		--extract-code-coverage)
 			EXTRACT_CODE_COVERAGE=y
+			;;
+		--keep-code-coverage)
+			KEEP_CODE_COVERAGE=y
 			;;
 		--install-composer-deps)
 			INSTALL_COMPOSER_DEPS=y
@@ -876,6 +887,8 @@ fi
 
 printCI "::endgroup::"
 toc
+
+rotate_code_coverage
 
 tic
 if [ $RUN_UNIT_TESTS = 'y' -o $RUN_INTEGRATION_TESTS = 'y' ]; then

--- a/.github/actions/run-tests/tests/entrypoints/test.sh
+++ b/.github/actions/run-tests/tests/entrypoints/test.sh
@@ -116,15 +116,17 @@ pushd custom_apps/cookbook > /dev/null
 
 make appinfo/info.xml
 
+FAILED=0
+
 if [ $RUN_UNIT_TESTS = 'y' ]; then
 	echo 'Starting unit testing.'
-	/phpunit -c phpunit.xml $PARAM_COVERAGE_UNIT "$@"
+	/phpunit -c phpunit.xml $PARAM_COVERAGE_UNIT "$@" || { FAILED=$?; true; }
 	echo 'Unit testing done.'
 fi
 
 if [ $RUN_INTEGRATION_TESTS = 'y' ]; then
 	echo 'Starting integration testing.'
-	/phpunit -c phpunit.integration.xml $PARAM_COVERAGE_INTEGRATION "$@"
+	/phpunit -c phpunit.integration.xml $PARAM_COVERAGE_INTEGRATION "$@" || { FAILED=$?; true; }
 	echo 'Integration testing done.'
 fi
 
@@ -150,3 +152,8 @@ if [ $CREATE_COVERAGE_REPORT = 'y' ]; then
 fi
 
 printCI "::endgroup::"
+
+if [ $FAILED != 0 ]; then
+	echo "Failing as testing failed"
+	exit $FAILED
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   [#926](https://github.com/nextcloud/cookbook/pull/926) @christianlupus
 - Allow unit test to run against webserver with PHP support
   [#927](https://github.com/nextcloud/cookbook/pull/927) @christianlupus
+- Enhance the unit test script for more user convinience
+  [#931](https://github.com/nextcloud/cookbook/pull/931) @christianlupus
 
 ### Documentation
 - Introduction about how to start coding


### PR DESCRIPTION
This will clean up existing code coverage reports upon creating a new one (only the very last is removed to allow iterative testing/work). Additionally, also for failing tests the code coverage is stored accordingly instead of cluttering the file system.