### PR TITLE
Create an app configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 - Allow import of recipes with HowToSections
   [#1255](https://github.com/nextcloud/cookbook/pull/1255) @christianlupus
 
+### Changed
+- Add an app configuration (settings modal) to replace the one in the sidebar
+  [#1258](https://github.com/nextcloud/cookbook/pull/1258) @MarcelRobitaille
+
 
 ## 0.9.17 - 2022-10-31
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nextcloud/event-bus": "3.0.2",
     "@nextcloud/moment": "^1.1.1",
     "@nextcloud/router": "^2.0.0",
-    "@nextcloud/vue": "^7.0.1",
+    "@nextcloud/vue": "^7.1.0",
     "caret-pos": "2.0.0",
     "linkifyjs": "^4.0.0",
     "lozad": "^1.16.0",

--- a/src/components/AppMain.vue
+++ b/src/components/AppMain.vue
@@ -16,6 +16,7 @@
             />
         </NcAppContent>
         <dialogs-wrapper></dialogs-wrapper>
+        <SettingsDialog />
     </NcContent>
 </template>
 
@@ -26,6 +27,7 @@ import NcContent from "@nextcloud/vue/dist/Components/NcContent"
 import AppControls from "cookbook/components/AppControls/AppControls.vue"
 import { emit, subscribe, unsubscribe } from "@nextcloud/event-bus"
 import AppNavi from "./AppNavi.vue"
+import SettingsDialog from "./SettingsDialog.vue"
 
 export default {
     name: "AppMain",
@@ -33,6 +35,7 @@ export default {
         NcAppContent,
         AppControls,
         AppNavi,
+        SettingsDialog,
         // eslint-disable-next-line vue/no-reserved-component-names
         NcContent,
     },

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -73,15 +73,18 @@
         </template>
 
         <template slot="footer">
-            <AppSettings
-                :scanning-library="scanningLibrary"
-                @reindex="reindex"
+            <NcAppNavigationNew
+                :text="t('cookbook', 'Cookbook settings')"
+                :button-class="['create', 'icon-settings']"
+                @click="handleOpenSettings"
             />
         </template>
     </NcAppNavigation>
 </template>
 
 <script>
+import { emit } from "@nextcloud/event-bus"
+
 import NcActionInput from "@nextcloud/vue/dist/Components/NcActionInput"
 import NcAppNavigation from "@nextcloud/vue/dist/Components/NcAppNavigation"
 import NcAppNavigationItem from "@nextcloud/vue/dist/Components/NcAppNavigationItem"
@@ -96,7 +99,7 @@ import api from "cookbook/js/api-interface"
 import helpers from "cookbook/js/helper"
 import { showSimpleAlertModal } from "cookbook/js/modals"
 
-import AppSettings from "./AppSettings.vue"
+import { SHOW_SETTINGS_EVENT } from "./SettingsDialog.vue"
 import AppNavigationCaption from "./AppNavigationCaption.vue"
 
 export default {
@@ -107,7 +110,6 @@ export default {
         NcAppNavigationItem,
         NcAppNavigationNew,
         NcCounterBubble,
-        AppSettings,
         AppNavigationCaption,
         PlusIcon,
     },
@@ -118,7 +120,6 @@ export default {
             downloading: false,
             isCategoryUpdating: [],
             loading: { categories: true },
-            scanningLibrary: false,
             uncatRecipes: 0,
         }
     },
@@ -345,40 +346,6 @@ export default {
         },
 
         /**
-         * Reindex all recipes
-         */
-        reindex() {
-            this.$log.debug("Calling reindex")
-            const $this = this
-            if (this.scanningLibrary) {
-                // No repeat clicks until we're done
-                return
-            }
-            this.scanningLibrary = true
-            api.recipes
-                .reindex()
-                .then(() => {
-                    $this.scanningLibrary = false
-                    // eslint-disable-next-line no-console
-                    console.log("Library reindexing complete")
-                    if (
-                        ["index", "search"].indexOf(this.$store.state.page) > -1
-                    ) {
-                        // This refreshes the current router view in case items in it changed during reindex
-                        $this.$router.go()
-                    } else {
-                        this.$log.debug("Calling getCategories from reindex")
-                        $this.getCategories()
-                    }
-                })
-                .catch(() => {
-                    $this.scanningLibrary = false
-                    // eslint-disable-next-line no-console
-                    console.log("Library reindexing failed!")
-                })
-        },
-
-        /**
          * Set loading recipe index to show the loading icon
          */
         setLoadingRecipe(id) {
@@ -392,6 +359,10 @@ export default {
             this.$store.dispatch("setAppNavigationVisible", {
                 isVisible: !this.$store.state.appNavigation.visible,
             })
+        },
+
+        handleOpenSettings() {
+            emit(SHOW_SETTINGS_EVENT)
         },
     },
 }

--- a/src/components/SettingsDialog.vue
+++ b/src/components/SettingsDialog.vue
@@ -6,6 +6,7 @@
         first-selected-section="keyboard shortcuts"
     >
         <NcAppSettingsSection
+            id="settings-recipe-folder"
             :title="t('cookbook', 'Recipe folder')"
             class="app-settings-section"
         >
@@ -46,6 +47,7 @@
             </fieldset>
         </NcAppSettingsSection>
         <NcAppSettingsSection
+            id="settings-recipe-display"
             :title="t('cookbook', 'Recipe display settings')"
             class="app-settings-section"
         >

--- a/src/components/SettingsDialog.vue
+++ b/src/components/SettingsDialog.vue
@@ -276,6 +276,8 @@ export default {
 </script>
 
 <style scoped>
+/* TODO: Use @nextcloud/vue LoadingIcon once we update to 7.0.0 and we won't
+ * have to do this */
 .material-design-icon.loading-icon ::v-deep svg {
     animation: rotate var(--animation-duration, 0.8s) linear infinite;
     color: var(--color-loading-dark);

--- a/src/components/SettingsDialog.vue
+++ b/src/components/SettingsDialog.vue
@@ -278,7 +278,7 @@ export default {
 <style scoped>
 /* TODO: Use @nextcloud/vue LoadingIcon once we update to 7.0.0 and we won't
  * have to do this */
-.material-design-icon.loading-icon ::v-deep svg {
+.material-design-icon.loading-icon:deep(svg) {
     animation: rotate var(--animation-duration, 0.8s) linear infinite;
     color: var(--color-loading-dark);
 }

--- a/src/components/SettingsDialog.vue
+++ b/src/components/SettingsDialog.vue
@@ -12,7 +12,7 @@
             <fieldset>
                 <ul>
                     <li>
-                        <NcButton @click="$emit('reindex')">
+                        <NcButton @click="reindex">
                             <template #icon>
                                 <LoadingIcon v-if="scanningLibrary" />
                                 <ReloadIcon v-else />


### PR DESCRIPTION
Fixes #1067

Move the AppNavigationSettings from the sidebar to a AppSettingsDialog modal that covers the screen.

This is what it should look like:

![image](https://user-images.githubusercontent.com/8503756/196308672-f745e419-eecf-46dc-b97e-cd7e7b81cba2.png)

This makes it easy for us to add more configuration options for things like notifications and alarms without cluttering the sidebar.