### PR TITLE
Revert "Removed obsolete parameters from OpenAPI specs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   [#1680](https://github.com/nextcloud/cookbook/pull/1680) @dependabot
 - Fix bug in browser console
   [#1686](https://github.com/nextcloud/cookbook/pull/1686) @christianlupus
+- Make OpenAPI specs more compatible regarding `@type`
+  [#1700](https://github.com/nextcloud/cookbook/pull/1700) @christianlupus
 
 
 ## 0.10.2 - 2023-03-24

--- a/docs/dev/api/0.1.0/objects.yaml
+++ b/docs/dev/api/0.1.0/objects.yaml
@@ -110,6 +110,10 @@ Instruction:
 Nutrition:
   type: object
   properties:
+    "@type":
+      type: string
+      example: NutritionInformation
+      description: Schema.org object description
     calories:
       type: string
       description: The number of calories for the given amount
@@ -158,6 +162,8 @@ Nutrition:
       type: string
       description: The number of grams of unsaturated fat
       example: 40 g
+  required:
+    - "@type"
 
 Recipe:
   #type: object
@@ -166,6 +172,10 @@ Recipe:
     - $ref: "#/RecipeStubInformation"
     - type: object
       properties:
+        "@type":
+          type: string
+          example: "Recipe"
+          description: Schema.org object type identifier
         id:
           type: string
           description: The index of the recipe. Note the representation as a string as the representation might change in the future.

--- a/docs/dev/api/0.1.1/objects.yaml
+++ b/docs/dev/api/0.1.1/objects.yaml
@@ -167,6 +167,11 @@ Instruction:
 Nutrition:
   type: object
   properties:
+    "@type":
+      type: string
+      example: NutritionInformation
+      description: Schema.org object description
+      default: NutritionInformation
     calories:
       type: string
       description: The number of calories for the given amount
@@ -215,6 +220,8 @@ Nutrition:
       type: string
       description: The number of grams of unsaturated fat
       example: 40 g
+  required:
+    - "@type"
 
 Recipe:
   #type: object
@@ -223,6 +230,11 @@ Recipe:
     - $ref: "#/RecipeStubInformation"
     - type: object
       properties:
+        "@type":
+          type: string
+          example: "Recipe"
+          default: Recipe
+          description: Schema.org object type identifier
         id:
           type: string
           description: The index of the recipe. Note the representation as a string as the representation might change in the future.


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

This reverts commit 07954bf2faffa5cd8bb54898a807680c06b532db.

The `@type` annotation should be still part of the OpenAPI description. Although the returned JSON objects are considered compatible with the schema.org standard, this does not mean, we should not make the implications explicit. Also, this makes reading more clean and avoid misunderstandings regarding if the `@type` is to be present or not.
## Concerns/issues

Just documentation, no effects

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
