### PR TITLE
Reduce bundle size, add code splitting

### DIFF
--- a/src/components/AppControls/AppControls.vue
+++ b/src/components/AppControls/AppControls.vue
@@ -175,7 +175,6 @@ import NcActions from "@nextcloud/vue/dist/Components/NcActions"
 import NcActionButton from "@nextcloud/vue/dist/Components/NcActionButton"
 // Cannot use `Button` else get `vue/no-reserved-component-names` eslint errors
 import NcButton from "@nextcloud/vue/dist/Components/NcButton"
-import NcActionInput from "@nextcloud/vue/dist/Components/NcActionInput"
 import NcLoadingIcon from "@nextcloud/vue/dist/Components/NcLoadingIcon"
 
 import PencilIcon from "icons/Pencil.vue"
@@ -192,6 +191,8 @@ import {
 
 import Location from "./Location.vue"
 import ModeIndicator from "./ModeIndicator.vue"
+
+import NcActionInput from "../SimpleActionInput.vue"
 
 export default {
     name: "AppControls",

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -82,7 +82,6 @@
 </template>
 
 <script>
-import NcActionInput from "@nextcloud/vue/dist/Components/NcActionInput"
 import NcAppNavigation from "@nextcloud/vue/dist/Components/NcAppNavigation"
 import NcAppNavigationItem from "@nextcloud/vue/dist/Components/NcAppNavigationItem"
 import NcAppNavigationNew from "@nextcloud/vue/dist/Components/NcAppNavigationNew"
@@ -98,6 +97,7 @@ import { showSimpleAlertModal } from "cookbook/js/modals"
 
 import AppSettings from "./AppSettings.vue"
 import AppNavigationCaption from "./AppNavigationCaption.vue"
+import NcActionInput from "./SimpleActionInput.vue"
 
 export default {
     name: "AppNavi",

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -254,7 +254,9 @@
 </template>
 
 <script>
+import Vue from "vue"
 import moment from "@nextcloud/moment"
+import VueShowdown from "vue-showdown"
 
 import api from "cookbook/js/api-interface"
 import helpers from "cookbook/js/helper"
@@ -268,6 +270,13 @@ import RecipeKeyword from "./RecipeKeyword.vue"
 import RecipeNutritionInfoItem from "./RecipeNutritionInfoItem.vue"
 import RecipeTimer from "./RecipeTimer.vue"
 import RecipeTool from "./RecipeTool.vue"
+
+// Markdown for Vue
+// Used by RecipeTool, RecipeInstruction, and RecipeIngredient
+Vue.use(VueShowdown, {
+    // set default flavor for Markdown
+    flavor: "vanilla",
+})
 
 export default {
     name: "RecipeView",

--- a/src/components/SimpleActionInput.vue
+++ b/src/components/SimpleActionInput.vue
@@ -21,7 +21,7 @@
   - along with this program. If not, see <http://www.gnu.org/licenses/>.
   -
   - This file is modified from:
-  - https://github.com/nextcloud/nextcloud-vue/blob/master/src/components/NcActionInput/NcActionInput.vue
+  - https://github.com/nextcloud/nextcloud-vue/blob/8caab6d0a9346231d77a236045723b75176b08cf/src/components/NcActionInput/NcActionInput.vue
   - Some features are stripped to avoid importing large dependencies to reduce
   - bundle size.
   - Please see: https://github.com/nextcloud/cookbook/pull/1116

--- a/src/components/SimpleActionInput.vue
+++ b/src/components/SimpleActionInput.vue
@@ -33,6 +33,9 @@
 </template>
 
 <script>
+import Vue from 'vue'
+import ArrowRight from "icons/ArrowRight.vue"
+
 const ActionGlobalMixin = {
     before() {
         // all actions requires a valid text content
@@ -72,14 +75,11 @@ const ActionGlobalMixin = {
     },
 }
 
-const GenRandomId = (length) => {
-    return Math.random()
+const GenRandomId = (length) =>
+    Math.random()
         .toString(36)
         .replace(/[^a-z]+/g, "")
         .slice(0, length || 5)
-}
-
-import ArrowRight from "icons/ArrowRight"
 
 export default {
     name: "ActionInput",
@@ -96,7 +96,7 @@ export default {
          */
         id: {
             type: String,
-            default: () => "action-" + GenRandomId(),
+            default: () => `action-${GenRandomId()}`,
             validator: (id) => id.trim() !== "",
         },
         /**
@@ -172,6 +172,7 @@ export default {
         onSubmit(event) {
             event.preventDefault()
             event.stopPropagation()
+
             if (!this.disabled) {
                 /**
                  * Emitted on submit of the input field
@@ -179,10 +180,11 @@ export default {
                  * @type {Event}
                  */
                 this.$emit("submit", event)
-            } else {
-                // ignore submit
-                return false
+                return true
             }
+
+            // ignore submit
+            return false
         },
         onChange(event) {
             /**

--- a/src/components/SimpleActionInput.vue
+++ b/src/components/SimpleActionInput.vue
@@ -268,21 +268,22 @@ $breakpoint-mobile: 1024px;
 
 // top-bar spacing
 $topbar-margin: 4px;
+
 button:not(.button-vue),
 input:not([type="range"]),
 textarea {
-    margin: 0;
     padding: 7px 6px;
+    border: 1px solid var(--color-border-dark);
+    border-radius: var(--border-radius);
+    margin: 0;
+    background-color: var(--color-main-background);
+
+    color: var(--color-text-lighter);
 
     cursor: text;
 
-    color: var(--color-text-lighter);
-    border: 1px solid var(--color-border-dark);
-    border-radius: var(--border-radius);
-    outline: none;
-    background-color: var(--color-main-background);
-
     font-size: 13px;
+    outline: none;
 
     &:not(:disabled):not(.primary) {
         &:hover,
@@ -294,17 +295,17 @@ textarea {
         }
 
         &:active {
+            background-color: var(--color-main-background);
             color: var(--color-text-light);
             outline: none;
-            background-color: var(--color-main-background);
         }
     }
 
     &:disabled {
+        background-color: var(--color-background-dark);
+        color: var(--color-text-maxcontrast);
         cursor: default;
         opacity: $opacity_disabled;
-        color: var(--color-text-maxcontrast);
-        background-color: var(--color-background-dark);
     }
 
     &:required {
@@ -318,10 +319,10 @@ textarea {
 
     /* Primary action button, use sparingly */
     &.primary {
-        cursor: pointer;
-        color: var(--color-primary-text);
         border-color: var(--color-primary-element);
         background-color: var(--color-primary-element);
+        color: var(--color-primary-text);
+        cursor: pointer;
 
         &:not(:disabled) {
             &:hover,
@@ -336,27 +337,27 @@ textarea {
         }
 
         &:disabled {
-            cursor: default;
-            color: var(--color-primary-text-dark);
             // opacity is already defined to .5 if disabled
             background-color: var(--color-primary-element);
+            color: var(--color-primary-text-dark);
+            cursor: default;
         }
     }
 }
 @mixin action-active {
     li {
         &.active {
-            background-color: var(--color-background-hover);
-            border-radius: 6px;
             padding: 0;
+            border-radius: 6px;
+            background-color: var(--color-background-hover);
         }
     }
 }
 
 @mixin action--disabled {
     .action--disabled {
-        pointer-events: none;
         opacity: $opacity_disabled;
+        pointer-events: none;
         &:hover,
         &:focus {
             cursor: default;
@@ -371,28 +372,28 @@ textarea {
 @mixin action-item($name) {
     .action-#{$name} {
         display: flex;
-        align-items: flex-start;
 
         width: 100%;
         height: auto;
-        margin: 0;
+        box-sizing: border-box; // otherwise router-link overflows in Firefox
+        align-items: flex-start;
         padding: 0;
         padding-right: $icon-margin;
-        box-sizing: border-box; // otherwise router-link overflows in Firefox
-
-        cursor: pointer;
-        white-space: nowrap;
-
-        opacity: $opacity_normal;
-        color: var(--color-main-text);
         border: 0;
         border-radius: 0; // otherwise Safari will cut the border-radius area
+        margin: 0;
         background-color: transparent;
         box-shadow: none;
+        color: var(--color-main-text);
+
+        cursor: pointer;
+        font-size: var(--default-font-size);
 
         font-weight: normal;
-        font-size: var(--default-font-size);
         line-height: $clickable-area;
+
+        opacity: $opacity_normal;
+        white-space: nowrap;
 
         &:hover,
         &:focus {
@@ -407,10 +408,10 @@ textarea {
         &__icon {
             width: $clickable-area;
             height: $clickable-area;
-            opacity: $opacity_full;
             background-position: $icon-margin center;
-            background-size: $icon-size;
             background-repeat: no-repeat;
+            background-size: $icon-size;
+            opacity: $opacity_full;
         }
 
         &::v-deep .material-design-icon {
@@ -425,17 +426,17 @@ textarea {
 
         // long text area
         p {
+
+            // in case there are no spaces like long email addresses
+            overflow: hidden;
             max-width: 220px;
-            line-height: 1.6em;
 
             // 14px are currently 1em line-height. Mixing units as '44px - 1.6em' does not work.
             padding: #{math.div($clickable-area - 1.6 * 14px, 2)} 0;
 
             cursor: pointer;
+            line-height: 1.6em;
             text-align: left;
-
-            // in case there are no spaces like long email addresses
-            overflow: hidden;
             text-overflow: ellipsis;
         }
 
@@ -446,12 +447,12 @@ textarea {
         }
 
         &__title {
+            display: inline-block;
+            overflow: hidden;
+            max-width: 100%;
             font-weight: bold;
             text-overflow: ellipsis;
-            overflow: hidden;
             white-space: nowrap;
-            max-width: 100%;
-            display: inline-block;
         }
     }
 }
@@ -462,23 +463,23 @@ $input-margin: 4px;
 
 .action-input {
     display: flex;
-    align-items: flex-start;
 
     width: 100%;
     height: auto;
-    margin: 0;
+    align-items: flex-start;
     padding: 0;
-
-    cursor: pointer;
-    white-space: nowrap;
-
-    color: var(--color-main-text);
     border: 0;
     border-radius: 0; // otherwise Safari will cut the border-radius area
+    margin: 0;
     background-color: transparent;
     box-shadow: none;
 
+    color: var(--color-main-text);
+
+    cursor: pointer;
+
     font-weight: normal;
+    white-space: nowrap;
 
     &::v-deep .material-design-icon {
         width: $clickable-area;
@@ -532,41 +533,41 @@ $input-margin: 4px;
     // Forms & text inputs
     &__form {
         display: flex;
-        align-items: center;
         flex: 1 1 auto;
+        align-items: center;
+        padding-right: $icon-margin;
 
         margin: $input-margin 0;
-        padding-right: $icon-margin;
     }
 
     &__submit {
         position: absolute;
-        left: -10000px;
         top: auto;
+        left: -10000px;
+        overflow: hidden;
         width: 1px;
         height: 1px;
-        overflow: hidden;
     }
 
     &__label {
         display: flex;
-        align-items: center;
-        justify-content: center;
 
         width: #{$clickable-area - $input-margin * 2};
         height: #{$clickable-area - $input-margin * 2};
         box-sizing: border-box;
-        margin: 0 0 0 -8px;
+        align-items: center;
+        justify-content: center;
         padding: 7px 6px;
-
-        opacity: $opacity_full;
-        color: var(--color-text-lighter);
         border: 1px solid var(--color-border-dark);
-        border-left-color: transparent;
         border-radius: 0 var(--border-radius) var(--border-radius) 0;
+        border-left-color: transparent;
+        margin: 0 0 0 -8px;
+        background-clip: padding-box;
         /* Avoid background under border */
         background-color: var(--color-main-background);
-        background-clip: padding-box;
+        color: var(--color-text-lighter);
+
+        opacity: $opacity_full;
 
         &,
         * {
@@ -576,11 +577,10 @@ $input-margin: 4px;
 
     /* Inputs inside popover supports text, submit & reset */
     &__input {
-        flex: 1 1 auto;
-
         min-width: $clickable-area * 3;
         min-height: #{$clickable-area - $input-margin * 2}; /* twice the element margin-y */
         max-height: #{$clickable-area - $input-margin * 2}; /* twice the element margin-y */
+        flex: 1 1 auto;
         margin: 0;
 
         // if disabled, change cursor

--- a/src/components/SimpleActionInput.vue
+++ b/src/components/SimpleActionInput.vue
@@ -1,0 +1,613 @@
+<template>
+    <li class="action">
+        <span class="action-input">
+            <slot name="icon">
+                <span :class="icon" class="action-input__icon" />
+            </slot>
+            <form
+                ref="form"
+                class="action-input__form"
+                :disabled="disabled"
+                @submit.prevent="onSubmit"
+            >
+                <input :id="id" type="submit" class="action-input__submit" />
+
+                <input
+                    :type="type"
+                    :value="value"
+                    :placeholder="text"
+                    :disabled="disabled"
+                    :aria-label="ariaLabel"
+                    v-bind="$attrs"
+                    :class="{ focusable: isFocusable }"
+                    class="action-input__input"
+                    @input="onInput"
+                    @change="onChange"
+                />
+                <label v-show="!disabled" :for="id" class="action-input__label">
+                    <ArrowRight :size="20" />
+                </label>
+            </form>
+        </span>
+    </li>
+</template>
+
+<script>
+const ActionGlobalMixin = {
+	before() {
+		// all actions requires a valid text content
+		// if none, forbid the component mount and throw error
+		if (!this.$slots.default || this.text.trim() === '') {
+			Vue.util.warn(`${this.$options.name} cannot be empty and requires a meaningful text content`, this)
+			this.$destroy()
+			this.$el.remove()
+		}
+	},
+
+	beforeUpdate() {
+		this.text = this.getText()
+	},
+
+	data() {
+		return {
+			// $slots are not reactive.
+			// We need to update  the content manually
+			text: this.getText(),
+		}
+	},
+
+	computed: {
+		isLongText() {
+			return this.text && this.text.trim().length > 20
+		},
+	},
+
+	methods: {
+		getText() {
+			return this.$slots.default ? this.$slots.default[0].text.trim() : ''
+		},
+	},
+}
+
+const GenRandomId = (length) => {
+	return Math.random()
+		.toString(36)
+		.replace(/[^a-z]+/g, '')
+		.slice(0, length || 5)
+}
+
+import ArrowRight from "icons/ArrowRight"
+
+export default {
+    name: "ActionInput",
+
+    components: {
+        ArrowRight,
+    },
+
+    mixins: [ActionGlobalMixin],
+
+    props: {
+        /**
+         * id attribute of the checkbox element
+         */
+        id: {
+            type: String,
+            default: () => "action-" + GenRandomId(),
+            validator: (id) => id.trim() !== "",
+        },
+        /**
+         * Icon to show with the action, can be either a CSS class or an URL
+         */
+        icon: {
+            type: String,
+            default: "",
+        },
+        /**
+         * type attribute of the input field
+         */
+        type: {
+            type: String,
+            default: "text",
+            validator(type) {
+                return (
+                    [
+                        "text",
+                    ].indexOf(type) > -1
+                )
+            },
+        },
+        /**
+         * value attribute of the input field
+         */
+        value: {
+            type: [String, Date, Number],
+            default: "",
+        },
+        /**
+         * disabled state of the input field
+         */
+        disabled: {
+            type: Boolean,
+            default: false,
+        },
+        /**
+         * aria-label attribute of the input field
+         */
+        ariaLabel: {
+            type: String,
+            default: "",
+        },
+    },
+
+    computed: {
+        /**
+         * determines if the action is focusable
+         *
+         * @return {boolean} is the action focusable ?
+         */
+        isFocusable() {
+            return !this.disabled
+        },
+    },
+
+    methods: {
+        onInput(event) {
+            /**
+             * Emitted on input events of the text field
+             *
+             * @type {Event|Date}
+             */
+            this.$emit("input", event)
+            /**
+             * Emitted when the inputs value changes
+             * ! DatetimePicker only send the value
+             *
+             * @type {string|Date}
+             */
+            this.$emit(
+                "update:value",
+                event.target ? event.target.value : event
+            )
+        },
+        onSubmit(event) {
+            event.preventDefault()
+            event.stopPropagation()
+            if (!this.disabled) {
+                /**
+                 * Emitted on submit of the input field
+                 *
+                 * @type {Event}
+                 */
+                this.$emit("submit", event)
+            } else {
+                // ignore submit
+                return false
+            }
+        },
+        onChange(event) {
+            /**
+             * Emitted on change of the input field
+             *
+             * @type {Event}
+             */
+            this.$emit("change", event)
+        },
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+@use 'sass:math';
+
+// https://uxplanet.org/7-rules-for-mobile-ui-button-design-e9cf2ea54556
+// recommended is 48px
+// 44px is what we choose and have very good visual-to-usability ratio
+$clickable-area: 44px;
+
+// background icon size
+// also used for the scss icon font
+$icon-size: 16px;
+
+// icon padding for a $clickable-area width and a $icon-size icon
+// ( 44px - 16px ) / 2
+$icon-margin: math.div($clickable-area - $icon-size, 2);
+
+// transparency background for icons
+$icon-focus-bg: rgba(127, 127, 127, .25);
+
+// popovermenu arrow width from the triangle center
+$arrow-width: 9px;
+
+// opacities
+$opacity_disabled: .5;
+$opacity_normal: .7;
+$opacity_full: 1;
+
+// menu round background hover feedback
+// good looking on dark AND white bg
+$action-background-hover: rgba(127, 127, 127, .25);
+
+// various structure data used in the 
+// `AppNavigation` component
+$header-height: 50px;
+$navigation-width: 300px;
+
+// mobile breakpoint
+$breakpoint-mobile: 1024px;
+
+// top-bar spacing
+$topbar-margin: 4px;
+button:not(.button-vue),
+input:not([type='range']),
+textarea {
+	margin: 0;
+	padding: 7px 6px;
+
+	cursor: text;
+
+	color: var(--color-text-lighter);
+	border: 1px solid var(--color-border-dark);
+	border-radius: var(--border-radius);
+	outline: none;
+	background-color: var(--color-main-background);
+
+	font-size: 13px;
+
+	&:not(:disabled):not(.primary) {
+		&:hover,
+		&:focus,
+		&.active {
+			/* active class used for multiselect */
+			border-color: var(--color-primary-element);
+			outline: none;
+		}
+
+		&:active {
+			color: var(--color-text-light);
+			outline: none;
+			background-color: var(--color-main-background);
+		}
+	}
+
+	&:disabled {
+		cursor: default;
+		opacity: $opacity_disabled;
+		color: var(--color-text-maxcontrast);
+		background-color: var(--color-background-dark);
+	}
+
+	&:required {
+		box-shadow: none;
+	}
+
+	&:invalid {
+		border-color: var(--color-error);
+		box-shadow: none !important;
+	}
+
+	/* Primary action button, use sparingly */
+	&.primary {
+		cursor: pointer;
+		color: var(--color-primary-text);
+		border-color: var(--color-primary-element);
+		background-color: var(--color-primary-element);
+
+		&:not(:disabled) {
+			&:hover,
+			&:focus,
+			&:active {
+				border-color: var(--color-primary-element-light);
+				background-color: var(--color-primary-element-light);
+			}
+			&:active {
+				color: var(--color-primary-text-dark);
+			}
+		}
+
+		&:disabled {
+			cursor: default;
+			color: var(--color-primary-text-dark);
+			// opacity is already defined to .5 if disabled
+			background-color: var(--color-primary-element);
+		}
+	}
+}
+@mixin action-active {
+	li {
+		&.active {
+			background-color: var(--color-background-hover);
+			border-radius: 6px;
+			padding: 0;
+		}
+	}
+}
+
+@mixin action--disabled {
+	.action--disabled {
+		pointer-events: none;
+		opacity: $opacity_disabled;
+		&:hover, &:focus {
+			cursor: default;
+			opacity: $opacity_disabled;
+		}
+		& * {
+			opacity: 1 !important;
+		}
+	}
+}
+
+
+@mixin action-item($name) {
+	.action-#{$name} {
+		display: flex;
+		align-items: flex-start;
+
+		width: 100%;
+		height: auto;
+		margin: 0;
+		padding: 0;
+		padding-right: $icon-margin;
+		box-sizing: border-box; // otherwise router-link overflows in Firefox
+
+		cursor: pointer;
+		white-space: nowrap;
+
+		opacity: $opacity_normal;
+		color: var(--color-main-text);
+		border: 0;
+		border-radius: 0; // otherwise Safari will cut the border-radius area
+		background-color: transparent;
+		box-shadow: none;
+
+		font-weight: normal;
+		font-size: var(--default-font-size);
+		line-height: $clickable-area;
+
+		&:hover,
+		&:focus {
+			opacity: $opacity_full;
+		}
+
+		& > span {
+			cursor: pointer;
+			white-space: nowrap;
+		}
+
+		&__icon {
+			width: $clickable-area;
+			height: $clickable-area;
+			opacity: $opacity_full;
+			background-position: $icon-margin center;
+			background-size: $icon-size;
+			background-repeat: no-repeat;
+		}
+
+		&::v-deep .material-design-icon {
+			width: $clickable-area;
+			height: $clickable-area;
+			opacity: $opacity_full;
+
+			.material-design-icon__svg {
+				vertical-align: middle;
+			}
+		}
+
+		// long text area
+		p {
+			max-width: 220px;
+			line-height: 1.6em;
+
+			// 14px are currently 1em line-height. Mixing units as '44px - 1.6em' does not work.
+			padding: #{math.div($clickable-area - 1.6 * 14px, 2)} 0;
+
+			cursor: pointer;
+			text-align: left;
+
+			// in case there are no spaces like long email addresses
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
+		&__longtext {
+			cursor: pointer;
+			// allow the use of `\n`
+			white-space: pre-wrap;
+		}
+
+		&__title {
+			font-weight: bold;
+			text-overflow: ellipsis;
+			overflow: hidden;
+			white-space: nowrap;
+			max-width: 100%;
+			display: inline-block;
+		}
+	}
+}
+@include action-active;
+@include action--disabled;
+
+$input-margin: 4px;
+
+.action-input {
+    display: flex;
+    align-items: flex-start;
+
+    width: 100%;
+    height: auto;
+    margin: 0;
+    padding: 0;
+
+    cursor: pointer;
+    white-space: nowrap;
+
+    color: var(--color-main-text);
+    border: 0;
+    border-radius: 0; // otherwise Safari will cut the border-radius area
+    background-color: transparent;
+    box-shadow: none;
+
+    font-weight: normal;
+
+    &::v-deep .material-design-icon {
+        width: $clickable-area;
+        height: $clickable-area;
+        opacity: $opacity_full;
+
+        .material-design-icon__svg {
+            vertical-align: middle;
+        }
+    }
+
+    // do not change the opacity of the datepicker
+    &:not(.action-input--picker) {
+        opacity: $opacity_normal;
+        &:hover,
+        &:focus {
+            opacity: $opacity_full;
+        }
+    }
+
+    // only change for the icon then
+    &--picker {
+        .action-input__icon {
+            opacity: $opacity_normal;
+        }
+        &:hover .action-input__icon,
+        &:focus .action-input__icon {
+            opacity: $opacity_full;
+        }
+    }
+
+    & > span {
+        cursor: pointer;
+        white-space: nowrap;
+    }
+
+    &__icon {
+        min-width: 0; /* Overwrite icons*/
+        min-height: 0;
+        /* Keep padding to define the width to
+			assure correct position of a possible text */
+        padding: #{math.div($clickable-area, 2)} 0 #{math.div(
+                $clickable-area,
+                2
+            )} $clickable-area;
+
+        background-position: #{$icon-margin} center;
+        background-size: $icon-size;
+    }
+
+    // Forms & text inputs
+    &__form {
+        display: flex;
+        align-items: center;
+        flex: 1 1 auto;
+
+        margin: $input-margin 0;
+        padding-right: $icon-margin;
+    }
+
+    &__submit {
+        position: absolute;
+        left: -10000px;
+        top: auto;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+    }
+
+    &__label {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        width: #{$clickable-area - $input-margin * 2};
+        height: #{$clickable-area - $input-margin * 2};
+        box-sizing: border-box;
+        margin: 0 0 0 -8px;
+        padding: 7px 6px;
+
+        opacity: $opacity_full;
+        color: var(--color-text-lighter);
+        border: 1px solid var(--color-border-dark);
+        border-left-color: transparent;
+        border-radius: 0 var(--border-radius) var(--border-radius) 0;
+        /* Avoid background under border */
+        background-color: var(--color-main-background);
+        background-clip: padding-box;
+
+        &,
+        * {
+            cursor: pointer;
+        }
+    }
+
+    /* Inputs inside popover supports text, submit & reset */
+    &__input {
+        flex: 1 1 auto;
+
+        min-width: $clickable-area * 3;
+        min-height: #{$clickable-area - $input-margin * 2}; /* twice the element margin-y */
+        max-height: #{$clickable-area - $input-margin * 2}; /* twice the element margin-y */
+        margin: 0;
+
+        // if disabled, change cursor
+        &:disabled {
+            cursor: default;
+        }
+
+        /* only show confirm borders if input is not focused */
+        &:not(:active):not(:hover):not(:focus) {
+            &:invalid {
+                & + .action-input__label {
+                    border-color: var(--color-error);
+                    border-left-color: transparent;
+                }
+            }
+            &:not(:disabled) + .action-input__label {
+                &:active,
+                &:hover,
+                &:focus {
+                    border-color: var(--color-primary-element);
+                    border-radius: var(--border-radius);
+                }
+            }
+        }
+        &:active,
+        &:hover,
+        &:focus {
+            &:not(:disabled) + .action-input__label {
+                /* above previous input */
+                z-index: 2;
+
+                border-color: var(--color-primary-element);
+                border-left-color: transparent;
+            }
+        }
+    }
+
+    &__picker::v-deep {
+        .mx-input {
+            margin: 0;
+        }
+    }
+
+    &__multi {
+        width: 100%;
+    }
+}
+
+// if a form is the last of the list
+// add the same bottomMargin as the right padding
+// for visual balance
+li:last-child > .action-input {
+    padding-bottom: $icon-margin - $input-margin;
+}
+
+// same for first item
+li:first-child > .action-input {
+    padding-top: $icon-margin - $input-margin;
+}
+</style>

--- a/src/components/SimpleActionInput.vue
+++ b/src/components/SimpleActionInput.vue
@@ -1,3 +1,32 @@
+<!--
+  - @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
+  -
+  - @author John Molakvoæ <skjnldsv@protonmail.com>
+  - @author Marco Ambrosini <marcoambrosini@icloud.com>
+  - @author Marcel Robitaille <mail@marcelrobitaille.me>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  - This file is modified from:
+  - https://github.com/nextcloud/nextcloud-vue/blob/master/src/components/NcActionInput/NcActionInput.vue
+  - Some features are stripped to avoid importing large dependencies to reduce
+  - bundle size.
+  - Please see: https://github.com/nextcloud/cookbook/pull/1116
+  -->
+
 <template>
     <li class="action">
         <span class="action-input">

--- a/src/components/SimpleActionInput.vue
+++ b/src/components/SimpleActionInput.vue
@@ -34,46 +34,49 @@
 
 <script>
 const ActionGlobalMixin = {
-	before() {
-		// all actions requires a valid text content
-		// if none, forbid the component mount and throw error
-		if (!this.$slots.default || this.text.trim() === '') {
-			Vue.util.warn(`${this.$options.name} cannot be empty and requires a meaningful text content`, this)
-			this.$destroy()
-			this.$el.remove()
-		}
-	},
+    before() {
+        // all actions requires a valid text content
+        // if none, forbid the component mount and throw error
+        if (!this.$slots.default || this.text.trim() === "") {
+            Vue.util.warn(
+                `${this.$options.name} cannot be empty and requires a meaningful text content`,
+                this
+            )
+            this.$destroy()
+            this.$el.remove()
+        }
+    },
 
-	beforeUpdate() {
-		this.text = this.getText()
-	},
+    beforeUpdate() {
+        this.text = this.getText()
+    },
 
-	data() {
-		return {
-			// $slots are not reactive.
-			// We need to update  the content manually
-			text: this.getText(),
-		}
-	},
+    data() {
+        return {
+            // $slots are not reactive.
+            // We need to update  the content manually
+            text: this.getText(),
+        }
+    },
 
-	computed: {
-		isLongText() {
-			return this.text && this.text.trim().length > 20
-		},
-	},
+    computed: {
+        isLongText() {
+            return this.text && this.text.trim().length > 20
+        },
+    },
 
-	methods: {
-		getText() {
-			return this.$slots.default ? this.$slots.default[0].text.trim() : ''
-		},
-	},
+    methods: {
+        getText() {
+            return this.$slots.default ? this.$slots.default[0].text.trim() : ""
+        },
+    },
 }
 
 const GenRandomId = (length) => {
-	return Math.random()
-		.toString(36)
-		.replace(/[^a-z]+/g, '')
-		.slice(0, length || 5)
+    return Math.random()
+        .toString(36)
+        .replace(/[^a-z]+/g, "")
+        .slice(0, length || 5)
 }
 
 import ArrowRight from "icons/ArrowRight"
@@ -110,11 +113,7 @@ export default {
             type: String,
             default: "text",
             validator(type) {
-                return (
-                    [
-                        "text",
-                    ].indexOf(type) > -1
-                )
+                return ["text"].indexOf(type) > -1
             },
         },
         /**
@@ -198,7 +197,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@use 'sass:math';
+@use "sass:math";
 
 // https://uxplanet.org/7-rules-for-mobile-ui-button-design-e9cf2ea54556
 // recommended is 48px
@@ -214,21 +213,21 @@ $icon-size: 16px;
 $icon-margin: math.div($clickable-area - $icon-size, 2);
 
 // transparency background for icons
-$icon-focus-bg: rgba(127, 127, 127, .25);
+$icon-focus-bg: rgba(127, 127, 127, 0.25);
 
 // popovermenu arrow width from the triangle center
 $arrow-width: 9px;
 
 // opacities
-$opacity_disabled: .5;
-$opacity_normal: .7;
+$opacity_disabled: 0.5;
+$opacity_normal: 0.7;
 $opacity_full: 1;
 
 // menu round background hover feedback
 // good looking on dark AND white bg
-$action-background-hover: rgba(127, 127, 127, .25);
+$action-background-hover: rgba(127, 127, 127, 0.25);
 
-// various structure data used in the 
+// various structure data used in the
 // `AppNavigation` component
 $header-height: 50px;
 $navigation-width: 300px;
@@ -239,191 +238,191 @@ $breakpoint-mobile: 1024px;
 // top-bar spacing
 $topbar-margin: 4px;
 button:not(.button-vue),
-input:not([type='range']),
+input:not([type="range"]),
 textarea {
-	margin: 0;
-	padding: 7px 6px;
+    margin: 0;
+    padding: 7px 6px;
 
-	cursor: text;
+    cursor: text;
 
-	color: var(--color-text-lighter);
-	border: 1px solid var(--color-border-dark);
-	border-radius: var(--border-radius);
-	outline: none;
-	background-color: var(--color-main-background);
+    color: var(--color-text-lighter);
+    border: 1px solid var(--color-border-dark);
+    border-radius: var(--border-radius);
+    outline: none;
+    background-color: var(--color-main-background);
 
-	font-size: 13px;
+    font-size: 13px;
 
-	&:not(:disabled):not(.primary) {
-		&:hover,
-		&:focus,
-		&.active {
-			/* active class used for multiselect */
-			border-color: var(--color-primary-element);
-			outline: none;
-		}
+    &:not(:disabled):not(.primary) {
+        &:hover,
+        &:focus,
+        &.active {
+            /* active class used for multiselect */
+            border-color: var(--color-primary-element);
+            outline: none;
+        }
 
-		&:active {
-			color: var(--color-text-light);
-			outline: none;
-			background-color: var(--color-main-background);
-		}
-	}
+        &:active {
+            color: var(--color-text-light);
+            outline: none;
+            background-color: var(--color-main-background);
+        }
+    }
 
-	&:disabled {
-		cursor: default;
-		opacity: $opacity_disabled;
-		color: var(--color-text-maxcontrast);
-		background-color: var(--color-background-dark);
-	}
+    &:disabled {
+        cursor: default;
+        opacity: $opacity_disabled;
+        color: var(--color-text-maxcontrast);
+        background-color: var(--color-background-dark);
+    }
 
-	&:required {
-		box-shadow: none;
-	}
+    &:required {
+        box-shadow: none;
+    }
 
-	&:invalid {
-		border-color: var(--color-error);
-		box-shadow: none !important;
-	}
+    &:invalid {
+        border-color: var(--color-error);
+        box-shadow: none !important;
+    }
 
-	/* Primary action button, use sparingly */
-	&.primary {
-		cursor: pointer;
-		color: var(--color-primary-text);
-		border-color: var(--color-primary-element);
-		background-color: var(--color-primary-element);
+    /* Primary action button, use sparingly */
+    &.primary {
+        cursor: pointer;
+        color: var(--color-primary-text);
+        border-color: var(--color-primary-element);
+        background-color: var(--color-primary-element);
 
-		&:not(:disabled) {
-			&:hover,
-			&:focus,
-			&:active {
-				border-color: var(--color-primary-element-light);
-				background-color: var(--color-primary-element-light);
-			}
-			&:active {
-				color: var(--color-primary-text-dark);
-			}
-		}
+        &:not(:disabled) {
+            &:hover,
+            &:focus,
+            &:active {
+                border-color: var(--color-primary-element-light);
+                background-color: var(--color-primary-element-light);
+            }
+            &:active {
+                color: var(--color-primary-text-dark);
+            }
+        }
 
-		&:disabled {
-			cursor: default;
-			color: var(--color-primary-text-dark);
-			// opacity is already defined to .5 if disabled
-			background-color: var(--color-primary-element);
-		}
-	}
+        &:disabled {
+            cursor: default;
+            color: var(--color-primary-text-dark);
+            // opacity is already defined to .5 if disabled
+            background-color: var(--color-primary-element);
+        }
+    }
 }
 @mixin action-active {
-	li {
-		&.active {
-			background-color: var(--color-background-hover);
-			border-radius: 6px;
-			padding: 0;
-		}
-	}
+    li {
+        &.active {
+            background-color: var(--color-background-hover);
+            border-radius: 6px;
+            padding: 0;
+        }
+    }
 }
 
 @mixin action--disabled {
-	.action--disabled {
-		pointer-events: none;
-		opacity: $opacity_disabled;
-		&:hover, &:focus {
-			cursor: default;
-			opacity: $opacity_disabled;
-		}
-		& * {
-			opacity: 1 !important;
-		}
-	}
+    .action--disabled {
+        pointer-events: none;
+        opacity: $opacity_disabled;
+        &:hover,
+        &:focus {
+            cursor: default;
+            opacity: $opacity_disabled;
+        }
+        & * {
+            opacity: 1 !important;
+        }
+    }
 }
 
-
 @mixin action-item($name) {
-	.action-#{$name} {
-		display: flex;
-		align-items: flex-start;
+    .action-#{$name} {
+        display: flex;
+        align-items: flex-start;
 
-		width: 100%;
-		height: auto;
-		margin: 0;
-		padding: 0;
-		padding-right: $icon-margin;
-		box-sizing: border-box; // otherwise router-link overflows in Firefox
+        width: 100%;
+        height: auto;
+        margin: 0;
+        padding: 0;
+        padding-right: $icon-margin;
+        box-sizing: border-box; // otherwise router-link overflows in Firefox
 
-		cursor: pointer;
-		white-space: nowrap;
+        cursor: pointer;
+        white-space: nowrap;
 
-		opacity: $opacity_normal;
-		color: var(--color-main-text);
-		border: 0;
-		border-radius: 0; // otherwise Safari will cut the border-radius area
-		background-color: transparent;
-		box-shadow: none;
+        opacity: $opacity_normal;
+        color: var(--color-main-text);
+        border: 0;
+        border-radius: 0; // otherwise Safari will cut the border-radius area
+        background-color: transparent;
+        box-shadow: none;
 
-		font-weight: normal;
-		font-size: var(--default-font-size);
-		line-height: $clickable-area;
+        font-weight: normal;
+        font-size: var(--default-font-size);
+        line-height: $clickable-area;
 
-		&:hover,
-		&:focus {
-			opacity: $opacity_full;
-		}
+        &:hover,
+        &:focus {
+            opacity: $opacity_full;
+        }
 
-		& > span {
-			cursor: pointer;
-			white-space: nowrap;
-		}
+        & > span {
+            cursor: pointer;
+            white-space: nowrap;
+        }
 
-		&__icon {
-			width: $clickable-area;
-			height: $clickable-area;
-			opacity: $opacity_full;
-			background-position: $icon-margin center;
-			background-size: $icon-size;
-			background-repeat: no-repeat;
-		}
+        &__icon {
+            width: $clickable-area;
+            height: $clickable-area;
+            opacity: $opacity_full;
+            background-position: $icon-margin center;
+            background-size: $icon-size;
+            background-repeat: no-repeat;
+        }
 
-		&::v-deep .material-design-icon {
-			width: $clickable-area;
-			height: $clickable-area;
-			opacity: $opacity_full;
+        &::v-deep .material-design-icon {
+            width: $clickable-area;
+            height: $clickable-area;
+            opacity: $opacity_full;
 
-			.material-design-icon__svg {
-				vertical-align: middle;
-			}
-		}
+            .material-design-icon__svg {
+                vertical-align: middle;
+            }
+        }
 
-		// long text area
-		p {
-			max-width: 220px;
-			line-height: 1.6em;
+        // long text area
+        p {
+            max-width: 220px;
+            line-height: 1.6em;
 
-			// 14px are currently 1em line-height. Mixing units as '44px - 1.6em' does not work.
-			padding: #{math.div($clickable-area - 1.6 * 14px, 2)} 0;
+            // 14px are currently 1em line-height. Mixing units as '44px - 1.6em' does not work.
+            padding: #{math.div($clickable-area - 1.6 * 14px, 2)} 0;
 
-			cursor: pointer;
-			text-align: left;
+            cursor: pointer;
+            text-align: left;
 
-			// in case there are no spaces like long email addresses
-			overflow: hidden;
-			text-overflow: ellipsis;
-		}
+            // in case there are no spaces like long email addresses
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
 
-		&__longtext {
-			cursor: pointer;
-			// allow the use of `\n`
-			white-space: pre-wrap;
-		}
+        &__longtext {
+            cursor: pointer;
+            // allow the use of `\n`
+            white-space: pre-wrap;
+        }
 
-		&__title {
-			font-weight: bold;
-			text-overflow: ellipsis;
-			overflow: hidden;
-			white-space: nowrap;
-			max-width: 100%;
-			display: inline-block;
-		}
-	}
+        &__title {
+            font-weight: bold;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+            max-width: 100%;
+            display: inline-block;
+        }
+    }
 }
 @include action-active;
 @include action--disabled;

--- a/src/components/SimpleActionInput.vue
+++ b/src/components/SimpleActionInput.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script>
-import Vue from 'vue'
+import Vue from "vue"
 import ArrowRight from "icons/ArrowRight.vue"
 
 const ActionGlobalMixin = {

--- a/src/components/SimpleActionInput.vue
+++ b/src/components/SimpleActionInput.vue
@@ -28,10 +28,16 @@
   -->
 
 <template>
-    <li class="action">
+    <li class="action" :class="{ 'action--disabled': disabled }">
         <span class="action-input">
             <slot name="icon">
-                <span :class="icon" class="action-input__icon" />
+                <span
+                    :class="[isIconUrl ? 'action-input__icon--url' : icon]"
+                    :style="{
+                        backgroundImage: isIconUrl ? `url(${icon})` : null,
+                    }"
+                    class="action-input__icon"
+                />
             </slot>
             <form
                 ref="form"
@@ -92,6 +98,13 @@ const ActionGlobalMixin = {
     },
 
     computed: {
+        isIconUrl() {
+            try {
+                return new URL(this.icon)
+            } catch (error) {
+                return false
+            }
+        },
         isLongText() {
             return this.text && this.text.trim().length > 20
         },
@@ -426,7 +439,6 @@ textarea {
 
         // long text area
         p {
-
             // in case there are no spaces like long email addresses
             overflow: hidden;
             max-width: 220px;

--- a/src/components/SimpleActionInput.vue
+++ b/src/components/SimpleActionInput.vue
@@ -518,8 +518,8 @@ $input-margin: 4px;
     &__icon {
         min-width: 0; /* Overwrite icons*/
         min-height: 0;
-        /* Keep padding to define the width to
-			assure correct position of a possible text */
+        /* Keep padding to define the width to */
+        /* assure correct position of a possible text */
         padding: #{math.div($clickable-area, 2)} 0 #{math.div(
                 $clickable-area,
                 2

--- a/src/main.js
+++ b/src/main.js
@@ -35,7 +35,9 @@ helpers.useRouter(router)
 const locale = document.documentElement
     .getAttribute("data-locale")
     .replace("_", "-")
-    .toLowerCase() // `en` is the default locale and cannot be dynamically imported. Will 404
+    .toLowerCase()
+
+// `en` is the default locale and cannot be dynamically imported. Will 404
 // https://github.com/moment/moment/issues/3624
 ;(locale === "en"
     ? Promise.resolve()

--- a/src/main.js
+++ b/src/main.js
@@ -33,8 +33,16 @@ __webpack_nonce__ = btoa(OC.requestToken)
 
 helpers.useRouter(router)
 
-const locale = document.documentElement.getAttribute('data-locale')
-import(`moment/locale/${locale}.js`).then(() => moment.locale(locale))
+const locale = document.documentElement
+    .getAttribute("data-locale")
+    .replace("_", "-")
+    .toLowerCase()
+;// `en` is the default locale and cannot be dynamically imported. Will 404
+// https://github.com/moment/moment/issues/3624
+(locale === "en"
+    ? Promise.resolve()
+    : import(`moment/locale/${locale}.js`)
+).then(() => moment.locale(locale))
 
 // A simple function to sanitize HTML tags
 // eslint-disable-next-line no-param-reassign

--- a/src/main.js
+++ b/src/main.js
@@ -35,10 +35,9 @@ helpers.useRouter(router)
 const locale = document.documentElement
     .getAttribute("data-locale")
     .replace("_", "-")
-    .toLowerCase()
-;// `en` is the default locale and cannot be dynamically imported. Will 404
+    .toLowerCase() // `en` is the default locale and cannot be dynamically imported. Will 404
 // https://github.com/moment/moment/issues/3624
-(locale === "en"
+;(locale === "en"
     ? Promise.resolve()
     : import(`moment/locale/${locale}.js`)
 ).then(() => moment.locale(locale))

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@
  */
 
 // Markdown
-import moment from "moment"
+import moment from "@nextcloud/moment"
 
 import Vue from "vue"
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,8 +6,7 @@
  */
 
 // Markdown
-import VueShowdown from "vue-showdown"
-import moment from 'moment'
+import moment from "moment"
 
 import Vue from "vue"
 
@@ -54,12 +53,6 @@ Vue.prototype.OC = OC
 
 // eslint-disable-next-line no-undef
 Vue.prototype.verboseDebugLogging = verboseDebugLogging
-
-// Markdown for Vue
-Vue.use(VueShowdown, {
-    // set default flavor for Markdown
-    flavor: "vanilla",
-})
 
 // TODO: Equivalent library for Vue3 when we make that transition:
 // https://github.com/rlemaigre/vue3-promise-dialog

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,6 @@
  * @license AGPL3 or later
  */
 
-// Markdown
 import moment from "@nextcloud/moment"
 
 import Vue from "vue"

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@
 
 // Markdown
 import VueShowdown from "vue-showdown"
+import moment from 'moment'
 
 import Vue from "vue"
 
@@ -31,6 +32,9 @@ if (__webpack_use_dev_server__ || false) {
 __webpack_nonce__ = btoa(OC.requestToken)
 
 helpers.useRouter(router)
+
+const locale = document.documentElement.getAttribute('data-locale')
+import(`moment/locale/${locale}.js`).then(() => moment.locale(locale))
 
 // A simple function to sanitize HTML tags
 // eslint-disable-next-line no-param-reassign

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,11 +7,11 @@
 import Vue from "vue"
 import VueRouter from "vue-router"
 
-import Index from "../components/AppIndex.vue"
-import NotFound from "../components/NotFound.vue"
-import RecipeView from "../components/RecipeView.vue"
-import RecipeEdit from "../components/RecipeEdit.vue"
-import Search from "../components/SearchResults.vue"
+const Index = () => import(/* webpackPrefetch: true */ "../components/AppIndex.vue")
+const NotFound = () => import(/* webpackPrefetch: true */ "../components/NotFound.vue")
+const RecipeView = () => import(/* webpackPrefetch: true */ "../components/RecipeView.vue")
+const RecipeEdit = () => import(/* webpackPrefetch: true */ "../components/RecipeEdit.vue")
+const Search = () => import(/* webpackPrefetch: true */ "../components/SearchResults.vue")
 
 Vue.use(VueRouter)
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,11 +7,16 @@
 import Vue from "vue"
 import VueRouter from "vue-router"
 
-const Index = () => import(/* webpackPrefetch: true */ "../components/AppIndex.vue")
-const NotFound = () => import(/* webpackPrefetch: true */ "../components/NotFound.vue")
-const RecipeView = () => import(/* webpackPrefetch: true */ "../components/RecipeView.vue")
-const RecipeEdit = () => import(/* webpackPrefetch: true */ "../components/RecipeEdit.vue")
-const Search = () => import(/* webpackPrefetch: true */ "../components/SearchResults.vue")
+const Index = () =>
+    import(/* webpackPrefetch: true */ "../components/AppIndex.vue")
+const NotFound = () =>
+    import(/* webpackPrefetch: true */ "../components/NotFound.vue")
+const RecipeView = () =>
+    import(/* webpackPrefetch: true */ "../components/RecipeView.vue")
+const RecipeEdit = () =>
+    import(/* webpackPrefetch: true */ "../components/RecipeEdit.vue")
+const Search = () =>
+    import(/* webpackPrefetch: true */ "../components/SearchResults.vue")
 
 Vue.use(VueRouter)
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ function cookbookConfig (env) {
             // Don't import all locales at once
             // Only the needed locale is dynamically loaded later
             new webpack.IgnorePlugin({ resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ }),
+            new webpack.IgnorePlugin({ resourceRegExp: /calendar-js/ }),
         ],
         resolve: {
             'alias': {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,9 @@ function cookbookConfig (env) {
                 '__webpack_use_dev_server__': env.dev_server || false,
                 'verboseDebugLogging': isDev && (process.env.VERBOSE || false),
             }),
+            // Don't import all locales at once
+            // Only the needed locale is dynamically loaded later
+            new webpack.IgnorePlugin({ resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ }),
         ],
         resolve: {
             'alias': {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,7 @@ function cookbookConfig (env) {
             // Only the needed locale is dynamically loaded later
             new webpack.IgnorePlugin({ resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ }),
             new webpack.IgnorePlugin({ resourceRegExp: /calendar-js/ }),
+            new webpack.IgnorePlugin({ resourceRegExp: /DatetimePicker/ }),
         ],
         resolve: {
             'alias': {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,8 +32,6 @@ function cookbookConfig (env) {
             // Don't import all locales at once
             // Only the needed locale is dynamically loaded later
             new webpack.IgnorePlugin({ resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ }),
-            new webpack.IgnorePlugin({ resourceRegExp: /calendar-js/ }),
-            new webpack.IgnorePlugin({ resourceRegExp: /DatetimePicker/ }),
         ],
         resolve: {
             'alias': {


### PR DESCRIPTION
I'm writing this as a PR only so you can see the code changes. I don't intend this to be merged as is. I am just trying to continue the code splitting discussion.

Fixes #455 
Fixes #1109 

I implemented "naive" code splitting. I say naive because I just did every different route. However, these routes are usually quite small. We might be better off including the truly tiny ones in the main bundle to minimize the number of network requests.

Here is the bundle analyzer for the `master` branch.
![image](https://user-images.githubusercontent.com/8503756/180922279-da292d7f-ee0a-41eb-bc91-ca3f137f6036.png)
- `cookbook-main.js` is 4.79 MB raw, 1.05 MB gzipped.
- `cookbook-guest.js` is 1.06 MB raw, 277 kB gzipped.

![image](https://user-images.githubusercontent.com/8503756/180922111-31f99808-632c-4bf0-8ec6-4da2d81f9e56.png)

This small change seems to have inadvertently split some node modules into their own chunks. Now we have:
- `cookbook-main.js` 3.67 MB raw, 872 kB gzipped
- `cookbook-guest.js` 1.06 MB raw, 277 kB gzipped.
- `moment` 711 kB raw, 112.97 kB gzipped
- `RecipeView.js` 87 kB raw, 16 kB gzipped
- `Multiselect.js` 173 kB raw, 45 kB gzipped
- `RecipeList.js` 63 kB raw, 13 kB gzipped
- `RecipeEdit.js` 114 kB raw, 21 kb gzipped
- `NotFound.js` 4 kB raw, 1.9 kB gzipped
- `SearchResult.js` 4.7 kB raw, 1.9 kB gzipped
- `AppIndex.js` 3 kB raw, 1.5 kB gzipped

Apparently, the chunks will be prefetched in Vue 3.0. I was not able to make them prefetch with the webpack magic comment `import(/* webpackPrefetch: true */ '')` for some reason. I am also unsure how to change the long file names. I tried `output: { filename: '' }` in the webpack config and the magic comment `/* webpackChunkName: "" */`, but no change.

I got some good savings by dynamically loading the `moment` locale:
![image](https://user-images.githubusercontent.com/8503756/180926195-7e356c75-2a9e-4aa9-9ff9-1a6eb774901a.png)

`cookbook-main.js` is almost unchanged and only one locale needs to be loaded

I think we may be better off going after npm packages than our own code.Maybe we can lazy load the mardown editor, replace `ActionInput`, etc. I'm not sure why `calendar-js` and `ical` are needed, but both are pretty big. They seem to not be imported anywhere. I only see reference to them in `package-lock.json` as a dependency of `nextcloud/vue`.

Maybe we can also look into tree shaking. 