### PR TITLE
Typo fix, also to prevent escaping issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- Fix translation string to not contain quotes
+  [#1582](https://github.com/nextcloud/cookbook/pull/1582) @roliverio
 
 ## 0.10.2 - 2023-03-24
 

--- a/src/components/SettingsDialog.vue
+++ b/src/components/SettingsDialog.vue
@@ -281,7 +281,7 @@ export default {
                 // eslint-disable-next-line no-console
                 console.error("Error while trying to save info blocks", err)
                 await showSimpleAlertModal(
-                    t("cookbook", "Couldn't save visible info blocks")
+                    t("cookbook", "Could not save visible info blocks")
                 )
                 this.resetVisibleInfoBlocks = true
                 this.visibleInfoBlocks = oldVal


### PR DESCRIPTION
Replacing "Couldn't" with "Could not"