### PR TITLE
Add network logging for responses, not only requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   [#1442](https://github.com/nextcloud/cookbook/pull/1442) @christianlupus
 - Reorder arrows are no longer hidden
   [#1446](https://github.com/nextcloud/cookbook/pull/1446) @christianlupus
+- Add network logging for responses, not only requests
+  [1405](https://github.com/nextcloud/cookbook/pull/1405) @MarcelRobitaille
 
 ### Maintenance
 - Update dependency for GitHub pages builder

--- a/src/js/api-interface.js
+++ b/src/js/api-interface.js
@@ -10,17 +10,28 @@ const baseUrl = `${generateUrl("apps/cookbook")}/webapp`
 // Add a debug log for every request
 instance.interceptors.request.use((config) => {
     Vue.$log.debug(
-        `Making "${config.method}" request to "${config.url}"`,
+        `[axios] Making "${config.method}" request to "${config.url}"`,
         config
     )
     const contentType = config.headers[config.method]["Content-Type"]
     if (!["application/json", "text/json"].includes(contentType)) {
         Vue.$log.warn(
-            `Request to "${config.url}" is using Content-Type "${contentType}", not JSON`
+            `[axios] Request to "${config.url}" is using Content-Type "${contentType}", not JSON`
         )
     }
     return config
 })
+
+instance.interceptors.response.use(
+    (response) => {
+        Vue.$log.debug("[axios] Received response", response)
+        return response
+    },
+    (error) => {
+        Vue.$log.warn("[axios] Received error", error)
+        return Promise.reject(error)
+    }
+)
 
 axios.defaults.headers.common.Accept = "application/json"
 


### PR DESCRIPTION
Fixes #1185 

Related to #1283 

Adds logging for network responses as well as network requests. With this, all the features requested in #1185 are implemented.