### PR TITLE
Prevent self-hosted runners by NC company due to quota issues

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     push:
         name: Build and push the latest test images
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         
         strategy:
             matrix:

--- a/.github/workflows/deploy-appstore.yml
+++ b/.github/workflows/deploy-appstore.yml
@@ -10,7 +10,7 @@ jobs:
     
     deploy:
         name: Deploy codebase
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         
         defaults:
             run:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ defaults:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.ref == 'refs/heads/master'
     needs: build
     steps:

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test-results:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Test results
     if: >-
       github.event.workflow_run.conclusion != 'skipped' &&

--- a/.github/workflows/pull-checks.yml
+++ b/.github/workflows/pull-checks.yml
@@ -8,7 +8,7 @@ jobs:
     
     changelog:
         name: Check if the changelog was updated
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         
         steps:
             -   name: Checkout the app
@@ -49,7 +49,7 @@ jobs:
     
     todo-checker:
         name: Check for added todo messages
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             -   name: Git version output
                 run: git version
@@ -77,7 +77,7 @@ jobs:
 
     appinfo:
         name: Check for matching app info file
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         steps:
             -   name: Checkout of the app
@@ -121,7 +121,7 @@ jobs:
     
     package-lint:
         name: Make sure the package.json is well-formatted
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         steps:
             -   name: Checkout of the app

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   
   code-lint:
     name: Run PHP Linter and Code Style checker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
         -   name: Checkout the project
             uses: actions/checkout@v3
@@ -104,7 +104,7 @@ jobs:
   
   unit-tests:
     name: Run the unittests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     
     strategy:
         fail-fast: false
@@ -229,7 +229,7 @@ jobs:
   
   unit-tests-master:
     name: Run the tests against the master branch of the NC server
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     
     steps:
       - name: Checkout the app
@@ -284,7 +284,7 @@ jobs:
     name: Upload artifacts to codecov.io
     needs: 
         - unit-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
         - name: Create folder structure
@@ -373,7 +373,7 @@ jobs:
     needs:
         - unit-tests
         - code-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     
     steps:
         -   name: Checkout the app
@@ -434,7 +434,7 @@ jobs:
             
   event_file:
     name: "Upload Event File"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Upload
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR should prevent usage of the self-hosted runners provided by the NC company. These are rather restricted in terms of storage and the tests tend to fail.