### PR TITLE
Fix of the build environment and the import Vue component

### DIFF
--- a/.github/actions/deploy/appinfo/info.xml.dist
+++ b/.github/actions/deploy/appinfo/info.xml.dist
@@ -20,7 +20,7 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/cookbook/stable/img/screenshot2.png</screenshot>
     <dependencies>
         <php min-version="7.4"/>
-        <nextcloud min-version="25" max-version="25"/>
+        <nextcloud min-version="25" max-version="26"/>
     </dependencies>
     <navigations>
         <navigation>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@
 ### Fixed
 - Make "None" category string translatable
   [#1323](https://github.com/nextcloud/cookbook/pull/1344) @seyfeb
+- Import was no longer possible as the handling of native events caused a glitch
+  [#1442](https://github.com/nextcloud/cookbook/pull/1442) @christianlupus
 
 ### Maintenance
 - Update dependency for GitHub pages builder
 - Fix package.json sort order
 - Migrate the dev environment to [docker-dev by Julius Haertl](https://github.com/juliushaertl/nextcloud-docker-dev)
   [#1440](https://github.com/nextcloud/cookbook/pull/1440) @christianlupus
+- Fix the build environment after regression
+  [#1442](https://github.com/nextcloud/cookbook/pull/1442) @christianlupus
 
 ## Documentation
 - Fixed some issues in the API description

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/cookbook/stable/img/screenshot2.png</screenshot>
     <dependencies>
         <php min-version="7.4"/>
-        <nextcloud min-version="25" max-version="25"/>
+        <nextcloud min-version="25" max-version="26"/>
     </dependencies>
     <navigations>
         <navigation>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "vuex": "^3.1.3"
       },
       "devDependencies": {
+        "@nextcloud/browserslist-config": "^2.3.0",
         "@nextcloud/stylelint-config": "^2.1.2",
         "@nextcloud/webpack-vue-config": "^5.3.0",
         "check-peer-dependencies": "^4.1.0",
@@ -638,6 +639,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/@nextcloud/browserslist-config": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/browserslist-config/-/browserslist-config-2.3.0.tgz",
+      "integrity": "sha512-1Tpkof2e9Q0UicHWahQnXXrubJoqyiaqsH9G52v3cjGeVeH3BCfa1FOa41eBwBSFe2/Jxj/wCH2YVLgIXpWbBg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0",
+        "npm": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@nextcloud/calendar-js": {
@@ -10785,6 +10796,12 @@
           "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw=="
         }
       }
+    },
+    "@nextcloud/browserslist-config": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/browserslist-config/-/browserslist-config-2.3.0.tgz",
+      "integrity": "sha512-1Tpkof2e9Q0UicHWahQnXXrubJoqyiaqsH9G52v3cjGeVeH3BCfa1FOa41eBwBSFe2/Jxj/wCH2YVLgIXpWbBg==",
+      "dev": true
     },
     "@nextcloud/calendar-js": {
       "version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "vuex": "^3.1.3"
   },
   "devDependencies": {
+    "@nextcloud/browserslist-config": "^2.3.0",
     "@nextcloud/stylelint-config": "^2.1.2",
     "@nextcloud/webpack-vue-config": "^5.3.0",
     "check-peer-dependencies": "^4.1.0",

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -16,6 +16,7 @@
                 :disabled="downloading ? 'disabled' : null"
                 :icon="downloading ? 'icon-loading-small' : 'icon-download'"
                 @submit="downloadRecipe"
+                @update:value="updateUrl"
             >
                 {{ t("cookbook", "Download recipe from URL") }}
             </NcActionInput>
@@ -121,6 +122,7 @@ export default {
             isCategoryUpdating: [],
             loading: { categories: true },
             uncatRecipes: 0,
+            importUrl: "",
         }
     },
     computed: {
@@ -232,14 +234,17 @@ export default {
             }
         },
 
+        updateUrl(e) {
+            this.importUrl = e
+        },
         /**
          * Download and import the recipe at given URL
          */
-        async downloadRecipe(e) {
+        async downloadRecipe() {
             this.downloading = true
             const $this = this
             try {
-                const response = await api.recipes.import(e.target[1].value)
+                const response = await api.recipes.import(this.importUrl)
                 const recipe = response.data
                 $this.downloading = false
                 helpers.goTo(`/recipe/${recipe.id}`)


### PR DESCRIPTION
The import did no longer work. This was caused by handling of native events in the Vue app. The underlying library was updated and the event indices were wrong. Thus, it should be completely handled by Vue events.

Further, the build environment needed an update as it was missing a dependency.