### PR TITLE
Add quick start guide for backend testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Fixed some issues in the API description
 - Fix security issue in GitHub pages with path insertion
   [#1457](https://github.com/nextcloud/cookbook/pull/1457) @christianlupus
+- Add quick start guide for backend testing
+  [#1466](https://github.com/nextcloud/cookbook/pull/1466) @MarcelRobitaille
 
 
 ## 0.10.1 - 2022-11-09

--- a/docs/dev/misc/automated-testing/index.md
+++ b/docs/dev/misc/automated-testing/index.md
@@ -22,9 +22,12 @@ The [overview of the backend testing framework](backend/) should give a general 
 These instructions will help you quickly get set up for testing using the default options.
 If you would like to learn more or use non-default options, you may read [Overview over the backend testing implementation](./backend/index.md).
 
-1. Open testing directory: `cd .github/actions/run-tests/`.
 1. Install [Docker](https://www.docker.com/) (e.g. `sudo apt install docker`). Nextcloud will be installed in Docker for testing.
+1. Install [PHP](https://www.php.net/) and some extensions: `sudo apt install php php-zip php-xml`
+1. Install [Composer](https://getcomposer.org/), the PHP package manager (e.g. `sudo apt install composer`)
 1. Although this app is written in PHP and JavaScript, the test helpers are written in Python. Please [install Python 3](https://www.python.org/downloads/).
+1. Install PHP dependencies: `composer install`
+1. Open testing directory: `cd .github/actions/run-tests/`.
 1. Create a Python virtual environment: `python -m venv venv`.
 1. Activate the virtual environment: `source venv/bin/activate`.
 1. Install Python dependencies: `pip install -r ./requirements.txt`.

--- a/docs/dev/misc/automated-testing/index.md
+++ b/docs/dev/misc/automated-testing/index.md
@@ -17,6 +17,21 @@ This will provide you with a list of options the script understands.
 So allow any future enhancements and bug tracking, there is some sort of documentation in place.
 The [overview of the backend testing framework](backend/) should give a general idea of the involved steps.
 
+### Quick start
+
+These instructions will help you quickly get set up for testing using the default options.
+If you would like to learn more or use non-default options, you may read [Overview over the backend testing implementation](./backend/index.md).
+
+1. Open testing directory: `cd .github/actions/run-tests/`.
+1. Install [Docker](https://www.docker.com/) (e.g. `sudo apt install docker`). Nextcloud will be installed in Docker for testing.
+1. Although this app is written in PHP and JavaScript, the test helpers are written in Python. Please [install Python 3](https://www.python.org/downloads/).
+1. Create a Python virtual environment: `python -m venv venv`.
+1. Activate the virtual environment: `source venv/bin/activate`.
+1. Install Python dependencies: `pip install -r ./requirements.txt`.
+1. Pull required Docker images: `./run-locally.py --pull`.
+1. Create a testing fixture: `./run-locally.py --create-fixture stable25 stable25`.
+1. Run the tests: `./run-locally.py --run-default-tests`.
+
 ## Frontend testing
 
 There is not yet any automated tests for the frontend in place.


### PR DESCRIPTION
The current documentation for backend testing are very detailed, but not very good for newcomers. This PR adds a quick start guide to help newcomers quickly get started with the defaults. The detailed docs are still there if the developer wants to learn more or use more advanced settings.