### PR TITLE
Prepare uml diagram generation during Jekyll build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,13 +40,13 @@ jobs:
         id: count-plantuml
         run: |
           count=$(find docs/ -name \*.puml | wc -l)
-          echo "There are $count number of plantuml files"
+          echo "There are $count plantuml files"
           echo "::set-output name=num::$count"
       - name: Install PlantUML on demand
         if: steps.count-plantuml.outputs.num > 0
         run: |
-          apt-get update
-          apt-get install --no-install-recommends plantuml
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y plantuml
       - name: Build PlantUML images
         if: steps.count-plantuml.outputs.num > 0
         run: make -C docs build-uml-svg

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,10 @@ concurrency:
   group: "pages"
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Build job
   build:
@@ -31,6 +35,22 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Pages
         uses: actions/configure-pages@v2
+
+      - name: Count number of plantuml files
+        id: count-plantuml
+        run: |
+          count=$(find docs/ -name \*.puml | wc -l)
+          echo "There are $count number of plantuml files"
+          echo "::set-output name=num::$count"
+      - name: Install PlantUML on demand
+        if: steps.count-plantuml.outputs.num > 0
+        run: |
+          apt-get update
+          apt-get install --no-install-recommends plantuml
+      - name: Build PlantUML images
+        if: steps.count-plantuml.outputs.num > 0
+        run: make -C docs build-uml-svg
+
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   [#1224](https://github.com/nextcloud/cookbook/pull/1224) @christianlupus
 - Remove obsolete code from Recipe service class
   [#1226](https://github.com/nextcloud/cookbook/pull/1226) @christianlupus
+- Allow for PlantUML diagrams in documentation
+  [#1229](https://github.com/nextcloud/cookbook/pull/1229) @christianlupus
 
 ### Removed
 - Remove the deprecated endpoints from version 0.9.15

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,10 +2,13 @@
 BUNDLER=bundler
 HOST=127.0.0.1
 
+PLANTUML_SRC=$(shell find -name \*.puml ! -path ./_site/\*)
+PLANTUML_DST_SVG=${PLANTUML_SRC:%.puml=%.svg}
+
 .PHONY: all
 all: help
 
-.PHONY: help watch build install
+.PHONY: help watch build install build-uml-svg
 
 help:
 	@echo "Make tragets supported:"
@@ -23,3 +26,15 @@ watch:
 install:
 	${BUNDLER} install
 
+build-uml-svg:
+ifeq ($(strip ${PLANTUML_SRC}),)
+	@echo 'No plantuml files were found. Skipping.'
+else
+	${MAKE} ${PLANTUML_DST_SVG}
+endif
+
+%.svg: %.puml
+	plantuml -tsvg $<
+
+%.png: %.puml
+	plantuml -tpng $<


### PR DESCRIPTION
The build process for the GitHub pages should contain an action to check for plantuml files and compile them in a prestep. This should allow simpler documentation generation.