### PR TITLE
Disable webpack bundle analyzer plugin by default to speed up development cycle

### DIFF
--- a/.github/workflows/pull-checks.yml
+++ b/.github/workflows/pull-checks.yml
@@ -139,7 +139,7 @@ jobs:
 
                     if [ $(git diff --name-only package.json | wc -l) -gt 0 ]; then
                     echo '::error file=package.json::The package.json file is not validly formatted.'
-                    echo '::notice::It is suggested to run `npm run package/lint`.'
+                    echo '::notice::It is suggested to run `npm run package-lint` and commit locally.'
                     exit 1
                     fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - Allow for PlantUML diagrams in documentation
   [#1229](https://github.com/nextcloud/cookbook/pull/1229) @christianlupus
 - Remove deprecated `::v-deep` CSS syntax @christianlupus
+- Disable webpack bundle analyzer plugin by default to speed up development cycle
+  [#1263](https://github.com/nextcloud/cookbook/pull/1263) @MarcelRobitaille
 
 ### Documentation
 - Fix bad writing

--- a/docs/dev/frontend/webpack-bundle-analyzer.md
+++ b/docs/dev/frontend/webpack-bundle-analyzer.md
@@ -4,7 +4,7 @@ The Webpack Bundle Analyzer Plugin is installed as a development dependency (see
 
 ## Usage
 
-The interactive view of the treemap is available at `http://localhost:8888` while running `npm run dev` in the terminal.
+The interactive view of the treemap is available at `http://localhost:8888` while running `npm run build-bundle-analyzer` in the terminal.
 
 ![Bundle Analyzer example](assets/webpack-bundle-analyzer_example.png)
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "main": "src/main.js",
   "scripts": {
     "build": "npx webpack --node-env production --progress --config webpack.config.js",
-    "build-dev": "npx webpack --node-env development --progress --config webpack.devel.js",
     "build-bundle-analyzer": "npx webpack --node-env development --progress --config webpack.devel.js --env BUNDLE_ANALYZER=true",
+    "build-dev": "npx webpack --node-env development --progress --config webpack.devel.js",
     "dev": "npx webpack --node-env development --progress --watch --config webpack.devel.js",
     "eslint": "npx eslint --cache --cache-strategy content 'src/**/*.{vue,js}'",
     "eslint-fix": "npx eslint --cache --cache-strategy content --fix 'src/**/*.{vue,js}'",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "npx webpack --node-env production --progress --config webpack.config.js",
     "build-dev": "npx webpack --node-env development --progress --config webpack.devel.js",
+    "build-bundle-analyzer": "npx webpack --node-env development --progress --config webpack.devel.js --env BUNDLE_ANALYZER=true",
     "dev": "npx webpack --node-env development --progress --watch --config webpack.devel.js",
     "eslint": "npx eslint --cache --cache-strategy content 'src/**/*.{vue,js}'",
     "eslint-fix": "npx eslint --cache --cache-strategy content --fix 'src/**/*.{vue,js}'",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "src/main.js",
   "scripts": {
     "build": "npx webpack --node-env production --progress --config webpack.config.js",
-    "build-dev": "npx webpack --node-env development --progress --config webpack.config.js",
+    "build-dev": "npx webpack --node-env development --progress --config webpack.devel.js",
     "dev": "npx webpack --node-env development --progress --watch --config webpack.devel.js",
     "eslint": "npx eslint --cache --cache-strategy content 'src/**/*.{vue,js}'",
     "eslint-fix": "npx eslint --cache --cache-strategy content --fix 'src/**/*.{vue,js}'",

--- a/webpack.devel.js
+++ b/webpack.devel.js
@@ -6,7 +6,7 @@ module.exports = (env) => merge(base(env), {
     plugins: env.BUNDLE_ANALYZER ? [
         new BundleAnalyzerPlugin(
             {
-                openAnalyzer: false,
+                openAnalyzer: true,
             }
         )
     ] : [],

--- a/webpack.devel.js
+++ b/webpack.devel.js
@@ -3,11 +3,11 @@ const base = require('./webpack.config.js')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 
 module.exports = (env) => merge(base(env), {
-    plugins: [
+    plugins: env.BUNDLE_ANALYZER ? [
         new BundleAnalyzerPlugin(
             {
                 openAnalyzer: false,
             }
         )
-    ],
+    ] : [],
 })


### PR DESCRIPTION
The bundle analyzer plugin is very slow. When I am running with `npm run dev`, this plugin takes a few seconds after each compile. This really slows down the code-test loop for no reason (I think 99% of the time, we are fixing bugs and adding new features, not optimizing the bundle). Therefore, this PR disables this plugin by default, and adds another npm script to build with this plugin enabled.

I also fixed `npm run build-dev` using `webpack.config.js` instead of `webpack.devel.js`, which I think was a mistake.

In summary:
- `npm run build` is unchanged
- `npm run build-dev` now uses `webpack.devel.js` and the bundle analyzer plugin is **disabled**
- `npm run build-bundle-analyzer` is a new script that uses `webpack.devel.js` and the bundle analyzer plugin is **enabled**
- `npm run dev` has the bundle analyzer plugin is **disabled**