### PR TITLE
Add yield calculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Add yield calculator
 
 ## 0.10.2 - 2023-03-24
 

--- a/src/components/RecipeIngredient.vue
+++ b/src/components/RecipeIngredient.vue
@@ -10,6 +10,7 @@
         <div class="ingredient">
             <VueShowdown :markdown="displayIngredient" />
         </div>
+        <span v-if="!ingredientHasCorrectSyntax" class="icon-error" />
     </li>
 </template>
 
@@ -22,6 +23,9 @@ export default {
         ingredient: {
             type: String,
             default: "",
+        },
+        ingredientHasCorrectSyntax: {
+            type: Boolean,
         },
         recipeIngredientsHaveSubgroups: {
             type: Boolean,

--- a/src/components/RecipeIngredient.vue
+++ b/src/components/RecipeIngredient.vue
@@ -103,5 +103,4 @@ li > .ingredient {
 li > span.icon-error {
     margin-left: 0.3em;
 }
-
 </style>

--- a/src/components/RecipeIngredient.vue
+++ b/src/components/RecipeIngredient.vue
@@ -99,4 +99,9 @@ li > .ingredient {
 .ingredient:deep(a) {
     text-decoration: underline;
 }
+
+li > span.icon-error {
+    margin-left: 0.3em;
+}
+
 </style>

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -131,18 +131,12 @@
                             "
                         />
                     </ul>
-                    <div v-if="!ingredientsSyntaxCorrect">
+                    <div v-if="!ingredientsSyntaxCorrect" class="ingredient-parsing-error">
                         <hr />
-                        <span class="icon-error date-icon" />
+                        <span class="icon-error" />
                         {{
                             // prettier-ignore
-                            t("cookbook", "ingredient can't be recalculated due to incorrect syntax.")
-                        }}
-                        {{
-                            // prettier-ignore
-                            t("cookbook", "Please change it to this syntax: amount unit ingredient.")
-                        }}
-                        {{ t("cookbook", "Example: 1 pinch of salt") }}
+                            t("cookbook", "The ingredient cannot be recalculated due to incorrect syntax. Please change it to this syntax: amount unit ingredient. Examples: 200 g carrots or 1 pinch of salt") }}
                     </div>
                 </section>
 
@@ -991,6 +985,10 @@ main {
             grid-row: 3/4;
         }
     }
+}
+
+.ingredient-parsing-error span.icon-error {
+    display: inline-block;
 }
 </style>
 

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -131,12 +131,16 @@
                             "
                         />
                     </ul>
-                    <div v-if="!ingredientsSyntaxCorrect" class="ingredient-parsing-error">
+                    <div
+                        v-if="!ingredientsSyntaxCorrect"
+                        class="ingredient-parsing-error"
+                    >
                         <hr />
                         <span class="icon-error" />
                         {{
                             // prettier-ignore
-                            t("cookbook", "The ingredient cannot be recalculated due to incorrect syntax. Please change it to this syntax: amount unit ingredient. Examples: 200 g carrots or 1 pinch of salt") }}
+                            t("cookbook", "The ingredient cannot be recalculated due to incorrect syntax. Please change it to this syntax: amount unit ingredient. Examples: 200 g carrots or 1 pinch of salt")
+                        }}
                     </div>
                 </section>
 

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -134,9 +134,15 @@
                     <div v-if="!ingredientsSyntaxCorrect">
                         <hr />
                         <span class="icon-error date-icon" />
-                        {{ t("cookbook", "ingredient can't be recalculated due to incorrect syntax.") }}
-                        {{ t("cookbook", "Please change it to this syntax: amount unit ingredient.") }}
-                        {{ t("cookbook", "Example: 12 pinch of salt") }}
+                        {{
+                            // prettier-ignore
+                            t("cookbook", "ingredient can't be recalculated due to incorrect syntax.")
+                        }}
+                        {{
+                            // prettier-ignore
+                            t("cookbook", "Please change it to this syntax: amount unit ingredient.")
+                        }}
+                        {{ t("cookbook", "Example: 1 pinch of salt") }}
                     </div>
                 </section>
 

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -133,10 +133,10 @@
                     </ul>
                     <div v-if="!ingredientsSyntaxCorrect">
                         <hr />
-                        <span class="icon-error date-icon" /> = ingredient can't
-                        be recalculated due to incorrect syntax. Please change
-                        it to this syntax: "amount unit ingredient". Example: 1
-                        pinch of salt
+                        <span class="icon-error date-icon" />
+                        {{ t("cookbook", "ingredient can't be recalculated due to incorrect syntax.") }}
+                        {{ t("cookbook", "Please change it to this syntax: amount unit ingredient.") }}
+                        {{ t("cookbook", "Example: 12 pinch of salt") }}
                     </div>
                 </section>
 


### PR DESCRIPTION
This pull request adds a client-side yield calculator to the recipe detail page of every recipe and fixes #116 

@christianlupus I wasn't able to find "how to add translations" in the docu. It's my first contribution to a Nextcloud project and I only found a link to transifex. Can you assist/guide me here please?

The function (without translation) is ready:
![20230326_215841](https://user-images.githubusercontent.com/36242595/227801592-641b4e91-ad42-406f-af4d-d8609dbaa486.gif)

Screenshots of the mobile version:
![grafik](https://user-images.githubusercontent.com/36242595/227801514-8d3154f5-dd90-4e02-880d-67eb4acba15f.png)




