### PR TITLE
Fix refresh-icon overlays name of recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Correct singular/plural translations
   [#1026](https://github.com/nextcloud/cookbook/pull/1026) @christianlupus
 - Update eslint-plugin-vue
+- Fix refresh-icon overlays name of recipe
+  [#1033](https://github.com/nextcloud/cookbook/pull/1033) @MarcelRobitaille
 
 ### Codebase maintenance
 - Removed codecov.io upload of intermediate merge commits during pull requests [#1028](https://github.com/nextcloud/cookbook/issues/1028)

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -63,6 +63,13 @@
                 :disable-drop="true"
             >
             </Breadcrumb>
+            <Breadcrumb
+                v-if="isLoading || isLoadingRecipe"
+                class="active"
+                :title="t('cookbook', 'Loading…')"
+                :disable-drop="true"
+            >
+            </Breadcrumb>
             <!-- Create new recipe -->
             <Breadcrumb
                 v-else-if="isCreate"
@@ -184,24 +191,24 @@
             <Breadcrumb
                 v-if="isLoading"
                 class="active no-arrow"
-                :title="t('cookbook', 'App is loading')"
+                title=""
                 :disable-drop="true"
             >
                 <ActionButton
                     icon="icon-loading-small"
-                    :aria-label="t('cookbook', 'Loading…')"
+                    :aria-label="t('cookbook', 'Loading app')"
                 />
             </Breadcrumb>
             <!-- Is a recipe loading? -->
             <Breadcrumb
                 v-else-if="isLoadingRecipe"
                 class="active no-arrow"
-                :title="t('cookbook', 'Loading recipe')"
+                title=""
                 :disable-drop="true"
             >
                 <ActionButton
                     icon="icon-loading-small"
-                    :aria-label="t('cookbook', 'Loading…')"
+                    :aria-label="t('cookbook', 'Loading recipe')"
                 />
             </Breadcrumb>
             <!-- No recipe found -->

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -62,18 +62,6 @@
                 :title="$store.state.recipe.name"
                 :disable-drop="true"
             >
-                <ActionButton
-                    :icon="
-                        $store.state.reloadingRecipe ===
-                        parseInt($route.params.id)
-                            ? 'icon-loading-small'
-                            : 'icon-history'
-                    "
-                    class="action-button"
-                    :aria-label="t('cookbook', 'Reload recipe')"
-                    @click="reloadRecipeEdit()"
-                    >{{ t("cookbook", "Reload recipe") }}</ActionButton
-                >
             </Breadcrumb>
             <!-- Create new recipe -->
             <Breadcrumb
@@ -107,18 +95,6 @@
                 :title="$store.state.recipe.name"
                 :disable-drop="true"
             >
-                <ActionButton
-                    :icon="
-                        $store.state.reloadingRecipe ===
-                        parseInt($route.params.id)
-                            ? 'icon-loading-small'
-                            : 'icon-history'
-                    "
-                    class="action-button"
-                    :aria-label="t('cookbook', 'Reload recipe')"
-                    @click="reloadRecipeView()"
-                    >{{ t("cookbook", "Reload recipe") }}</ActionButton
-                >
             </Breadcrumb>
             <Breadcrumb
                 v-if="isRecipe"
@@ -136,6 +112,44 @@
                         )
                     "
                     >{{ t("cookbook", "Edit recipe") }}</ActionButton
+                >
+            </Breadcrumb>
+            <Breadcrumb
+                v-if="isEdit"
+                class="no-arrow"
+                title=""
+                :disable-drop="true"
+            >
+                <ActionButton
+                    :icon="
+                        $store.state.reloadingRecipe ===
+                        parseInt($route.params.id)
+                            ? 'icon-loading-small'
+                            : 'icon-history'
+                    "
+                    class="action-button"
+                    :aria-label="t('cookbook', 'Reload recipe')"
+                    @click="reloadRecipeEdit()"
+                    >{{ t("cookbook", "Reload recipe") }}</ActionButton
+                >
+            </Breadcrumb>
+            <Breadcrumb
+                v-if="isRecipe"
+                class="no-arrow"
+                title=""
+                :disable-drop="true"
+            >
+                <ActionButton
+                    :icon="
+                        $store.state.reloadingRecipe ===
+                        parseInt($route.params.id)
+                            ? 'icon-loading-small'
+                            : 'icon-history'
+                    "
+                    class="action-button"
+                    :aria-label="t('cookbook', 'Reload recipe')"
+                    @click="reloadRecipeView()"
+                    >{{ t("cookbook", "Reload recipe") }}</ActionButton
                 >
             </Breadcrumb>
             <Breadcrumb


### PR DESCRIPTION
Fix #987 

Move the reload button out of the title button and into its own breadcrumb. This is a temporary solution. The permanent solution is to use some component other than breadcrumb, which is not designed for this.