### PR TITLE
Pass the url to the parsers of the recipes to allow for domain-specific parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
   [#1050](https://github.com/nextcloud/cookbook/pull/1050) @christianlupus
 - Migrated node-sass to dart sass
   [#1051](https://github.com/nextcloud/cookbook/pull/1051) @christianlupus
+- Add the url as a parameter to allow for specialized parsers per website in the backend
+  [#1060](https://github.com/nextcloud/cookbook/pull/1060) @christianlupus
 
 ### Codebase maintenance
 - Removed codecov.io upload of intermediate merge commits during pull requests

--- a/lib/Helper/HTMLParser/AbstractHtmlParser.php
+++ b/lib/Helper/HTMLParser/AbstractHtmlParser.php
@@ -19,8 +19,9 @@ abstract class AbstractHtmlParser {
 	 * Extract the recipe from the given document.
 	 *
 	 * @param \DOMDocument $document The document to parse
+	 * @param ?string $url The URL of the recipe to import
 	 * @return array The JSON content in the document as a PHP array
 	 * @throws HtmlParsingException If the parsing was not successful
 	 */
-	abstract public function parse(\DOMDocument $document): array;
+	abstract public function parse(\DOMDocument $document, ?string $url): array;
 }

--- a/lib/Helper/HTMLParser/HttpJsonLdParser.php
+++ b/lib/Helper/HTMLParser/HttpJsonLdParser.php
@@ -22,7 +22,7 @@ class HttpJsonLdParser extends AbstractHtmlParser {
 		$this->jsonService = $jsonService;
 	}
 
-	public function parse(\DOMDocument $document): array {
+	public function parse(\DOMDocument $document, ?string $url): array {
 		$xpath = new \DOMXPath($document);
 
 		$json_ld_elements = $xpath->query("//*[@type='application/ld+json']");

--- a/lib/Helper/HTMLParser/HttpMicrodataParser.php
+++ b/lib/Helper/HTMLParser/HttpMicrodataParser.php
@@ -31,7 +31,7 @@ class HttpMicrodataParser extends AbstractHtmlParser {
 		parent::__construct($l10n);
 	}
 
-	public function parse(DOMDocument $document): array {
+	public function parse(DOMDocument $document, ?string $url): array {
 		$this->xpath = new DOMXPath($document);
 
 		$selectorHttp = "//*[@itemtype='http://schema.org/Recipe']";

--- a/lib/Service/RecipeExtractionService.php
+++ b/lib/Service/RecipeExtractionService.php
@@ -29,14 +29,15 @@ class RecipeExtractionService {
 	 * Parse a DOM document using all registered parsers
 	 *
 	 * @param \DOMDocument $document The document to parse
+	 * @param ?string $url The URL of the recipe to be parsed
 	 * @throws HtmlParsingException If no parser was able to successfully parse the document
 	 * @return array The data as returned from the parser
 	 */
-	public function parse(\DOMDocument $document): array {
+	public function parse(\DOMDocument $document, ?string $url): array {
 		/** @var $parser AbstractHtmlParser */
 		foreach ($this->parsers as $parser) {
 			try {
-				return $parser->parse($document);
+				return $parser->parse($document, $url);
 			} catch (HtmlParsingException $ex) {
 				// Silently ignore failure as there might be other parsers better suited
 			}

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -834,7 +834,7 @@ class RecipeService {
 		$this->htmlDownloadService->downloadRecipe($url);
 
 		try {
-			$json = $this->recipeExtractionService->parse($this->htmlDownloadService->getDom());
+			$json = $this->recipeExtractionService->parse($this->htmlDownloadService->getDom(), $url);
 		} catch (HtmlParsingException $ex) {
 			throw new ImportException($ex->getMessage(), null, $ex);
 		}

--- a/tests/Unit/Helper/HTMLParser/HttpJsonLdParserTest.php
+++ b/tests/Unit/Helper/HTMLParser/HttpJsonLdParserTest.php
@@ -74,7 +74,7 @@ class HttpJsonLdParserTest extends TestCase {
 		$document->loadHTML($content);
 
 		try {
-			$res = $parser->parse($document);
+			$res = $parser->parse($document, 'http://example.com');
 
 			$jsonDest = file_get_contents(__DIR__ . "/res_JsonLd/$jsonFile");
 			$expected = json_decode($jsonDest, true);

--- a/tests/Unit/Helper/HTMLParser/HttpMicrodataParserTest.php
+++ b/tests/Unit/Helper/HTMLParser/HttpMicrodataParserTest.php
@@ -59,7 +59,7 @@ class HttpMicrodataParserTest extends TestCase {
 		$document->loadHTML($content);
 
 		try {
-			$res = $parser->parse($document);
+			$res = $parser->parse($document, 'http://example.com');
 
 			$jsonDest = file_get_contents(__DIR__ . "/res_Microdata/$jsonFile");
 			$expected = json_decode($jsonDest, true);
@@ -145,7 +145,7 @@ class HttpMicrodataParserTest extends TestCase {
 		$document->loadHTML($content);
 
 		try {
-			$res = $parser->parse($document);
+			$res = $parser->parse($document, 'http://exmapl.com');
 
 			$jsonDest = file_get_contents(__DIR__ . "/res_Microdata/$jsonFile");
 			$expected = json_decode($jsonDest, true);


### PR DESCRIPTION
Closes #217 

This is the last part to finish the structure in order to make domain-antagonistic parsers possible.