### PR TITLE
Fix filters to allow for multi-line text in some fields

### DIFF
--- a/.github/actions/run-tests/test_runner/runner.py
+++ b/.github/actions/run-tests/test_runner/runner.py
@@ -66,11 +66,11 @@ class TestRunner:
 
 		sp = p.pr.run(cmd, env=env)
 
-		l.logger.printSetOutput('silent-fail', 'false')
+		l.logger.printSetOutput('silentFail', 'false')
 		if sp.returncode != 0:
 			if args.install_untested:
 				l.logger.printWarning('Failed testing with setting --install-untested')
-				l.logger.printSetOutput('silent-fail', 'true')
+				l.logger.printSetOutput('silentFail', 'true')
 				return 0
 			else:
 				return sp.returncode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   [#1119](https://github.com/nextcloud/cookbook/pull/1119) @MarcelRobitaille
 - Reactivate step debugging  in PHP
   [#1160](https://github.com/nextcloud/cookbook/pull/1160) @christianlupus
+- Fix multi-line code entry in some fields during editing
+  [#1162](https://github.com/nextcloud/cookbook/pull/1162) @christianlupus
 
 ### Maintenance
 - Add composer.json to version control to have unique installed dependency versions

--- a/lib/Helper/Filter/JSON/FixIngredientsFilter.php
+++ b/lib/Helper/Filter/JSON/FixIngredientsFilter.php
@@ -49,8 +49,7 @@ class FixIngredientsFilter extends AbstractJSONFilter {
 
 		$ingredients = array_map(function ($t) {
 			$t = trim($t);
-			$t = preg_replace('/\s+/', ' ', $t);
-			$t = $this->textCleaner->cleanUp($t);
+			$t = $this->textCleaner->cleanUp($t, false);
 			return $t;
 		}, $ingredients);
 		$ingredients = array_values($ingredients);

--- a/lib/Helper/Filter/JSON/FixInstructionsFilter.php
+++ b/lib/Helper/Filter/JSON/FixInstructionsFilter.php
@@ -103,7 +103,6 @@ class FixInstructionsFilter extends AbstractJSONFilter {
 
 		$instructions = array_map(function ($x) {
 			$x = trim($x);
-			$x = preg_replace('/\s+/', ' ', $x);
 			$x = $this->textCleaner->cleanUp($x, false);
 
 			return $x;

--- a/lib/Helper/Filter/JSON/FixToolsFilter.php
+++ b/lib/Helper/Filter/JSON/FixToolsFilter.php
@@ -49,8 +49,7 @@ class FixToolsFilter extends AbstractJSONFilter {
 
 		$tools = array_map(function ($t) {
 			$t = trim($t);
-			$t = preg_replace('/\s+/', ' ', $t);
-			$t = $this->textCleaner->cleanUp($t);
+			$t = $this->textCleaner->cleanUp($t, false);
 			return $t;
 		}, $tools);
 		$tools = array_filter($tools, fn ($t) => ($t));

--- a/tests/Integration/Helper/Filter/JSON/FixInstructionsFilterTest.php
+++ b/tests/Integration/Helper/Filter/JSON/FixInstructionsFilterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace OCA\Cookbook\tests\Integration\Helper\Filter\JSON;
+
+use OCP\IL10N;
+use OCP\ILogger;
+use PHPUnit\Framework\TestCase;
+use OCA\Cookbook\Service\JsonService;
+use PHPUnit\Framework\MockObject\Stub;
+use OCA\Cookbook\Helper\TextCleanupHelper;
+use OCA\Cookbook\Helper\Filter\JSON\FixInstructionsFilter;
+
+/**
+ * @covers OCA\Cookbook\Helper\Filter\JSON\FixInstructionsFilter
+ * @covers OCA\Cookbook\Exception\InvalidRecipeException
+ */
+class FixInstructionsFilterTest extends TestCase {
+	/** @var FixInstructionsFilter */
+	private $dut;
+
+	/** @var TextCleanupHelper */
+	private $textCleanupHelper;
+
+	/** @var array */
+	private $stub;
+
+	protected function setUp(): void {
+		/** @var Stub|IL10N $l */
+		$l = $this->createStub(IL10N::class);
+		$l->method('t')->willReturnArgument(0);
+
+		/** @var ILogger */
+		$logger = $this->createStub(ILogger::class);
+
+		$this->textCleanupHelper = new TextCleanupHelper();
+		$jsonService = new JsonService();
+
+		$this->dut = new FixInstructionsFilter($l, $logger, $this->textCleanupHelper, $jsonService);
+
+		$this->stub = [
+			'name' => 'The name of the recipe',
+			'id' => 1234,
+		];
+	}
+
+	public function dpParseInstructions() {
+		yield 'Instructions in multiple lines' => [
+			"a\nb\rc\r\nd",
+			['a','b','c','d'], true
+		];
+		yield 'Instructions with HTML Entities' => [
+			"<p>a</p>\n<ul><li>b</li><li>c</li></ul><p>d</p>",
+			['a','b','c','d'], true
+		];
+		yield 'Instructions with empty HTML Entities' => [
+			"a\n<p></p><ul><li></li><li></li></ul><p></p>\nb\nc\nd",
+			['a','b','c','d'], true
+		];
+
+		yield 'Instructions with Markdown' => [
+			["a\nb\nc"],
+			["a\nb\nc"], false
+		];
+		yield 'Instructions with untrimmed Markdown' => [
+			["a\n  b \td\nc"],
+			["a\n b d\nc"], true
+		];
+	}
+
+	/** @dataProvider dpParseInstructions */
+	public function testParseInstructions($originalInstructions, $expected, $changeExpected) {
+		$recipe = $this->stub;
+		$recipe['recipeInstructions'] = $originalInstructions;
+
+		$changed = $this->dut->apply($recipe);
+
+		$this->stub['recipeInstructions'] = $expected;
+		$this->assertEquals($this->stub, $recipe);
+		$this->assertEquals($changeExpected, $changed);
+	}
+}

--- a/tests/Integration/Helper/Filter/JSON/FixToolsFilterTest.php
+++ b/tests/Integration/Helper/Filter/JSON/FixToolsFilterTest.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace OCA\Cookbook\tests\Unit\Helper\Filter\JSON;
+namespace OCA\Cookbook\tests\Integration\Helper\Filter\JSON;
 
-use OCA\Cookbook\Exception\InvalidRecipeException;
 use OCP\IL10N;
 use OCP\ILogger;
 use PHPUnit\Framework\TestCase;
@@ -14,7 +13,7 @@ class FixToolsFilterTest extends TestCase {
 	/** @var FixToolsFilter */
 	private $dut;
 
-	/** @var TextCleanupHelper|Stub */
+	/** @var TextCleanupHelper */
 	private $textCleanupHelper;
 
 	/** @var array */
@@ -28,7 +27,7 @@ class FixToolsFilterTest extends TestCase {
 		/** @var ILogger */
 		$logger = $this->createStub(ILogger::class);
 
-		$this->textCleanupHelper = $this->createStub(TextCleanupHelper::class);
+		$this->textCleanupHelper = new TextCleanupHelper();
 
 		$this->dut = new FixToolsFilter($l, $logger, $this->textCleanupHelper);
 
@@ -38,18 +37,10 @@ class FixToolsFilterTest extends TestCase {
 		];
 	}
 
-	public function testNonExisting() {
-		$recipe = $this->stub;
-		$this->assertTrue($this->dut->apply($recipe));
-
-		$this->stub['tools'] = [];
-		$this->assertEquals($this->stub, $recipe);
-	}
-
 	public function dp() {
 		return [
 			[['a','b','c'], ['a','b','c'], false],
-			[[' a  ',''], ['a'], true],
+			[["  a   \tb ",'   c  '],['a b','c'],true],
 		];
 	}
 
@@ -58,22 +49,10 @@ class FixToolsFilterTest extends TestCase {
 		$recipe = $this->stub;
 		$recipe['tools'] = $startVal;
 
-		$this->textCleanupHelper->method('cleanUp')->willReturnArgument(0);
-
 		$ret = $this->dut->apply($recipe);
 
 		$this->stub['tools'] = $expectedVal;
 		$this->assertEquals($changed, $ret);
 		$this->assertEquals($this->stub, $recipe);
-	}
-
-	public function testApplyString() {
-		$recipe = $this->stub;
-		$recipe['tools'] = 'some text';
-
-		$this->textCleanupHelper->method('cleanUp')->willReturnArgument(0);
-		$this->expectException(InvalidRecipeException::class);
-
-		$this->dut->apply($recipe);
 	}
 }

--- a/tests/Unit/Helper/Filter/JSON/FixIngredientsFilterTest.php
+++ b/tests/Unit/Helper/Filter/JSON/FixIngredientsFilterTest.php
@@ -50,7 +50,6 @@ class FixIngredientsFilterTest extends TestCase {
 		return [
 			[['a','b','c'], ['a','b','c'], false],
 			[[' a  ',''], ['a'], true],
-			[["  a   \tb ",'   c  '],['a b','c'],true],
 		];
 	}
 

--- a/tests/Unit/Helper/Filter/JSON/FixInstructionsFilterTest.php
+++ b/tests/Unit/Helper/Filter/JSON/FixInstructionsFilterTest.php
@@ -137,6 +137,11 @@ class FixInstructionsFilterTest extends TestCase {
 			"a\n<p></p><ul><li></li><li></li></ul><p></p>\nb\nc\nd",
 			['a','b','c','d'], true
 		];
+
+		yield 'Instructions with Markdown' => [
+			["a\nb\nc"],
+			["a\nb\nc"], false
+		];
 	}
 
 	/** @dataProvider dpParseInstructions */


### PR DESCRIPTION
This fixes a regression introduced in #1097. It was not possible to type multi-line text in instructions, ingredients, and tools fields.