### PR TITLE
Revert versioning scheme of dependency to use normal releases again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@
   [#1758](https://github.com/nextcloud/cookbook/pull/1758) @christianlupus
 - Update browserlist bz nextcloud
   [#1792](https://github.com/nextcloud/cookbook/pull/1792) @dependabot
+- Fix workaround introduced in #1758
+  [#1802](https://github.com/nextcloud/cookbook/pull/1802) @christianlupus
 
 
 ## 0.10.2 - 2023-03-24

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "devDependencies": {
         "@nextcloud/browserslist-config": "^2.3.0",
         "@nextcloud/stylelint-config": "^2.1.2",
-        "@nextcloud/webpack-vue-config": "github:nextcloud/webpack-vue-config#fix/prettier-15-support",
+        "@nextcloud/webpack-vue-config": "^6.0.0",
         "check-peer-dependencies": "^4.1.0",
         "clean-webpack-plugin": "^4.0.0",
         "eslint": "^8.2.0",
@@ -3092,29 +3092,29 @@
       }
     },
     "node_modules/@nextcloud/webpack-vue-config": {
-      "version": "5.5.1",
-      "resolved": "git+ssh://git@github.com/nextcloud/webpack-vue-config.git#32885856f7940b680f53029bc571c6f76581ee3a",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-6.0.0.tgz",
+      "integrity": "sha512-CLI1D5eFn/NSy2dq7U8I3R2YnE9yvHA01c49ukZmKiOEkDVFHRSkyBMQDfX0G77hHvPiIQuJdJ3ozN1esZu9kg==",
       "dev": true,
-      "license": "AGPL-3.0-or-later",
       "engines": {
         "node": "^20.0.0",
         "npm": "^9.0.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.19.6",
-        "babel-loader": "^9.0.0",
-        "css-loader": "^6.7.1",
+        "@babel/core": "^7.22.9",
+        "babel-loader": "^9.1.3",
+        "css-loader": "^6.8.1",
         "node-polyfill-webpack-plugin": "2.0.1",
-        "sass": "^1.55.0",
-        "sass-loader": "^13.1.0",
-        "style-loader": "^3.3.1",
+        "sass": "^1.64.2",
+        "sass-loader": "^13.3.2",
+        "style-loader": "^3.3.3",
         "ts-loader": "^9.4.4",
-        "vue": "^2.7.13",
-        "vue-loader": "^15.10.0",
-        "vue-template-compiler": "^2.7.13",
-        "webpack": "^5.74.0",
-        "webpack-cli": "^5.0.1",
-        "webpack-dev-server": "^4.11.1"
+        "vue": "^2.7.14",
+        "vue-loader": "^15.10.1",
+        "vue-template-compiler": "^2.7.14",
+        "webpack": "^5.88.2",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^4.15.1"
       }
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@nextcloud/browserslist-config": "^2.3.0",
     "@nextcloud/stylelint-config": "^2.1.2",
-    "@nextcloud/webpack-vue-config": "github:nextcloud/webpack-vue-config#fix/prettier-15-support",
+    "@nextcloud/webpack-vue-config": "^6.0.0",
     "check-peer-dependencies": "^4.1.0",
     "clean-webpack-plugin": "^4.0.0",
     "eslint": "^8.2.0",


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

This is mainly a reversal of 2f20aee. The change was introduced to allow updating prettier to version 3. With the fix in the upstream library, this temporary workaround can be dropped.

## Concerns/issues

None known.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
