### PR TITLE
Use new logging framework consistently

### DIFF
--- a/src/components/AppMain.vue
+++ b/src/components/AppMain.vue
@@ -48,7 +48,7 @@ export default {
     watch: {
         /* This is left here as an example in case the routes need to be debugged again
         '$route' (to, from) {
-            console.log(this.$window.isSameBaseRoute(from.fullPath, to.fullPath))
+            this.$log.debug(this.$window.isSameBaseRoute(from.fullPath, to.fullPath))
         },
         */
     },

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -324,8 +324,7 @@ export default {
                             continue
                         }
                         if ($this.$refs[`app-navi-cat-${i}`][0].opened) {
-                            // eslint-disable-next-line no-console
-                            console.log(
+                            this.$log.info(
                                 `Reloading recipes in ${
                                     $this.$refs[`app-navi-cat-${i}`][0].title
                                 }`

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -437,8 +437,7 @@ export default {
                 $this.allRecipes = response.data
             })
             .catch((e) => {
-                // eslint-disable-next-line no-console
-                console.log(e)
+                this.$log.error(e)
             })
             .then(() => {
                 // finally
@@ -602,22 +601,19 @@ export default {
                                 // prettier-ignore
                                 t("cookbook","Unknown answer returned from server. See logs.")
                             )
-                            // eslint-disable-next-line no-console
-                            console.log(e.response)
+                            this.$log.error(e.response)
                     }
                 } else if (e.request) {
                     await showSimpleAlertModal(
                         t("cookbook", "No answer for request was received.")
                     )
-                    // eslint-disable-next-line no-console
-                    console.log(e)
+                    this.$log.error(e)
                 } else {
                     await showSimpleAlertModal(
                         // prettier-ignore
                         t("cookbook","Could not start request to save recipe.")
                     )
-                    // eslint-disable-next-line no-console
-                    console.log(e)
+                    this.$log.error(e)
                 }
             } finally {
                 $this.$store.dispatch("setSavingRecipe", {

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -322,7 +322,7 @@ export default {
             }
 
             if (this.$store.state.recipe === null) {
-                // console.log("Recipe is null")
+                this.$log.debug("Recipe is null")
                 return recipe
             }
 
@@ -452,9 +452,9 @@ export default {
     },
     watch: {
         recipe(r) {
-            // console.log('Recipe has been updated')
+            this.$log.debug('Recipe has been updated')
             if (r) {
-                // console.log("Recipe", r)
+                this.$log.debug("Recipe", r)
 
                 if (r.description) {
                     this.parsedDescription = t("cookbook", "Loading…")
@@ -475,8 +475,7 @@ export default {
                                 this.parsedIngredients.splice(idx, 1, x)
                             })
                             .catch((ex) => {
-                                // eslint-disable-next-line no-console
-                                console.log(ex)
+                                this.$log.error(ex)
                             })
                     })
                 } else {
@@ -493,8 +492,7 @@ export default {
                                 this.parsedInstructions.splice(idx, 1, x)
                             })
                             .catch((ex) => {
-                                // eslint-disable-next-line no-console
-                                console.log(ex)
+                                this.$log.error(ex)
                             })
                     })
                 } else {
@@ -511,8 +509,7 @@ export default {
                                 this.parsedTools.splice(idx, 1, x)
                             })
                             .catch((ex) => {
-                                // eslint-disable-next-line no-console
-                                console.log(ex)
+                                this.$log.error(ex)
                             })
                     })
                 } else {

--- a/src/components/SettingsDialog.vue
+++ b/src/components/SettingsDialog.vue
@@ -252,8 +252,7 @@ export default {
                 .reindex()
                 .then(() => {
                     $this.scanningLibrary = false
-                    // eslint-disable-next-line no-console
-                    console.log("Library reindexing complete")
+                    this.$log.info("Library reindexing complete")
                     if (
                         ["index", "search"].indexOf(this.$store.state.page) > -1
                     ) {
@@ -265,8 +264,7 @@ export default {
                 })
                 .catch(() => {
                     $this.scanningLibrary = false
-                    // eslint-disable-next-line no-console
-                    console.log("Library reindexing failed!")
+                    this.$log.error("Library reindexing failed!")
                 })
         },
 


### PR DESCRIPTION
Replace all instances of `console.log` and alternatives with `this.$log.info` or `Vue.$log.info`.

In #1404, I noticed that although a logging framework was added in #1283, `console.log` and `console.error` were still used frequently throughout the app. This PR aims to replace all of these with the logging framework.