### PR TITLE
Fix keyword ordering buttons clipped by top bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Fixed
 - Prevent slow loading of recipes due to iteration over all files
   [#1072](https://github.com/nextcloud/cookbook/pull/1072) @christianlupus
+- Fix keyword ordering buttons being clipped by top bar
+  [#1103](https://github.com/nextcloud/cookbook/pull/1103) @MarcelRobitaille
 
 ### Maintenance
 - Add composer.json to version control to have unique installed dependency versions

--- a/src/components/RecipeListKeywordCloud.vue
+++ b/src/components/RecipeListKeywordCloud.vue
@@ -39,15 +39,19 @@
                 />
             </transition-group>
         </div>
-        <div class="settings-buttons">
+        <div
+            v-if="uniqKeywords.length > 0"
+            class="settings-buttons"
+        >
             <button
-                class="ordering-button"
+                class="settings-button ordering-button"
                 :title="orderButtonTitle"
                 @click="toggleOrderCriterium"
             >
                 {{ orderButtonText }}
             </button>
             <button
+                class="settings-button"
                 :class="toggleSizeIcon"
                 :title="t('cookbook', 'Toggle keyword area size')"
                 @click="toggleCloudSize"
@@ -222,6 +226,7 @@ export default {
 <style lang="scss" scoped>
 .kw-container {
     position: relative;
+    display: flex;
 }
 
 .kw {
@@ -249,11 +254,11 @@ export default {
 }
 
 .settings-buttons {
-    position: absolute;
-    right: 10px;
-    bottom: -8px;
+    display: flex;
+    align-items: flex-start;
+    padding: 0.5rem;
 
-    button {
+    .settings-button {
         min-height: 8px;
         font-size: 8px;
         vertical-align: bottom;

--- a/src/components/RecipeListKeywordCloud.vue
+++ b/src/components/RecipeListKeywordCloud.vue
@@ -39,10 +39,7 @@
                 />
             </transition-group>
         </div>
-        <div
-            v-if="uniqKeywords.length > 0"
-            class="settings-buttons"
-        >
+        <div v-if="uniqKeywords.length > 0" class="settings-buttons">
             <button
                 class="settings-button ordering-button"
                 :title="orderButtonTitle"


### PR DESCRIPTION
Fixes #1100 

If there are no keywords, I just don't show the ordering buttons. I also updated the styles using flexbox to layout the buttons a bit better (IMO). Before, the buttons were slightly under the keywords. Now, they are top-aligned.

Before:

![image](https://user-images.githubusercontent.com/8503756/180596652-04b49d62-14e3-4ab4-91c3-9d6891a53692.png)


After:
![image](https://user-images.githubusercontent.com/8503756/180596633-21d40c6c-c6a2-4c77-8819-9da9f4043a5c.png)
