### PR TITLE
Removed api routes as announced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Removed
+- Remove the deprecated endpoints from version 0.9.15
+  [#1200](https://github.com/nextcloud/cookbook/pull/1200) @christianlupus
 
 
 ## 0.9.15 - 2022-09-08

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -55,24 +55,6 @@ return [
 		['name' => 'config_api#config', 'url' => '/api/v1/config', 'verb' => 'POST'],
 		['name' => 'config_api#reindex', 'url' => '/api/v1/reindex', 'verb' => 'POST'],
 
-		// DEPRECATED ROUTES
-		// These routes are here only to avoid breaking the current 3rd party apps. They will be removed with the next release.
-
-		['name' => 'recipe_api#import', 'url' => '/import', 'verb' => 'POST', 'postfix' => '_legacy'],
-		['name' => 'recipe_api#image', 'url' => '/recipes/{id}/image', 'verb' => 'GET', 'requirements' => ['id' => '\d+'], 'postfix' => '_legacy'],
-		['name' => 'recipe_api#category', 'url' => '/api/category/{category}', 'verb' => 'GET', 'postfix' => '_legacy'],
-		['name' => 'recipe_api#tags', 'url' => '/api/tags/{keywords}', 'verb' => 'GET', 'postfix' => '_legacy'],
-		['name' => 'recipe_api#search', 'url' => '/api/search/{query}', 'verb' => 'GET', 'postfix' => '_legacy'],
-
-		['name' => 'keyword_api#keywords', 'url' => '/keywords', 'verb' => 'GET', 'postfix' => '_legacy'],
-
-		['name' => 'category_api#categories', 'url' => '/categories', 'verb' => 'GET', 'postfix' => '_legacy'],
-		['name' => 'category_api#rename', 'url' => '/api/category/{category}', 'verb' => 'PUT', 'postfix' => '_legacy'],
-
-		['name' => 'config_api#list', 'url' => '/config', 'verb' => 'GET', 'postfix' => '_legacy'],
-		['name' => 'config_api#config', 'url' => '/config', 'verb' => 'POST', 'postfix' => '_legacy'],
-		['name' => 'config_api#reindex', 'url' => '/reindex', 'verb' => 'POST', 'postfix' => '_legacy'],
-
 		// Preflight option for CORS API
 		['name' => 'util_api#preflighted_cors', 'url' => '/api/{path}', 'verb' => 'OPTIONS', 'requirements' => ['path' => '.+']],
 	],

--- a/docs/dev/api/changelog/0.md
+++ b/docs/dev/api/changelog/0.md
@@ -8,6 +8,11 @@ This serves only for developers to find the changes better.
 
 ## Unpublished
 
+### Remove deprecated endpoints
+The duplicated (deprecated) endpoints in v0.9.15 are removed.
+Any endpoints not under `/webapp/` or `/api/v1/` are no longer working.
+See also [the section](#split-and-rename-api-endpoints).
+
 
 ## Version 0.1.0 - cookbook v0.9.15 - 2022-09-08
 


### PR DESCRIPTION
This finished the migration of the api endpoints. All deprecated API endpoints are finally removed.