### PR TITLE
Enable webpack server in development machine from all IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Maintenance
 - Fix URL of Transifex after upstream subdomain change
   [#1598](https://github.com/nextcloud/cookbook/pull/1598) @rakekniven
+- Fix webpack dev server settings to allow for docker dev environment
+  [#1607](https://github.com/nextcloud/cookbook/pull/1607) @christianlupus
 
 
 ## 0.10.2 - 2023-03-24

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "package-lint": "npx prettier-package-json --write ./package.json",
     "prettier": "npx prettier --check src",
     "prettier-fix": "npx prettier --write src",
-    "serve": "npx webpack serve --node-env development --progress --config webpack.config.js --env dev_server",
+    "serve": "npx webpack serve --node-env development --progress --config webpack.config.js --env dev_server --allowed-hosts all",
     "stylelint": "npx stylelint src",
     "stylelint-fix": "npx stylelint --fix src",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This just allowws live reloading with the current setup in combination with Julius Haertls docker dev environment