### PR TITLE
Remove Breadcrumbs component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   [#1106](https://github.com/nextcloud/cookbook/pull/1106) @christianlupus
 - Make recipeYield optional
   [#1108](https://github.com/nextcloud/cookbook/pull/1108) @christianlupus
+- Fix UI glitches caused by improper use of Breadcrumbs component
+  [#1105](https://github.com/nextcloud/cookbook/pull/1105) @MarcelRobitaille
 
 ### Maintenance
 - Add composer.json to version control to have unique installed dependency versions

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -322,7 +322,8 @@ export default {
     /* Make sure the wrapper is always at least as tall as the tallest element
      * we expect (primary button) to prevent flickering when loading, etc. */
     /* 44px is the height of nextcloud/vue button (not exposed as a variable :[ ) */
-    min-height: 44px;
+    /* 16px from 8px top/bottom padding */
+    min-height: 60px;
     flex-direction: row;
 
     padding: 8px 1rem;

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -14,23 +14,6 @@
                 :title="t('cookbook', 'All recipes')"
                 :disable-drop="true"
             />
-            <Breadcrumb
-                v-if="isIndex"
-                class="no-arrow"
-                title=""
-                :disable-drop="true"
-            >
-                <!-- This is clumsy design but the component cannot display just one input element on the breadcrumbs bar -->
-                <ActionInput
-                    icon="icon-quota"
-                    :value="filterValue"
-                    @update:value="updateFilters"
-                    >{{ t("cookbook", "Filter") }}</ActionInput
-                >
-                <ActionInput icon="icon-search" @submit="search">{{
-                    t("cookbook", "Search")
-                }}</ActionInput>
-            </Breadcrumb>
             <!-- SEARCH PAGE -->
             <Breadcrumb
                 v-if="isSearch"
@@ -77,24 +60,6 @@
                 :title="t('cookbook', 'New recipe')"
                 :disable-drop="true"
             />
-            <Breadcrumb
-                v-if="isEdit || isCreate"
-                class="no-arrow"
-                title=""
-                :disable-drop="true"
-            >
-                <ActionButton
-                    :icon="
-                        $store.state.savingRecipe
-                            ? 'icon-loading-small'
-                            : 'icon-checkmark'
-                    "
-                    class="action-button"
-                    :aria-label="t('cookbook', 'Save changes')"
-                    @click="saveChanges()"
-                    >{{ t("cookbook", "Save changes") }}</ActionButton
-                >
-            </Breadcrumb>
             <!-- View recipe -->
             <Breadcrumb
                 v-if="isRecipe"
@@ -102,87 +67,6 @@
                 :title="$store.state.recipe.name"
                 :disable-drop="true"
             >
-            </Breadcrumb>
-            <Breadcrumb
-                v-if="isRecipe"
-                class="no-arrow"
-                title=""
-                :disable-drop="true"
-            >
-                <ActionButton
-                    icon="icon-rename"
-                    class="action-button"
-                    :aria-label="t('cookbook', 'Edit recipe')"
-                    @click="goToRecipe($store.state.recipe.id)"
-                    >{{ t("cookbook", "Edit recipe") }}</ActionButton
-                >
-            </Breadcrumb>
-            <Breadcrumb
-                v-if="isEdit"
-                class="no-arrow"
-                title=""
-                :disable-drop="true"
-            >
-                <ActionButton
-                    :icon="
-                        $store.state.reloadingRecipe ===
-                        parseInt($route.params.id)
-                            ? 'icon-loading-small'
-                            : 'icon-history'
-                    "
-                    class="action-button"
-                    :aria-label="t('cookbook', 'Reload recipe')"
-                    @click="reloadRecipeEdit()"
-                    >{{ t("cookbook", "Reload recipe") }}</ActionButton
-                >
-            </Breadcrumb>
-            <Breadcrumb
-                v-if="isRecipe"
-                class="no-arrow"
-                title=""
-                :disable-drop="true"
-            >
-                <ActionButton
-                    :icon="
-                        $store.state.reloadingRecipe ===
-                        parseInt($route.params.id)
-                            ? 'icon-loading-small'
-                            : 'icon-history'
-                    "
-                    class="action-button"
-                    :aria-label="t('cookbook', 'Reload recipe')"
-                    @click="reloadRecipeView()"
-                    >{{ t("cookbook", "Reload recipe") }}</ActionButton
-                >
-            </Breadcrumb>
-            <Breadcrumb
-                v-if="isRecipe"
-                class="no-arrow"
-                title=""
-                :disable-drop="true"
-            >
-                <ActionButton
-                    class="action-button"
-                    :aria-label="t('cookbook', 'Print recipe')"
-                    @click="printRecipe()"
-                >
-                    <template #icon=""><printer-icon :size="20" /></template>
-                    {{ t("cookbook", "Print recipe") }}
-                </ActionButton>
-            </Breadcrumb>
-            <Breadcrumb
-                v-if="isRecipe"
-                class="no-arrow"
-                title=""
-                :disable-drop="true"
-            >
-                <ActionButton
-                    icon="icon-delete"
-                    class="action-button"
-                    :aria-label="t('cookbook', 'Delete recipe')"
-                    @click="deleteRecipe()"
-                    >{{ t("cookbook", "Delete recipe") }}</ActionButton
-                >
             </Breadcrumb>
             <!-- Is the app loading? -->
             <Breadcrumb
@@ -223,27 +107,135 @@
                 :disable-drop="true"
             />
         </Breadcrumbs>
+        {{/* Primary buttons */}}
+        <Button
+            v-if="isRecipe"
+            type="primary"
+            :aria-label="t('cookbook', 'Edit recipe')"
+            @click="goToRecipe($store.state.recipe.id)"
+        >
+            <template #icon>
+                <PencilIcon :size="20" />
+            </template>
+            {{ t("cookbook", "Edit recipe") }}
+        </Button>
+        <Button
+            v-if="isEdit || isCreate"
+            type="primary"
+            :aria-label="t('cookbook', 'Save changes')"
+            @click="saveChanges()"
+        >
+            <template #icon>
+                <LoadingIcon
+                    v-if="$store.state.savingRecipe"
+                    :size="20"
+                    class="animation-rotate"
+                />
+                <CheckmarkIcon v-else :size="20" />
+            </template>
+            {{ t("cookbook", "Save changes") }}
+        </Button>
+        <!-- This is clumsy design but the component cannot display just one input element on the breadcrumbs bar -->
+        <Actions
+            v-if="isIndex"
+            default-icon="icon-search-white"
+            :menu-title="t('cookbook', 'Search')"
+            :primary="true"
+        >
+            <ActionInput
+                icon="icon-quota"
+                :value="filterValue"
+                @update:value="updateFilters"
+            >
+                {{ t("cookbook", "Filter") }}
+            </ActionInput>
+            <ActionInput icon="icon-search" @submit="search">
+                {{ t("cookbook", "Search") }}
+            </ActionInput>
+        </Actions>
+        {{/* Overflow buttons (3-dot menu) */}}
+        <Actions
+            v-if="isRecipe || isEdit"
+            :force-menu="true"
+            class="overflow-menu"
+        >
+            <ActionButton
+                v-if="isEdit"
+                :icon="
+                    $store.state.reloadingRecipe === parseInt($route.params.id)
+                        ? 'icon-loading-small'
+                        : 'icon-history'
+                "
+                class="action-button"
+                :aria-label="t('cookbook', 'Reload recipe')"
+                @click="reloadRecipeEdit()"
+            >
+                {{ t("cookbook", "Reload recipe") }}
+            </ActionButton>
+            <ActionButton
+                v-if="isRecipe"
+                :icon="
+                    $store.state.reloadingRecipe === parseInt($route.params.id)
+                        ? 'icon-loading-small'
+                        : 'icon-history'
+                "
+                class="action-button"
+                :aria-label="t('cookbook', 'Reload recipe')"
+                @click="reloadRecipeView()"
+            >
+                {{ t("cookbook", "Reload recipe") }}
+            </ActionButton>
+            <ActionButton
+                v-if="isRecipe"
+                class="action-button"
+                :aria-label="t('cookbook', 'Print recipe')"
+                @click="printRecipe()"
+            >
+                <template #icon=""><printer-icon :size="20" /></template>
+                {{ t("cookbook", "Print recipe") }}
+            </ActionButton>
+            <ActionButton
+                v-if="isRecipe"
+                icon="icon-delete"
+                class="action-button"
+                :aria-label="t('cookbook', 'Delete recipe')"
+                @click="deleteRecipe()"
+            >
+                {{ t("cookbook", "Delete recipe") }}
+            </ActionButton>
+        </Actions>
     </div>
 </template>
 
 <script>
 import helpers from "cookbook/js/helper"
 
+import Actions from "@nextcloud/vue/dist/Components/Actions"
 import ActionButton from "@nextcloud/vue/dist/Components/ActionButton"
+import Button from "@nextcloud/vue/dist/Components/Button"
 import ActionInput from "@nextcloud/vue/dist/Components/ActionInput"
 import Breadcrumbs from "@nextcloud/vue/dist/Components/Breadcrumbs"
 import Breadcrumb from "@nextcloud/vue/dist/Components/Breadcrumb"
 
+import PencilIcon from "icons/Pencil.vue"
+import LoadingIcon from "icons/Loading.vue"
+import CheckmarkIcon from "icons/Check.vue"
 import PrinterIcon from "icons/Printer.vue"
 
 export default {
     name: "AppControls",
     components: {
+        Actions,
         ActionButton,
         ActionInput,
+        // eslint-disable-next-line vue/no-reserved-component-names
+        Button,
         Breadcrumbs,
         Breadcrumb,
         PrinterIcon,
+        PencilIcon,
+        LoadingIcon,
+        CheckmarkIcon,
     },
     data() {
         return {
@@ -381,6 +373,10 @@ export default {
     padding-left: 4px;
     border-bottom: 1px solid var(--color-border);
     background-color: var(--color-main-background);
+
+    padding: 8px;
+    display: flex;
+    flex-direction: row;
 }
 
 .active {
@@ -391,11 +387,22 @@ export default {
 .breadcrumbs {
     width: calc(100% - 60px);
     flex-basis: 100%;
-    margin-left: 40px;
+}
+
+.wrapper .breadcrumbs /deep/ .breadcrumb__crumbs {
+    min-width: unset;
 }
 
 .no-arrow::before {
     content: "" !important;
+}
+
+.overflow-menu {
+    margin-left: 8px;
+}
+
+.animation-rotate {
+    animation: rotate var(--animation-duration, 0.8s) linear infinite;
 }
 
 @media print {

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -2,48 +2,46 @@
     <div class="wrapper">
         <!-- Use $store.state.page for page matching to make sure everything else has been set beforehand! -->
         <div class="status-header">
-            <span v-if="isSearch" class="mode-indicator">{{
-                searchTitle
-            }}</span>
-            <span v-else-if="isEdit" class="mode-indicator"
-                >Editing recipe</span
-            >
-            <span v-else-if="isRecipe" class="mode-indicator"
-                >Viewing recipe</span
-            >
+            <ModeIndicator v-if="isSearch" :title="searchTitle" />
+            <ModeIndicator v-else-if="isEdit" title="Editing recipe" />
+            <ModeIndicator v-else-if="isRecipe" title="Viewing recipe" />
             <!-- INDEX PAGE -->
-            <h2 v-if="isIndex" class="location" :disable-drop="true">
-                {{ t("cookbook", "All recipes") }}
-            </h2>
-            <h2 v-else-if="isSearch && $route.params.value" class="location">
-                {{
-                    $route.params.value === "_"
-                        ? "None"
+            <Location v-if="isIndex" :title="t('cookbook', 'All recipes')" />
+            <Location
+                v-else-if="isSearch && $route.params.value"
+                :title="
+                    $route.params.value === '_'
+                        ? 'None'
                         : decodeURIComponent($route.params.value)
-                }}
-            </h2>
+                "
+            />
             <!-- Recipe view / edit -->
-            <h2 v-else-if="isEdit || isRecipe" class="location">
-                {{ $store.state.recipe.name }}
-            </h2>
+            <Location
+                v-else-if="isEdit || isRecipe"
+                :title="$store.state.recipe.name"
+            />
             <!-- Is app loading? -->
-            <h2 v-else-if="isLoading" class="location">
-                {{ t("cookbook", "Loading app") }}
-            </h2>
+            <Location
+                v-else-if="isLoading"
+                :title="t('cookbook', 'Loading app')"
+            />
             <!-- Is a recipe loading? -->
-            <h2 v-else-if="isLoadingRecipe" class="location">
-                {{ t("cookbook", "Loading recipe") }}
-            </h2>
+            <Location
+                v-else-if="isLoadingRecipe"
+                :title="t('cookbook', 'Loading recipe')"
+            />
             <!-- No recipe found -->
-            <h2 v-else-if="recipeNotFound" class="location">
-                {{ t("cookbook", "Recipe not found") }}
-            </h2>
+            <Location
+                v-else-if="recipeNotFound"
+                :title="t('cookbook', 'Recipe not found')"
+            />
             <!-- No page found -->
-            <h2 v-else-if="pageNotFound" class="location">
-                {{ "t('cookbook', 'Page not found')" }}
-            </h2>
+            <Location
+                v-else-if="pageNotFound"
+                :title="t('cookbook', 'Page not found')"
+            />
             <!-- Create new recipe -->
-            <h2 v-else-if="isCreate" class="location">Creating new recipe</h2>
+            <Location v-else-if="isCreate" title="Creating new recipe" />
         </div>
         {{/* Primary buttons */}}
         <SimpleButton
@@ -159,6 +157,20 @@ import LoadingIcon from "icons/Loading.vue"
 import CheckmarkIcon from "icons/Check.vue"
 import PrinterIcon from "icons/Printer.vue"
 
+const ModeIndicator = {
+    props: ["title"],
+    render(h) {
+        return h("span", { class: "mode-indicator" }, this.title)
+    },
+}
+
+const Location = {
+    props: ["title"],
+    render(h) {
+        return h("h2", { class: "location" }, this.title)
+    },
+}
+
 export default {
     name: "AppControls",
     components: {
@@ -170,6 +182,8 @@ export default {
         PencilIcon,
         LoadingIcon,
         CheckmarkIcon,
+        ModeIndicator,
+        Location,
     },
     data() {
         return {

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -3,8 +3,14 @@
         <!-- Use $store.state.page for page matching to make sure everything else has been set beforehand! -->
         <div class="status-header">
             <ModeIndicator v-if="isSearch" :title="searchTitle" />
-            <ModeIndicator v-else-if="isEdit" title="Editing recipe" />
-            <ModeIndicator v-else-if="isRecipe" title="Viewing recipe" />
+            <ModeIndicator
+                v-else-if="isEdit"
+                :title="t('cookbook', 'Editing recipe')"
+            />
+            <ModeIndicator
+                v-else-if="isRecipe"
+                :title="t('cookbook', 'Viewing recipe')"
+            />
             <!-- INDEX PAGE -->
             <Location v-if="isIndex" :title="t('cookbook', 'All recipes')" />
             <Location
@@ -41,7 +47,10 @@
                 :title="t('cookbook', 'Page not found')"
             />
             <!-- Create new recipe -->
-            <Location v-else-if="isCreate" title="Creating new recipe" />
+            <Location
+                v-else-if="isCreate"
+                :title="t('cookbook', 'Creating new recipe')"
+            />
         </div>
         {{/* Primary buttons */}}
         <SimpleButton

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -311,6 +311,11 @@ export default {
 
 <style scoped>
 .wrapper {
+    /* 44px is the height of nextcloud/vue button (not exposed as a variable :[ ) */
+    --nc-button-size: 44px;
+
+    --vertical-padding: 8px;
+
     /* Sticky is better than fixed because fixed takes the element out of flow,
      which breaks the height, putting elements underneath */
     position: sticky;
@@ -324,12 +329,10 @@ export default {
     width: 100%;
     /* Make sure the wrapper is always at least as tall as the tallest element
      * we expect (primary button) to prevent flickering when loading, etc. */
-    /* 44px is the height of nextcloud/vue button (not exposed as a variable :[ ) */
-    /* 16px from 8px top/bottom padding */
-    min-height: 60px;
+    min-height: calc(44px + 2 * var(--vertical-padding));
     flex-direction: row;
 
-    padding: 8px 1rem;
+    padding: var(--vertical-padding) 1rem var(--vertical-padding) calc(44px + 2 * var(--vertical-padding));
     border-bottom: 1px solid var(--color-border);
     background-color: var(--color-main-background);
     gap: 8px;

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -167,7 +167,10 @@ const ModeIndicator = {
 const Location = {
     props: ["title"],
     render(h) {
-        return h("h2", { class: "location" }, this.title)
+        // Wrapper is to enable vertical centering if only child
+        return h('div', { class: 'location-wrapper' }, [
+            h("h2", { class: "location" }, this.title),
+        ])
     },
 }
 
@@ -341,14 +344,29 @@ export default {
     flex-grow: 1;
     flex-shrink: 1;
     align-items: flex-start;
-    justify-content: center;
+    justify-content: space-around;
 }
 
 .mode-indicator {
     font-size: 0.9em;
+    line-height: 0.9em;
 }
 
-.location {
+.location-wrapper {
+    width: 100%;
+}
+
+.location-wrapper:only-child {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+/* The .status-header is justify-content: space-around. If there is no
+ * .mode-indicator, this will put the .location at the top. Override to place in
+ * the center */
+.status-header /deep/ .location {
     /* Don't let the location go wider than the space available */
     width: 100%;
     margin: 0;

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -168,7 +168,7 @@ const Location = {
     props: ["title"],
     render(h) {
         // Wrapper is to enable vertical centering if only child
-        return h('div', { class: 'location-wrapper' }, [
+        return h("div", { class: "location-wrapper" }, [
             h("h2", { class: "location" }, this.title),
         ])
     },
@@ -332,7 +332,8 @@ export default {
     min-height: calc(44px + 2 * var(--vertical-padding));
     flex-direction: row;
 
-    padding: var(--vertical-padding) 1rem var(--vertical-padding) calc(44px + 2 * var(--vertical-padding));
+    padding: var(--vertical-padding) 1rem var(--vertical-padding)
+        calc(44px + 2 * var(--vertical-padding));
     border-bottom: 1px solid var(--color-border);
     background-color: var(--color-main-background);
     gap: 8px;
@@ -360,8 +361,8 @@ export default {
 }
 
 .location-wrapper:only-child {
-    flex: 1;
     display: flex;
+    flex: 1;
     flex-direction: column;
     justify-content: center;
 }

--- a/src/components/AppControls.vue
+++ b/src/components/AppControls.vue
@@ -1,128 +1,66 @@
 <template>
     <div class="wrapper">
         <!-- Use $store.state.page for page matching to make sure everything else has been set beforehand! -->
-        <Breadcrumbs class="breadcrumbs" root-icon="icon-category-organization">
-            <Breadcrumb
-                :title="t('cookbook', 'Home')"
-                :to="'/'"
-                :disable-drop="true"
-            />
+        <div class="status-header">
+            <span v-if="isSearch" class="mode-indicator">{{
+                searchTitle
+            }}</span>
+            <span v-else-if="isEdit" class="mode-indicator"
+                >Editing recipe</span
+            >
+            <span v-else-if="isRecipe" class="mode-indicator"
+                >Viewing recipe</span
+            >
             <!-- INDEX PAGE -->
-            <Breadcrumb
-                v-if="isIndex"
-                class="active no-arrow"
-                :title="t('cookbook', 'All recipes')"
-                :disable-drop="true"
-            />
-            <!-- SEARCH PAGE -->
-            <Breadcrumb
-                v-if="isSearch"
-                class="not-link"
-                :title="searchTitle"
-                :disable-drop="true"
-            />
-            <Breadcrumb
-                v-if="isSearch && $route.params.value"
-                class="active"
-                :title="
-                    $route.params.value === '_'
-                        ? 'None'
+            <h2 v-if="isIndex" class="location" :disable-drop="true">
+                {{ t("cookbook", "All recipes") }}
+            </h2>
+            <h2 v-else-if="isSearch && $route.params.value" class="location">
+                {{
+                    $route.params.value === "_"
+                        ? "None"
                         : decodeURIComponent($route.params.value)
-                "
-                :disable-drop="true"
-            />
-            <!-- RECIPE PAGES -->
-            <!-- Edit recipe -->
-            <Breadcrumb
-                v-if="isEdit"
-                class="not-link"
-                :title="t('cookbook', 'Edit recipe')"
-                :disable-drop="true"
-            />
-            <Breadcrumb
-                v-if="isEdit"
-                class="active"
-                :title="$store.state.recipe.name"
-                :disable-drop="true"
-            >
-            </Breadcrumb>
-            <Breadcrumb
-                v-if="isLoading || isLoadingRecipe"
-                class="active"
-                :title="t('cookbook', 'Loading…')"
-                :disable-drop="true"
-            >
-            </Breadcrumb>
-            <!-- Create new recipe -->
-            <Breadcrumb
-                v-else-if="isCreate"
-                class="active"
-                :title="t('cookbook', 'New recipe')"
-                :disable-drop="true"
-            />
-            <!-- View recipe -->
-            <Breadcrumb
-                v-if="isRecipe"
-                class="active"
-                :title="$store.state.recipe.name"
-                :disable-drop="true"
-            >
-            </Breadcrumb>
-            <!-- Is the app loading? -->
-            <Breadcrumb
-                v-if="isLoading"
-                class="active no-arrow"
-                title=""
-                :disable-drop="true"
-            >
-                <ActionButton
-                    icon="icon-loading-small"
-                    :aria-label="t('cookbook', 'Loading app')"
-                />
-            </Breadcrumb>
+                }}
+            </h2>
+            <!-- Recipe view / edit -->
+            <h2 v-else-if="isEdit || isRecipe" class="location">
+                {{ $store.state.recipe.name }}
+            </h2>
+            <!-- Is app loading? -->
+            <h2 v-else-if="isLoading" class="location">
+                {{ t("cookbook", "Loading app") }}
+            </h2>
             <!-- Is a recipe loading? -->
-            <Breadcrumb
-                v-else-if="isLoadingRecipe"
-                class="active no-arrow"
-                title=""
-                :disable-drop="true"
-            >
-                <ActionButton
-                    icon="icon-loading-small"
-                    :aria-label="t('cookbook', 'Loading recipe')"
-                />
-            </Breadcrumb>
+            <h2 v-else-if="isLoadingRecipe" class="location">
+                {{ t("cookbook", "Loading recipe") }}
+            </h2>
             <!-- No recipe found -->
-            <Breadcrumb
-                v-else-if="recipeNotFound"
-                class="active no-arrow"
-                :title="t('cookbook', 'Recipe not found')"
-                :disable-drop="true"
-            />
+            <h2 v-else-if="recipeNotFound" class="location">
+                {{ t("cookbook", "Recipe not found") }}
+            </h2>
             <!-- No page found -->
-            <Breadcrumb
-                v-else-if="pageNotFound"
-                class="active no-arrow"
-                :title="t('cookbook', 'Page not found')"
-                :disable-drop="true"
-            />
-        </Breadcrumbs>
+            <h2 v-else-if="pageNotFound" class="location">
+                {{ "t('cookbook', 'Page not found')" }}
+            </h2>
+            <!-- Create new recipe -->
+            <h2 v-else-if="isCreate" class="location">Creating new recipe</h2>
+        </div>
         {{/* Primary buttons */}}
-        <Button
+        <SimpleButton
             v-if="isRecipe"
             type="primary"
-            :aria-label="t('cookbook', 'Edit recipe')"
+            :aria-label="t('cookbook', 'Edit')"
             @click="goToRecipe($store.state.recipe.id)"
         >
             <template #icon>
                 <PencilIcon :size="20" />
             </template>
-            {{ t("cookbook", "Edit recipe") }}
-        </Button>
-        <Button
+            {{ t("cookbook", "Edit") }}
+        </SimpleButton>
+        <SimpleButton
             v-if="isEdit || isCreate"
             type="primary"
-            :aria-label="t('cookbook', 'Save changes')"
+            :aria-label="t('cookbook', 'Save')"
             @click="saveChanges()"
         >
             <template #icon>
@@ -133,8 +71,8 @@
                 />
                 <CheckmarkIcon v-else :size="20" />
             </template>
-            {{ t("cookbook", "Save changes") }}
-        </Button>
+            {{ t("cookbook", "Save") }}
+        </SimpleButton>
         <!-- This is clumsy design but the component cannot display just one input element on the breadcrumbs bar -->
         <Actions
             v-if="isIndex"
@@ -212,10 +150,9 @@ import helpers from "cookbook/js/helper"
 
 import Actions from "@nextcloud/vue/dist/Components/Actions"
 import ActionButton from "@nextcloud/vue/dist/Components/ActionButton"
-import Button from "@nextcloud/vue/dist/Components/Button"
+// Cannot use `Button` else get `vue/no-reserved-component-names` eslint errors
+import SimpleButton from "@nextcloud/vue/dist/Components/Button"
 import ActionInput from "@nextcloud/vue/dist/Components/ActionInput"
-import Breadcrumbs from "@nextcloud/vue/dist/Components/Breadcrumbs"
-import Breadcrumb from "@nextcloud/vue/dist/Components/Breadcrumb"
 
 import PencilIcon from "icons/Pencil.vue"
 import LoadingIcon from "icons/Loading.vue"
@@ -228,11 +165,8 @@ export default {
         Actions,
         ActionButton,
         ActionInput,
-        // eslint-disable-next-line vue/no-reserved-component-names
-        Button,
-        Breadcrumbs,
-        Breadcrumb,
         PrinterIcon,
+        SimpleButton,
         PencilIcon,
         LoadingIcon,
         CheckmarkIcon,
@@ -369,36 +303,49 @@ export default {
 
     /* The height of the nextcloud header */
     top: var(--header-height);
+    display: flex;
     width: 100%;
-    padding-left: 4px;
+    /* Make sure the wrapper is always at least as tall as the tallest element
+     * we expect (primary button) to prevent flickering when loading, etc. */
+    /* 44px is the height of nextcloud/vue button (not exposed as a variable :[ ) */
+    min-height: 44px;
+    flex-direction: row;
+
+    padding: 8px 1rem;
     border-bottom: 1px solid var(--color-border);
     background-color: var(--color-main-background);
+    gap: 8px;
+}
 
-    padding: 8px;
+.status-header {
     display: flex;
-    flex-direction: row;
+    /* Allow the title to shrink*/
+    min-width: 0;
+    flex-basis: 0;
+    flex-direction: column;
+    flex-grow: 1;
+    flex-shrink: 1;
+    align-items: flex-start;
+    justify-content: center;
 }
 
-.active {
-    cursor: default !important;
-    font-weight: bold;
+.mode-indicator {
+    font-size: 0.9em;
 }
 
-.breadcrumbs {
-    width: calc(100% - 60px);
-    flex-basis: 100%;
-}
-
-.wrapper .breadcrumbs /deep/ .breadcrumb__crumbs {
-    min-width: unset;
-}
-
-.no-arrow::before {
-    content: "" !important;
-}
-
-.overflow-menu {
-    margin-left: 8px;
+.location {
+    /* Don't let the location go wider than the space available */
+    width: 100%;
+    margin: 0;
+    font-size: 1.2em;
+    line-height: 1em;
+    /* overflow-x: hidden breaks overflow-y: visible
+    https://stackoverflow.com/questions/6421966/css-overflow-x-visible-and-overflow-y-hidden-causing-scrollbar-issue */
+    overflow-x: clip;
+    overflow-y: visible;
+    /* Show ... when overflowing */
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .animation-rotate {

--- a/src/components/AppControls/AppControls.vue
+++ b/src/components/AppControls/AppControls.vue
@@ -166,22 +166,8 @@ import LoadingIcon from "icons/Loading.vue"
 import CheckmarkIcon from "icons/Check.vue"
 import PrinterIcon from "icons/Printer.vue"
 
-const ModeIndicator = {
-    props: ["title"],
-    render(h) {
-        return h("span", { class: "mode-indicator" }, this.title)
-    },
-}
-
-const Location = {
-    props: ["title"],
-    render(h) {
-        // Wrapper is to enable vertical centering if only child
-        return h("div", { class: "location-wrapper" }, [
-            h("h2", { class: "location" }, this.title),
-        ])
-    },
-}
+import Location from "./Location.vue"
+import ModeIndicator from "./ModeIndicator.vue"
 
 export default {
     name: "AppControls",

--- a/src/components/AppControls/Location.vue
+++ b/src/components/AppControls/Location.vue
@@ -1,0 +1,18 @@
+<template>
+    <div class="location-wrapper">
+        <h2 class="location">{{ title }}</h2>
+    </div>
+</template>
+
+<script>
+export default {
+    // eslint-disable-next-line vue/multi-word-component-names
+    name: "Location",
+    props: {
+        title: {
+            type: String,
+            default: "",
+        },
+    },
+}
+</script>

--- a/src/components/AppControls/ModeIndicator.vue
+++ b/src/components/AppControls/ModeIndicator.vue
@@ -1,0 +1,16 @@
+<template>
+    <span class="mode-indicator">{{ title }}</span>
+</template>
+
+<script>
+export default {
+    // eslint-disable-next-line vue/multi-word-component-names
+    name: "ModeIndicator",
+    props: {
+        title: {
+            type: String,
+            default: "",
+        },
+    },
+}
+</script>

--- a/src/components/AppMain.vue
+++ b/src/components/AppMain.vue
@@ -15,7 +15,7 @@
 <script>
 import AppContent from "@nextcloud/vue/dist/Components/AppContent"
 import Content from "@nextcloud/vue/dist/Components/Content"
-import AppControls from "./AppControls.vue"
+import AppControls from "cookbook/components/AppControls/AppControls.vue"
 import AppNavi from "./AppNavi.vue"
 
 export default {

--- a/src/components/AppMain.vue
+++ b/src/components/AppMain.vue
@@ -39,7 +39,8 @@ export default {
 
 <style lang="scss" scoped>
 .app-navigation {
-    z-index: 1;
+    /* Content has z-index 1000 */
+    z-index: 2000;
 }
 
 .cookbook-app-content {

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -473,6 +473,13 @@ export default {
     opacity: 1;
 }
 
+/* By default, the bar is 44px, and the toggle button margin-right is -44px */
+/* Our top bar has 8px top/bottom padding, so move the toggle button accordingly */
+>>> .app-navigation-toggle {
+    margin-top: 8px;
+    margin-right: -52px !important;
+}
+
 @media print {
     * {
         display: none !important;

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -112,7 +112,7 @@
                             : 'icon-checkmark'
                     "
                 ></span>
-                {{ t("cookbook", "Save changes") }}
+                {{ t("cookbook", "Save") }}
             </button>
         </div>
         <edit-multiselect-popup

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -10,7 +10,7 @@
             </div>
 
             <div class="meta">
-                <h2>{{ $store.state.recipe.name }}</h2>
+                <h2 class="heading">{{ $store.state.recipe.name }}</h2>
                 <div class="details">
                     <div v-if="recipe.keywords.length">
                         <ul v-if="recipe.keywords.length">
@@ -643,6 +643,10 @@ export default {
 
 .meta {
     margin: 0 1rem;
+}
+
+.heading {
+    margin-top: 12px;
 }
 
 .dates {


### PR DESCRIPTION
- Remove the troublesome `Breadcrumbs` component.
- Show the "location" (recipe name, category name, etc) in an `h2`. Consistently show the "mode" where applicable (Viewing category, Viewing recipe, Editing recipe). Previously, "Edit" was shown when editing, but nothing was shown when viewing. This should be more clear and consistent.
- Move all of the buttons to the right of the bar. Each page should have a primary button (Edit, Save, Search) and all the rest go into an overflow 3-dot menu

To-do:

- [ ] Fix translations. "Save changes" was changed to "Save". "Edit recipe" was changed to "Edit". Some new strings were added: "Viewing recipe", "Editing recipe", "Creating new recipe"

Fixes #281
Fixes #896 

https://user-images.githubusercontent.com/8503756/180622714-5f3f1c98-fedb-40f9-b7e1-a0c733f273e5.mp4

![image](https://user-images.githubusercontent.com/8503756/180623130-c2792c69-a5fe-4a56-b9ad-d0dd6efe9e66.png)