### PR TITLE
Allow the client to specify the image type using Accept header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Added
 - Add IDE configuration to codebase to prevent small issues
   [#978](https://github.com/nextcloud/cookbook/pull/978) @christianlupus
+- Allow client to specify accepted image types
+  [#982](https://github.com/nextcloud/cookbook/pull/982) @christianlupus
 
 ### Fixed
 - Refactor the code for image handling to make it testable

--- a/docs/dev/api/0.0.2/index.html
+++ b/docs/dev/api/0.0.2/index.html
@@ -39,7 +39,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "https://nextcloud.github.io/cookbook/dev/api/0.0.2/openapi-cookbook.yaml",
+        url: "openapi-cookbook.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/docs/dev/api/0.0.3/index.html
+++ b/docs/dev/api/0.0.3/index.html
@@ -39,7 +39,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "https://nextcloud.github.io/cookbook/dev/api/0.0.3/openapi-cookbook.yaml",
+        url: "openapi-cookbook.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/docs/dev/api/0.0.3/openapi-cookbook.yaml
+++ b/docs/dev/api/0.0.3/openapi-cookbook.yaml
@@ -297,7 +297,18 @@ paths:
             type: integer
       responses:
         200:
-          description: Image was obtained and will be inresponse either as image/jpeg or image/svg+xml
+          description: Image was obtained and will be in response either as image/jpeg or image/svg+xml
+          content:
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/svg+xml:
+              schema:
+                type: string
+                format: binary
+        406:
+          description: The recipe has no image whose MIME type matches the Accept header
   /api/search/{query}:
     parameters:
       - in: path

--- a/lib/Controller/RecipeController.php
+++ b/lib/Controller/RecipeController.php
@@ -214,7 +214,7 @@ class RecipeController extends Controller {
 			if (array_search('svg', $acceptedExtensions, true) === false) {
 				// We may not serve a SVG image. Tell the client about the missing image.
 				$json = [
-					'msg' => $this->l->t('No image with the matching mime type was fount on the server.'),
+					'msg' => $this->l->t('No image with the matching mime type was found on the server.'),
 				];
 				return new JSONResponse($json, Http::STATUS_NOT_ACCEPTABLE);
 			} else {

--- a/lib/Helper/AcceptHeaderParsingHelper.php
+++ b/lib/Helper/AcceptHeaderParsingHelper.php
@@ -3,9 +3,9 @@
 namespace OCA\Cookbook\Helper;
 
 /**
- * This class parses the Accepts header from a HTTP request and returns an array of accepted file extensions.
+ * This class parses the Accepts header of an HTTP request and returns an array of accepted file extensions.
  *
- * The return values is a list of extensions that the client is willing to accept.
+ * The return value is a list of extensions that the client is willing to accept.
  * Higher priorities are sorted first in the array.
  */
 class AcceptHeaderParsingHelper {

--- a/lib/Helper/AcceptHeaderParsingHelper.php
+++ b/lib/Helper/AcceptHeaderParsingHelper.php
@@ -72,14 +72,6 @@ class AcceptHeaderParsingHelper {
 		return $weightedParts;
 	}
 
-	private function addWeightedPart($weight, $part, &$weightedParts): void {
-		if (! array_key_exists($weight, $weightedParts)) {
-			$weightedParts[$weight] = [];
-		}
-
-		array_push($weightedParts[$weight], $part);
-	}
-
 	private function parsePart($part): array {
 		if (preg_match('/\s*(.+?)\s*;q=([0-9.]+)\s*$/', $part, $matches) === 0) {
 			// No qualifier was found

--- a/lib/Helper/AcceptHeaderParsingHelper.php
+++ b/lib/Helper/AcceptHeaderParsingHelper.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace OCA\Cookbook\Helper;
+
+/**
+ * This class parses the Accepts header from a HTTP request and returns an array of accepted file extensions.
+ *
+ * The return values is a list of extensions that the client is willing to accept.
+ * Higher priorities are sorted first in the array.
+ */
+class AcceptHeaderParsingHelper {
+
+	/**
+	 * Parse the content of a header and generate the list of valid file extensions the client will accept.
+	 *
+	 * The entries in the return value will be sorted according to the priority given by the sender.
+	 * Higher priority entries are sorted first.
+	 *
+	 * @param string $header The value of the Accept header to be parsed
+	 * @return array The sorted list of file extensions that are valid
+	 */
+	public function parseHeader(string $header): array {
+		$parts = explode(',', $header);
+		$parts = array_map(function ($x) {
+			return trim($x);
+		}, $parts);
+
+		// $this->sortParts($parts);
+		$weightedParts = $this->sortAndWeightParts($parts);
+
+		$extensions = [];
+
+		foreach ($weightedParts as $wp) {
+			$ex = $this->getFileTypes($wp['type']);
+
+			foreach ($ex as $e) {
+				if (array_search($e, $extensions) === false) {
+					$extensions[] = $e;
+				}
+			}
+		}
+		return $extensions;
+	}
+
+	/**
+	 * Return the list of all supported file extensions by the app.
+	 * The return value in the same format as with the parseHeader function
+	 *
+	 * @return array The list of supported file extensions by the app
+	 */
+	public function getDefaultExtensions(): array {
+		return ['jpg'];
+	}
+
+	private function sortAndWeightParts(array $parts): array {
+		$weightedParts = array_map(function ($x) {
+			return $this->parsePart($x);
+		}, $parts);
+
+		usort($weightedParts, function ($a, $b) {
+			$tmp = $a['weight'] - $b['weight'];
+			if ($tmp < - 0.001) {
+				return -1;
+			} elseif ($tmp > 0.001) {
+				return 1;
+			} else {
+				return 0;
+			}
+		});
+		$weightedParts = array_reverse($weightedParts);
+
+		return $weightedParts;
+	}
+
+	private function addWeightedPart($weight, $part, &$weightedParts): void {
+		if (! array_key_exists($weight, $weightedParts)) {
+			$weightedParts[$weight] = [];
+		}
+
+		array_push($weightedParts[$weight], $part);
+	}
+
+	private function parsePart($part): array {
+		if (preg_match('/\s*(.+?)\s*;q=([0-9.]+)\s*$/', $part, $matches) === 0) {
+			// No qualifier was found
+			$mime = trim($part);
+			$weight = 1;
+		} else {
+			// Separate qualifier and part
+			$mime = trim($matches[1]);
+			$weight = $matches[2];
+		}
+
+		return [
+			'type' => $mime,
+			'weight' => $weight,
+		];
+	}
+
+	private function getFileTypes(string $mime): array {
+		$parts = explode(';', $mime, 2);
+		switch ($parts[0]) {
+			case 'image/jpeg':
+			case 'image/jpg':
+				return ['jpg'];
+			case 'image/png':
+				return ['png'];
+			case 'image/svg+xml':
+				return ['svg'];
+			case 'image/*':
+				return ['jpg', 'png', 'svg'];
+			case '*/*':
+				return ['jpg', 'png', 'svg'];
+		}
+		return [];
+	}
+}

--- a/tests/Unit/Helper/AcceptHeaderParsingHelperTest.php
+++ b/tests/Unit/Helper/AcceptHeaderParsingHelperTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace OCA\Cookbook\tests\Unit\Helper;
+
+use OCA\Cookbook\Helper\AcceptHeaderParsingHelper;
+use PHPUnit\Framework\TestCase;
+
+class AcceptHeaderParsingHelperTest extends TestCase {
+
+	/**
+	 * @var AcceptHeaderParsingHelper
+	 */
+	private $dut;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->dut = new AcceptHeaderParsingHelper();
+	}
+
+	public function testDefaultExtensions() {
+		$ret = $this->dut->getDefaultExtensions();
+
+		$this->assertEquals(['jpg'], $ret);
+	}
+
+	public function dataProvider() {
+		yield ['image/jpeg', ['jpg']];
+		yield ['image/jpg', ['jpg']];
+		yield ['image/png', ['png']];
+		yield ['image/svg+xml', ['svg']];
+		yield ['image/*', ['jpg', 'png', 'svg']];
+		yield ['*/*', ['jpg', 'png', 'svg']];
+		yield ['image/jpeg, image/*', ['jpg', 'png', 'svg']];
+		yield ['image/jpeg;q=0.9, image/*;q=0.5', ['jpg', 'png', 'svg']];
+		yield ['image/webn, image/jpeg', ['jpg']];
+		yield ['image/webn', []];
+		yield ['image/png;q=0.5, image/jpg', ['jpg', 'png']];
+		yield ['image/png;q=0.5, image/jpeg;q=0.3, image/svg+xml', ['svg', 'png', 'jpg']];
+		yield ['image/png, image/jpeg;q=0.3, image/svg+xml;q=0.9', ['png', 'svg', 'jpg']];
+	}
+
+	/**
+	 * @dataProvider dataProvider
+	 */
+	public function testParseHeader($header, $expected) {
+		$this->assertEquals($expected, $this->dut->parseHeader($header));
+	}
+}


### PR DESCRIPTION
Closes #954

This is a quick fix for issue #954. This checks the accept header and returns a 406 HTTP error in case no JPG file was found on the server,

This is not yet capable to support other image files (like PNG) but this is the first step toward multi-type image files. The multi-type must be implemented separately as it is a more involved change/refactor involved.