### PR TITLE
Create docker images for databases

### DIFF
--- a/.github/actions/run-tests/test_runner/docker_management.py
+++ b/.github/actions/run-tests/test_runner/docker_management.py
@@ -11,12 +11,19 @@ def pullImages(args, quiet=True):
 	p.pr.run(cmd).check_returncode()
 
 	imageName = 'nextcloudcookbook/testci:php{version}'.format(version=args.php_version[0])
-	cmd = ['docker', 'pull', '--quiet', imageName]
-	if not quiet:
-		cmd = [x for x in cmd if x != '--quiet']
-	sp = p.pr.run(cmd)
-	if sp.returncode == 0:
-		p.pr.run(['docker', 'tag', imageName, 'cookbook_unittesting_dut'])
+
+	def runPull(localName, remoteName):
+		quietPart = ['--quiet'] if quiet else []
+		cmdPull = ['docker', 'pull'] + quietPart + [remoteName]
+		pull = p.pr.run(cmdPull)
+		if pull.returncode == 0:
+			p.pr.run(['docker', 'tag', remoteName, localName])
+		else:
+			l.logger.printWarning('Failure loading upstream docker image.')
+
+	runPull('cookbook_unittesting_dut', imageName)
+	runPull('cookbook_unittesting_mysql', 'nextcloudcookbook/mariadb-test:latest')
+	runPull('cookbook_unittesting_postgres', 'nextcloudcookbook/postgres-test:latest')
 
 	l.logger.printTask('Pulling images finished')
 

--- a/.github/actions/run-tests/test_runner/docker_management.py
+++ b/.github/actions/run-tests/test_runner/docker_management.py
@@ -46,9 +46,25 @@ def pushImages(args):
 		'docker', 'tag', 'cookbook_unittesting_dut', pushedName
 	]).check_returncode()
 
+	p.pr.run([
+		'docker', 'tag', 'cookbook_unittesting_mysql', 'nextcloudcookbook/mariadb-test:latest'
+	]).check_returncode()
+
+	p.pr.run([
+		'docker', 'tag', 'cookbook_unittesting_postgres', 'nextcloudcookbook/postgres-test:latest'
+	]).check_returncode()
+
 	l.logger.printTask('Pushing docker images to repository')
 	p.pr.run([
 		'docker', 'push', pushedName
+	]).check_returncode()
+
+	p.pr.run([
+		'docker', 'push', 'nextcloudcookbook/mariadb-test:latest'
+	]).check_returncode()
+
+	p.pr.run([
+		'docker', 'push', 'nextcloudcookbook/postgres-test:latest'
 	]).check_returncode()
 
 def handleDockerImages(args):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Fix API endpoint helpers to enforce JSON answers and minor styling enhancements
   [#1202](https://github.com/nextcloud/cookbook/pull/1202) @christianlupus
 
+### Maintenance
+- Use the pre-built database images for MySQL and PostgreSQL tests
+  [#1204](https://github.com/nextcloud/cookbook/pull/1204) @christianlupus
+
 ### Removed
 - Remove the deprecated endpoints from version 0.9.15
   [#1200](https://github.com/nextcloud/cookbook/pull/1200) @christianlupus


### PR DESCRIPTION
This will create and use the docker images for MySQL and PostgreSQL with eatmydata enabled. This should speed up the CI tests a bit.