### PR TITLE
Fix the endpoint used for updating recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   [#1105](https://github.com/nextcloud/cookbook/pull/1105) @MarcelRobitaille
 - Fix typos and styling issues
   [#1112](https://github.com/nextcloud/cookbook/pull/1112) @christianlupus
+- Fix API endpoint used for updating recipes
+  [#1119](https://github.com/nextcloud/cookbook/pull/1119) @MarcelRobitaille
 
 ### Maintenance
 - Add composer.json to version control to have unique installed dependency versions

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -605,7 +605,7 @@ export default {
             const $this = this
 
             const request = (() => {
-                if (this.$store.state.recipe.id) {
+                if (this.$route.params.id ?? false) {
                     return this.$store.dispatch("updateRecipe", {
                         recipe: this.recipeWithCorrectedYield,
                     })

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -605,7 +605,7 @@ export default {
             const $this = this
 
             const request = (() => {
-                if (this.recipe_id) {
+                if (this.$store.state.recipe.id) {
                     return this.$store.dispatch("updateRecipe", {
                         recipe: this.recipeWithCorrectedYield,
                     })


### PR DESCRIPTION
Fixes #1073

`this.recipe_id` is null, so use the recipe ID saved in the store.

I've tested it in the browsed. Where I was seeing `POST` before, I am now seeing `PUT`.