### PR TITLE
chore: add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2
+indent_style = space
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.svg]
+insert_final_newline = false
+
+[package*.json]
+indent_size = 2
+indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,10 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.{vue,js}]
+indent_style = space
+indent_size = 4
+
 [*.yml]
 indent_size = 2
 indent_style = space

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@
   [#1802](https://github.com/nextcloud/cookbook/pull/1802) @christianlupus
 - Update lint config
   [#1783](https://github.com/nextcloud/cookbook/pull/1783) @dependabot
+- Add editorconfig file for better cooperation
+  [#1771](https://github.com/nextcloud/cookbook/pull/1771) @SethFalco
 
 
 ## 0.10.2 - 2023-03-24


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

When contributing to the Cookbook app, everyone has different editor settings might may conflict with the project's conventions.

For example, I use spaces over tabs so when I hit the tab key, it inserts necessary number of spaces instead.

This just copies over the `.editorconfig` from [nextcloud/server](https://github.com/nextcloud/server/blob/master/.editorconfig) so that contributors have a more seamless experience when working with the project. As the file defines that the project uses tabs, editors will know to leave tabs as-is.

I removed redundant rules, like `*.feature` and `build/psalm-baseline.xml` which aren't relevant to this repository.

## Concerns/issues

N/A

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
