### PR TITLE
Fix bug that thumbnail file needs to be created if not yet existing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   [#965](https://github.com/nextcloud/cookbook/pull/965) @christianlupus
 - Mark cookbook app as compatible with NC24
   [#977](https://github.com/nextcloud/cookbook/pull/977) @christianlupus
+- Fix bug that prevent generation of thumbnails when no previous thumbnails are present
+  [#985](https://github.com/nextcloud/cookbook/pull/985) @christianlupus
 
 ### Documentation
 - Corrected some spelling issues

--- a/lib/Helper/ImageService/ThumbnailFileHelper.php
+++ b/lib/Helper/ImageService/ThumbnailFileHelper.php
@@ -89,7 +89,11 @@ class ThumbnailFileHelper {
 		
 		if ($this->fileHelper->hasImage($recipeFolder)) {
 			$full = $this->fileHelper->getImage($recipeFolder);
-			$file = $recipeFolder->get($filename);
+			if ($recipeFolder->nodeExists($filename)) {
+				$file = $recipeFolder->get($filename);
+			} else {
+				$file = $recipeFolder->newFile($filename);
+			}
 
 			$this->generationHelper->generateThumbnail($full, $type, $file);
 		} else {

--- a/tests/Unit/Helper/ImageService/ThumbnailFileHelperTest.php
+++ b/tests/Unit/Helper/ImageService/ThumbnailFileHelperTest.php
@@ -198,11 +198,18 @@ class ThumbnailFileHelperTest extends TestCase {
 		];
 		$f->method('get')->willReturnMap($fileMap);
 		
+		$cnt = 0;
+		if (! $thumbExists) {
+			$cnt ++;
+		}
+		if (! $miniExists) {
+			$cnt ++;
+		}
 		$newFileMap = [
 			['thumb.jpg', null, $thumb],
 			['thumb16.jpg', null, $mini],
 		];
-		$f->method('newFile')->willReturnMap($newFileMap);
+		$f->expects($this->exactly($cnt))->method('newFile')->willReturnMap($newFileMap);
 
 		$full = $this->createStub(File::class);
 		$this->fileHelper->method('hasImage')->willReturn(true);


### PR DESCRIPTION
Adding an image to a recipe without image causes the thumbnail generator to throw an exception.