### PR TITLE
Fix PHP versions in Docker pre-built images

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -13,10 +13,9 @@ jobs:
         strategy:
             matrix:
                 phpVersion:
-                    - "7.4"
-                    - "7.3"
                     - "8.0"
                     - "8.1"
+                    - "8.2"
                     # - "8"
         steps:
             - name: Check if secret is known

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,7 +119,7 @@ jobs:
             httpServer:
                 - "apache"
             include:
-                # Test different databses
+                # Test different databases
                 -   database: sqlite
                     coreVersion: 27
                     phpVersion: "8.1"


### PR DESCRIPTION
This just fixes the need for up to date images during CI/CD building