### PR TITLE
chore: upgrade docs to docker compose v2

### DIFF
--- a/.github/actions/run-tests/run-locally.py
+++ b/.github/actions/run-tests/run-locally.py
@@ -13,6 +13,7 @@ if args.debug_python:
 	debugpy.wait_for_client()
 
 # print(args)
+test_runner.docker_helper.initialize(args)
 
 test_runner.ci_printer.logger = test_runner.ci_printer.CILogger(args.ci)
 

--- a/.github/actions/run-tests/test_runner/argument_parser.py
+++ b/.github/actions/run-tests/test_runner/argument_parser.py
@@ -7,6 +7,7 @@ def parseArguments():
 
 	parser.add_argument('-v', '--verbose', action='store_true', help='Do not hide the output of intermediate commands')
 	parser.add_argument('--debug-python', action='store_true', help='Activate the python debugger to develop the test environments.')
+	parser.add_argument('--use-docker-compose-legacy', action='store_true', help='Use the legacy docker-compose v1 instead of the new docker compose.')
 
 	group = parser.add_argument_group('Docker image management', 'Manage the docker images involved in the test routines.')
 

--- a/.github/actions/run-tests/test_runner/db.py
+++ b/.github/actions/run-tests/test_runner/db.py
@@ -5,26 +5,26 @@ class PostgresConnector:
 		self.user = user
 		self.password = password
 		self.db = db
-	
+
 	def getUser(self):
 		return self.user
 
 	def getDb(self):
 		return self.db
-	
+
 	def getPassword(self):
 		return self.password
-	
+
 	def callSQL(self, input, params = [], text=True, capture_output=True, stdin=None):
 		cmd = [
-			'docker-compose', 'exec', '-T', 'postgres', 'psql', '-U', self.user, self.db,
+			'docker', 'compose', 'exec', '-T', 'postgres', 'psql', '-U', self.user, self.db,
 			'-v', 'ON_ERROR_STOP=1'
 		]
 		return p.pr.run(cmd + params, text=text, input=input, capture_output=capture_output, stdin=stdin)
-	
+
 	def dumpDb(self, name):
 		cmd = [
-			'docker-compose', 'exec', '-T', 'postgres', 'pg_dump', '-U', self.user, self.db, '--clean', '--if-exists'
+			'docker', 'compose', 'exec', '-T', 'postgres', 'pg_dump', '-U', self.user, self.db, '--clean', '--if-exists'
 		]
 		with open(name, 'w') as fp:
 			p.pr.run(cmd, stdout=fp).check_returncode()
@@ -34,27 +34,27 @@ class MysqlConnector:
 		self.user = user
 		self.password = password
 		self.db = db
-	
+
 	def getUser(self):
 		return self.user
-	
+
 	def getDb(self):
 		return self.db
-	
+
 	def getPassword(self):
 		return self.password
 
 	def callSQL(self, input, params = [], text=True, capture_output=True, stdin=None):
 		cmd = [
-			'docker-compose', 'exec', '-T', 'mysql', 'mysql', '-u', self.user, 
+			'docker', 'compose', 'exec', '-T', 'mysql', 'mysql', '-u', self.user,
 			'-p{pwd}'.format(pwd=self.password), self.db
 		]
 		# print('input', input)
 		return p.pr.run(cmd + params, text=text, input=input, capture_output=capture_output, stdin=stdin)
-	
+
 	def dumpDb(self, name):
 		cmd = [
-			'docker-compose', 'exec', '-T', 'mysql', 'mysqldump', '-u', self.user,
+			'docker', 'compose', 'exec', '-T', 'mysql', 'mysqldump', '-u', self.user,
 			'-p{pwd}'.format(pwd=self.password), '--add-drop-database', '--database', self.db
 		]
 		with open(name, 'w') as fp:

--- a/.github/actions/run-tests/test_runner/db.py
+++ b/.github/actions/run-tests/test_runner/db.py
@@ -1,10 +1,12 @@
 import test_runner.proc as p
+import test_runner.docker_helper
 
 class PostgresConnector:
 	def __init__(self, user='tester', password='tester_pass', db='nc_test'):
 		self.user = user
 		self.password = password
 		self.db = db
+		self.dockerComposeCmd = test_runner.docker_helper.instance.getDockerCompose()
 
 	def getUser(self):
 		return self.user
@@ -16,15 +18,15 @@ class PostgresConnector:
 		return self.password
 
 	def callSQL(self, input, params = [], text=True, capture_output=True, stdin=None):
-		cmd = [
-			'docker', 'compose', 'exec', '-T', 'postgres', 'psql', '-U', self.user, self.db,
+		cmd = self.dockerComposeCmd + [
+			'exec', '-T', 'postgres', 'psql', '-U', self.user, self.db,
 			'-v', 'ON_ERROR_STOP=1'
 		]
 		return p.pr.run(cmd + params, text=text, input=input, capture_output=capture_output, stdin=stdin)
 
 	def dumpDb(self, name):
-		cmd = [
-			'docker', 'compose', 'exec', '-T', 'postgres', 'pg_dump', '-U', self.user, self.db, '--clean', '--if-exists'
+		cmd = self.dockerComposeCmd + [
+			'exec', '-T', 'postgres', 'pg_dump', '-U', self.user, self.db, '--clean', '--if-exists'
 		]
 		with open(name, 'w') as fp:
 			p.pr.run(cmd, stdout=fp).check_returncode()
@@ -34,6 +36,7 @@ class MysqlConnector:
 		self.user = user
 		self.password = password
 		self.db = db
+		self.dockerComposeCmd = test_runner.docker_helper.instance.getDockerCompose()
 
 	def getUser(self):
 		return self.user
@@ -45,16 +48,16 @@ class MysqlConnector:
 		return self.password
 
 	def callSQL(self, input, params = [], text=True, capture_output=True, stdin=None):
-		cmd = [
-			'docker', 'compose', 'exec', '-T', 'mysql', 'mysql', '-u', self.user,
+		cmd = self.dockerComposeCmd + [
+			'exec', '-T', 'mysql', 'mysql', '-u', self.user,
 			'-p{pwd}'.format(pwd=self.password), self.db
 		]
 		# print('input', input)
 		return p.pr.run(cmd + params, text=text, input=input, capture_output=capture_output, stdin=stdin)
 
 	def dumpDb(self, name):
-		cmd = [
-			'docker', 'compose', 'exec', '-T', 'mysql', 'mysqldump', '-u', self.user,
+		cmd = self.dockerComposeCmd + [
+			'exec', '-T', 'mysql', 'mysqldump', '-u', self.user,
 			'-p{pwd}'.format(pwd=self.password), '--add-drop-database', '--database', self.db
 		]
 		with open(name, 'w') as fp:

--- a/.github/actions/run-tests/test_runner/docker_helper.py
+++ b/.github/actions/run-tests/test_runner/docker_helper.py
@@ -1,0 +1,15 @@
+class DockerHelper:
+	def __init__(self, args):
+		self.useLegacy = args.use_docker_compose_legacy
+	
+	def getDockerCompose(self):
+		if self.useLegacy:
+			return ['docker-compose']
+		else:
+			return ['docker', 'compose']
+
+instance = None
+
+def initialize(args):
+	global instance
+	instance = DockerHelper(args)

--- a/.github/actions/run-tests/test_runner/docker_management.py
+++ b/.github/actions/run-tests/test_runner/docker_management.py
@@ -2,10 +2,14 @@ import test_runner.ci_printer
 import test_runner.timer
 import test_runner.ci_printer as l
 import test_runner.proc as p
+import test_runner.docker_helper
 
 def pullImages(args, quiet=True):
 	l.logger.printTask('Pulling pre-built images')
-	cmd = ['docker', 'compose', 'pull']
+
+	dockerComposeCmd = test_runner.docker_helper.instance.getDockerCompose()
+
+	cmd = dockerComposeCmd + ['pull']
 	if quiet:
 		cmd.append('--quiet')
 	p.pr.run(cmd).check_returncode()
@@ -30,7 +34,9 @@ def pullImages(args, quiet=True):
 def buildImages(args, pull=True):
 	l.logger.printTask('Building images')
 
-	cmd = ['docker', 'compose', 'build', '--force-rm']
+	dockerComposeCmd = test_runner.docker_helper.instance.getDockerCompose()
+
+	cmd = dockerComposeCmd + ['build', '--force-rm']
 	if pull:
 		cmd.append('--pull')
 	if args.ci:
@@ -41,7 +47,7 @@ def buildImages(args, pull=True):
 
 	p.pr.run(cmd).check_returncode()
 
-	p.pr.run(['docker', 'compose', 'build', '--pull', '--force-rm', 'mysql', 'postgres', 'www']).check_returncode()
+	p.pr.run(dockerComposeCmd + ['build', '--pull', '--force-rm', 'mysql', 'postgres', 'www']).check_returncode()
 
 	l.logger.printTask('Building images finished.')
 

--- a/.github/actions/run-tests/test_runner/docker_management.py
+++ b/.github/actions/run-tests/test_runner/docker_management.py
@@ -5,7 +5,7 @@ import test_runner.proc as p
 
 def pullImages(args, quiet=True):
 	l.logger.printTask('Pulling pre-built images')
-	cmd = ['docker-compose', 'pull']
+	cmd = ['docker', 'compose', 'pull']
 	if quiet:
 		cmd.append('--quiet')
 	p.pr.run(cmd).check_returncode()
@@ -29,8 +29,8 @@ def pullImages(args, quiet=True):
 
 def buildImages(args, pull=True):
 	l.logger.printTask('Building images')
-	
-	cmd = ['docker-compose', 'build', '--force-rm']
+
+	cmd = ['docker', 'compose', 'build', '--force-rm']
 	if pull:
 		cmd.append('--pull')
 	if args.ci:
@@ -41,7 +41,7 @@ def buildImages(args, pull=True):
 
 	p.pr.run(cmd).check_returncode()
 
-	p.pr.run(['docker-compose', 'build', '--pull', '--force-rm', 'mysql', 'postgres', 'www']).check_returncode()
+	p.pr.run(['docker', 'compose', 'build', '--pull', '--force-rm', 'mysql', 'postgres', 'www']).check_returncode()
 
 	l.logger.printTask('Building images finished.')
 
@@ -83,14 +83,14 @@ def handleDockerImages(args):
 	if args.pull or args.create_images:
 		pullImages(args, not args.verbose)
 		t.toc('Pulling done')
-	
+
 	if args.create_images:
 		pull = not args.pull_php_base_image
 		buildImages(args, pull)
 		t.toc('Building done')
-	
+
 	if args.push_images:
 		pushImages(args)
-	
+
 	l.logger.endGroup()
 	t.toc()

--- a/.github/actions/run-tests/test_runner/runner.py
+++ b/.github/actions/run-tests/test_runner/runner.py
@@ -1,6 +1,7 @@
 
 import test_runner.ci_printer as l
 import test_runner.proc as p
+import test_runner.docker_helper
 
 import os
 
@@ -9,7 +10,7 @@ class TestRunner:
 		pass
 
 	def __buildRunCmd(self, args, subArgs):
-		cmd = ['docker', 'compose', 'run', '--rm', 'dut']
+		cmd = test_runner.docker_helper.instance.getDockerCompose() + ['run', '--rm', 'dut']
 
 		if args.run_unit_tests:
 			cmd.append('--run-unit-tests')

--- a/.github/actions/run-tests/test_runner/runner.py
+++ b/.github/actions/run-tests/test_runner/runner.py
@@ -9,23 +9,23 @@ class TestRunner:
 		pass
 
 	def __buildRunCmd(self, args, subArgs):
-		cmd = ['docker-compose', 'run', '--rm', 'dut']
+		cmd = ['docker', 'compose', 'run', '--rm', 'dut']
 
 		if args.run_unit_tests:
 			cmd.append('--run-unit-tests')
-		
+
 		if args.run_integration_tests:
 			cmd.append('--run-integration-tests')
-		
+
 		if args.run_migration_tests:
 			cmd.append('--run-migration-tests')
-		
+
 		if args.extract_code_coverage:
 			cmd.append('--create-coverage-report')
-		
+
 		if args.install_composer_deps:
 			cmd.append('--install-composer-deps')
-		
+
 		if args.build_npm:
 			cmd.append('--build-npm')
 
@@ -42,7 +42,7 @@ class TestRunner:
 			modes.append('trace')
 		if args.enable_profiling:
 			modes.append('profile')
-		
+
 		return ",".join(modes)
 
 	def runTests(self, args, subArgs, db):
@@ -64,4 +64,3 @@ class TestRunner:
 		sp = p.pr.run(cmd, env=env)
 
 		return sp.returncode
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@
   [#1783](https://github.com/nextcloud/cookbook/pull/1783) @dependabot
 - Add editorconfig file for better cooperation
   [#1771](https://github.com/nextcloud/cookbook/pull/1771) @SethFalco
+- Use docker compose for tests by default
+  [#1772](https://github.com/nextcloud/cookbook/pull/1772) @SethFalco
 
 
 ## 0.10.2 - 2023-03-24

--- a/docs/dev/contributing/setup.md
+++ b/docs/dev/contributing/setup.md
@@ -9,17 +9,22 @@ First a nextcloud server is needed to run the app within.
 
 There are multiple methods to set up the Nextcloud development environment.
 
-1. The [official guide](https://docs.nextcloud.com/server/latest/developer_manual/getting_started/devenv.html) walks you through installing Nextcloud and its dependencies on bare metal.
-1. Alternatively, you can use [this Docker Compose configuration](https://github.com/juliushaertl/nextcloud-docker-dev). This method is easier in that you don't have to manually install Nextcloud, a SQL database, etc.<br>
+:warning: DO NOT USE THIS IN PRODUCTION Various settings in this setup are considered insecure and default passwords and secrets are used all over the place.
+
+1. By default, you can use [this Docker Compose configuration](https://github.com/juliushaertl/nextcloud-docker-dev). This method is easier in that you don't have to manually install Nextcloud, a SQL database, etc.<br>
     Follow the instructions in this repository, noting that the default username/password are admin/admin.<br>
-    Please pay attention to the warning from that repository:
-    > :warning: DO NOT USE THIS IN PRODUCTION Various settings in this setup are considered insecure and default passwords and secrets are used all over the place
-1. There is also [this repository](https://github.com/christianlupus/nextcloud-docker-debug) that contains a configuration using Docker Compose as well. This setup is tailored down to allow easy debugging and profiling of apps. The repository has an extensive documentation attached in form of a README file on how to setup.<br>
-    **This repository is only for development purposes. Do not use for productive usage!**
+1. Alternatively, the [official guide](https://docs.nextcloud.com/server/latest/developer_manual/getting_started/devenv.html) walks you through installing Nextcloud and its dependencies on bare metal.
 
 ## Add Cookbook to your Nextcloud environment's apps directory
 
 You must install the checked out version of the app into the corresponding folder of the nextcloud server.
+
+### Usage of [nextcloud-docker-dev](https://github.com/juliushaertl/nextcloud-docker-dev) by juliushaertl (Default)
+
+If you installed via Docker, [the volumes section of the `docker-compose.yml`](https://github.com/juliushaertl/nextcloud-docker-dev/blob/2bbf26cc257081d9ed72abc947441849fca59dcd/docker-compose.yml#L68) shows that there are many options for specifying apps.
+
+Just go with the documentation attached in the repository and follow the steps.
+This should bring you to a running environment.
 
 ### Bare metal installation
 
@@ -29,21 +34,9 @@ cd /var/www/nextcloud/apps
 git clone https://github.com/nextcloud/cookbook.git # you may want to clone your own fork if you are contributing pull requests
 ```
 
-### Usage of [nextcloud-docker-dev](https://github.com/juliushaertl/nextcloud-docker-dev) by juliushaertl
-
-If you installed via Docker, [the volumes section of the `docker-compose.yml`](https://github.com/juliushaertl/nextcloud-docker-dev/blob/2bbf26cc257081d9ed72abc947441849fca59dcd/docker-compose.yml#L68) shows that there are many options for specifying apps.
-
-The easiest way might be to add a new line in this section after cloning [`nextcloud/cookbook`](https://github.com/nextcloud/cookbook) in the same folder as [`juliushaertl/nextcloud-docker-dev`](https://github.com/juliushaertl/nextcloud-docker-dev):
-```
-- ../cookbook:/var/www/html/apps/cookbook:ro
-```
-You might need to adopt the path specification according to your local setup. Also note that docker-compose needs the correct indentation (spaces and no tabs!) to work well.
-
-Be sure to recreate the containers after modifying `docker-compose.yml` using `docker compose up -d`.
-
 ## Install PHP dependencies
 
-The app needs some depdencies in the PHP backend. These are managed via [composer](http://composer.org). Make sure, you have composer ready on your development machine.
+The app needs some dependencies in the PHP backend. These are managed via [composer](http://composer.org). Make sure, you have composer ready on your development machine.
 
 To install the required packages just run in the root of the checked-out source folder of the cookbook app
 ```

--- a/docs/dev/contributing/setup.md
+++ b/docs/dev/contributing/setup.md
@@ -14,7 +14,7 @@ There are multiple methods to set up the Nextcloud development environment.
     Follow the instructions in this repository, noting that the default username/password are admin/admin.<br>
     Please pay attention to the warning from that repository:
     > :warning: DO NOT USE THIS IN PRODUCTION Various settings in this setup are considered insecure and default passwords and secrets are used all over the place
-1. There is also [this repository](https://github.com/christianlupus/nextcloud-docker-debug) that contains a configuration using docker-compose as well. This setup is tailored down to allow easy debugging and profiling of apps. The repository has an extensive documentation attached in form of a README file on how to setup.<br>
+1. There is also [this repository](https://github.com/christianlupus/nextcloud-docker-debug) that contains a configuration using Docker Compose as well. This setup is tailored down to allow easy debugging and profiling of apps. The repository has an extensive documentation attached in form of a README file on how to setup.<br>
     **This repository is only for development purposes. Do not use for productive usage!**
 
 ## Add Cookbook to your Nextcloud environment's apps directory
@@ -39,7 +39,7 @@ The easiest way might be to add a new line in this section after cloning [`nextc
 ```
 You might need to adopt the path specification according to your local setup. Also note that docker-compose needs the correct indentation (spaces and no tabs!) to work well.
 
-Be sure to recreate the containers after modifying `docker-compose.yml` using `docker-compose up -d`.
+Be sure to recreate the containers after modifying `docker-compose.yml` using `docker compose up -d`.
 
 ## Install PHP dependencies
 


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Upgrades instructions and the local test runner to use Docker Compose v2 instead of Docker Compose.

Docker Compose v2 has been out for some time, and Docker Compose v1 (`docker-compose`) no longer receives updates.

> From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.
> 
> — https://docs.docker.com/compose/ 

I think it makes sense to push the documentation and commands over to the v2 equivalents now, since this is what most engineers should have installed now. 

## Concerns/issues

I have only tested this locally. I'm not sure if this will work as-is on CI or if more needs to be done.

It's also worth considering if a significant portion of maintainers/contributors cannot upgrade to Docker Compose v2 for some reason? :thinking: (I can't think of one, but I'm just wary as I don't know why this repository was still using `docker-compose` instead of `docker compose`.)

A similar proposal was made for nextcloud-docker-dev, which looks like it will be merged soon too:

* https://github.com/juliushaertl/nextcloud-docker-dev/pull/209

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
