### PR TITLE
Add browser notification support to timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+- Add browser notification support for timers
+  [1409](https://github.com/nextcloud/cookbook/pull/1409) @MarcelRobitaille
+
 ### Fixed
 - Make "None" category string translatable
   [1323](https://github.com/nextcloud/cookbook/pull/1344) @seyfeb

--- a/src/components/RecipeTimer.vue
+++ b/src/components/RecipeTimer.vue
@@ -63,6 +63,9 @@ export default {
             this.resetTimeDisplay()
         },
     },
+    async created() {
+        this.notificationPermission = await Notification.requestPermission()
+    },
     mounted() {
         this.resetTimeDisplay()
         // Start loading the sound early so it's ready to go when we need to
@@ -92,12 +95,20 @@ export default {
                 // Start playing audio to alert the user that the timer is up
                 this.audio.play()
 
-                await showSimpleAlertModal(t("cookbook", "Cooking time is up!"))
+                const message = t("cookbook", "Cooking time is up!")
+
+                if (this.notificationPermission === "granted") {
+                    const notification = new Notification(message)
+                    notification.addEventListener("error", (error) => {
+                        // eslint-disable-next-line no-console
+                        console.error("Error showing notification:", error)
+                    })
+                }
+
+                await showSimpleAlertModal(message)
 
                 // Stop audio after the alert is confirmed
                 this.audio.pause()
-
-                // cookbook.notify(t('cookbook', 'Cooking time is up!'))
                 $this.countdown = null
                 $this.showFullTime = false
                 $this.resetTimeDisplay()

--- a/src/components/SimpleAlertModal.vue
+++ b/src/components/SimpleAlertModal.vue
@@ -1,7 +1,8 @@
 <template>
     <NcModal :title="title" @close="$close">
         <div class="modal__wrapper">
-            <div class="modal__content">{{ content }}</div>
+            <div v-if="!multiline" class="modal__content">{{ content }}</div>
+            <p v-else v-for="line in content" class="modal__content">{{ line }}</p>
             <div class="modal__button-bar">
                 <NcButton type="primary" @click="$close">{{
                     t("cookbook", "Dismiss")
@@ -20,6 +21,11 @@ export default {
     components: {
         NcModal,
         NcButton,
+    },
+    computed: {
+        multiline() {
+            return Array.isArray(this.content)
+        },
     },
 }
 </script>

--- a/src/js/browser_notifications.js
+++ b/src/js/browser_notifications.js
@@ -1,0 +1,38 @@
+import { showSimpleAlertModal } from "cookbook/js/modals"
+
+export const requestPermission = async ({ justification }) => {
+
+    // Exit early if browser doesn't support notifications
+    if (!("Notification" in window)) {
+        return
+    }
+
+    // Exit early if already granted
+    if (Notification.permission === 'granted') {
+        return
+    }
+
+    await showSimpleAlertModal(justification)
+    await Notification.requestPermission()
+}
+
+export const notify = async (title, options) => {
+
+    // Exit early if browser doesn't support notifications
+    if (!("Notification" in window)) {
+        return
+    }
+
+    // Try one more time to get permission (maybe the caller forgot to call
+    // requestPermission first)
+    // If it's still not granted, exit early
+    if (Notification.permission !== 'granted' && (await Notification.requestPermission() !== 'granted')) {
+        return
+    }
+
+    const notification = new Notification(title, options)
+    notification.addEventListener("error", (error) => {
+        // eslint-disable-next-line no-console
+        console.error("Error showing notification:", error)
+    })
+}


### PR DESCRIPTION
Fixes #1064

In addition to showing a popup dialog, also send a browser notification.

I am also working on a UI to enable/disable different alert methods as discussed in #1064. I am also working on Nextcloud / push notifications as discussed in #1129. I wonder if these could be rolled in here.

I think the UI to enable/disable alert methods could be its own issue that depends on #1064 and #1129, but maybe these shouldn't be published in a release until the possibility to turn them off is added. What do you think?