### PR TITLE
Rename the app from nextcloud-cookbook to cookbook

### DIFF
--- a/lib/Controller/MainController.php
+++ b/lib/Controller/MainController.php
@@ -75,7 +75,7 @@ class MainController extends Controller {
 			// Check if the user folder can be accessed
 			$this->userFolder->getFolder();
 		} catch (UserFolderNotWritableException $ex) {
-			Util::addScript('cookbook', 'nextcloud-cookbook-guest');
+			Util::addScript('cookbook', 'cookbook-guest');
 			return new TemplateResponse($this->appName, 'invalid_guest');
 		}
 		/*
@@ -86,7 +86,7 @@ class MainController extends Controller {
 
 		$this->dbCacheService->triggerCheck();
 
-		Util::addScript('cookbook', 'nextcloud-cookbook-main');
+		Util::addScript('cookbook', 'cookbook-main');
 		return new TemplateResponse($this->appName, 'index');  // templates/index.php
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nextcloud-cookbook",
+  "name": "cookbook",
   "version": "0.9.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextcloud-cookbook",
+      "name": "cookbook",
       "version": "0.9.13",
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextcloud-cookbook",
+  "name": "cookbook",
   "version": "0.9.13",
   "description": "",
   "license": "AGPL-3.0-or-later",

--- a/src/guest.js
+++ b/src/guest.js
@@ -16,8 +16,7 @@ import AppInvalidGuest from "./components/AppInvalidGuest.vue"
 // eslint-disable-next-line camelcase,no-undef
 if (__webpack_use_dev_server__ || false) {
     // eslint-disable-next-line camelcase,no-undef
-    __webpack_public_path__ =
-        "http://127.0.0.1:3000/apps/nextcloud-cookbook/js/"
+    __webpack_public_path__ = "http://127.0.0.1:3000/apps/cookbook/js/"
 }
 
 // eslint-disable-next-line func-names, import/newline-after-import

--- a/src/main.js
+++ b/src/main.js
@@ -22,8 +22,7 @@ import AppMain from "./components/AppMain.vue"
 // eslint-disable-next-line camelcase,no-undef
 if (__webpack_use_dev_server__ || false) {
     // eslint-disable-next-line camelcase,no-undef
-    __webpack_public_path__ =
-        "http://127.0.0.1:3000/apps/nextcloud-cookbook/js/"
+    __webpack_public_path__ = "http://127.0.0.1:3000/apps/cookbook/js/"
 }
 
 // eslint-disable-next-line func-names, import/newline-after-import


### PR DESCRIPTION
The old name causes problems when using the webpack `file-loader`. The
URL from this would start `/apps/nextcloud-cookbook` although the proper
install location and the proper URL to load the file is
`/apps/cookbook`.
Besides this `file-loader` issue, this change makes everything more
consistent and more conformal to best practices.

I am assuming that URLs like the GitHub repository and matrix should remain the same.