### PR TITLE
Add editor configuration to codebase

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Xdebug on 9000 for PHPUnit",
+            "type": "php",
+            "request": "launch",
+            "port": 9000,
+            "pathMappings": {
+                "/nextcloud/custom_apps/cookbook": "${workspaceFolder:cookbook}"
+            }
+        },
+        {
+            "name": "Xdebug on 9000 for Live-Test",
+            "type": "php",
+            "request": "launch",
+            "port": 9000,
+            "pathMappings": {
+                "/var/www/html/custom_apps/cookbook": "${workspaceFolder:cookbook}",
+                "/var/www/html": "${workspaceFolder:base}"
+            }
+        },
+        {
+            "name": "Xdebug on 9003 for PHPUnit",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/nextcloud/custom_apps/cookbook": "${workspaceFolder:cookbook}"
+            }
+        },
+        {
+            "name": "Xdebug on 9003 for Live-Test",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/var/www/html/custom_apps/cookbook": "${workspaceFolder:cookbook}",
+                "/var/www/html": "${workspaceFolder:base}"
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+    "css.validate": false,
+    "less.validate": false,
+    "scss.validate": false,
+    "intelephense.environment.includePaths": [
+        "../../base/lib",
+    ],
+    "intelephense.files.exclude": [
+        "**/.git/**",
+        "**/.svn/**",
+        "**/.hg/**",
+        "**/CVS/**",
+        "**/.DS_Store/**",
+        "**/node_modules/**",
+        "**/bower_components/**",
+        "**/vendor/**/{Tests,tests}/**",
+        "**/.history/**",
+        "**/vendor/**/vendor/**",
+        ".github/actions/run-tests/volumes/nextcloud/custom_apps/cookbook/**",
+        ".github/actions/run-tests/volumes/nextcloud/3rdparty/**",
+        ".github/actions/run-tests/volumes/**",
+        ".github/actions/run-tests/volumes"
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+- Add IDE configuration to codebase to prevent small issues
+  [#978](https://github.com/nextcloud/cookbook/pull/978) @christianlupus
+
 ### Fixed
 - Refactor the code for image handling to make it testable
   [#933](https://github.com/nextcloud/cookbook/pull/933) @christianlupus

--- a/cookbook.code-workspace
+++ b/cookbook.code-workspace
@@ -1,0 +1,49 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../../base"
+		},
+		{
+			"path": "tests/phpunit/vendor",
+			"name": "phpunit-composer"
+		}
+	],
+	"settings": {
+		"editor.insertSpaces": false,
+		"files.exclude": {
+			".github/actions/run-tests/volumes/cookbook/**/*": true,
+			".github/actions/run-tests/volumes/coverage/**/*": true,
+			".github/actions/run-tests/volumes/data/**/*": true,
+			".github/actions/run-tests/volumes/dumps/**/*": true,
+			".github/actions/run-tests/volumes/mysql/**/*": true,
+			".github/actions/run-tests/volumes/output/**/*": true,
+			".github/actions/run-tests/volumes/postgres/**/*": true,
+			".github/actions/run-tests/volumes/nextcloud/custom_apps/cookbook/**/*": true,
+			".github/actions/run-tests/volumes/**/*": true
+		},
+		"files.watcherExclude": {
+			".github/actions/run-tests/volumes/nextcloud/custom_apps/cookbook/**/*": true,
+			".github/actions/run-tests/volumes/nextcloud/**/*": true
+		},
+		"intelephense.trace.server": "message",
+		"intelephense.files.exclude": [
+			"**/.git/**",
+			"**/.svn/**",
+			"**/.hg/**",
+			"**/CVS/**",
+			"**/.DS_Store/**",
+			"**/node_modules/**",
+			"**/bower_components/**",
+			"**/vendor/**/{Tests,tests}/**",
+			"**/.history/**",
+			"**/vendor/**/vendor/**",
+			"3rdparty/**"
+		],
+		"cSpell.words": [
+			"Nextcloud"
+		]
+	}
+}


### PR DESCRIPTION
This adds a default configuration to the codebase that allows to set up a complete development environment. A side effect is that the stash push/pop in the hool will not cause trouble with the IDE.

For now, the IDE is VS code. Other IDEs might be added if need arises.