### PR TITLE
Feat/add empty content view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   [#1723](https://github.com/nextcloud/cookbook/pull/1743) @j0hannesr0th
 - Add Android client to README
   [#1767](https://github.com/nextcloud/cookbook/pull/1767) @lneugebauer
+- Show info for empty cookbook or categories in recipe overview
+  [#1866](https://github.com/nextcloud/cookbook/pull/1767) @seyfeb
 
 ### Fixed
 - Fix translation string to not contain quotes

--- a/src/components/RecipeList.vue
+++ b/src/components/RecipeList.vue
@@ -1,5 +1,70 @@
 <template>
     <div>
+        <div v-if="recipeObjects.length == 0">
+            <NcEmptyContent v-if="!isCategorySelected">
+                <template #description>
+                    <div class="center p-4">
+                        <div>
+                            {{
+                                t("cookbook", "No recipes created or imported.")
+                            }}
+                        </div>
+                        <div>
+                            {{
+                                t(
+                                    "cookbook",
+                                    "To get started, you may use the text box in the left navigation bar to import a new recipe. Click below to create a recipe from scratch.",
+                                )
+                            }}
+                        </div>
+                    </div>
+                </template>
+                <template #icon>
+                    <RecipeIcon />
+                </template>
+                <template #name>
+                    <h1 class="empty-content__name">
+                        {{ t("cookbook", "No recipes") }}
+                    </h1>
+                </template>
+                <template #action>
+                    <router-link :to="'/recipe/create'">
+                        <NcButton type="primary"> Create new recipe! </NcButton>
+                    </router-link>
+                </template>
+            </NcEmptyContent>
+
+            <NcEmptyContent v-if="isCategorySelected">
+                <template #description>
+                    <div class="center p-4">
+                        <div>
+                            {{
+                                t(
+                                    "cookbook",
+                                    "No recipes matching the selected category found.",
+                                )
+                            }}
+                        </div>
+                        <div>
+                            {{
+                                t(
+                                    "cookbook",
+                                    "Try selecting a category from the left navigation bar.",
+                                )
+                            }}
+                        </div>
+                    </div>
+                </template>
+                <template #icon>
+                    <RecipeIcon />
+                </template>
+                <template #name>
+                    <h1 class="empty-content__name">
+                        {{ t("cookbook", "No recipes") }}
+                    </h1>
+                </template>
+            </NcEmptyContent>
+        </div>
         <RecipeListKeywordCloud
             v-if="showTagCloudInRecipeList"
             v-model="keywordFilter"
@@ -50,6 +115,9 @@
 </template>
 
 <script>
+import RecipeIcon from "vue-material-design-icons/ChefHat.vue"
+import NcButton from "@nextcloud/vue/dist/Components/NcButton"
+import NcEmptyContent from "@nextcloud/vue/dist/Components/NcEmptyContent"
 import NcMultiselect from "@nextcloud/vue/dist/Components/NcMultiselect"
 import RecipeCard from "./RecipeCard.vue"
 import RecipeListKeywordCloud from "./RecipeListKeywordCloud.vue"
@@ -57,8 +125,11 @@ import RecipeListKeywordCloud from "./RecipeListKeywordCloud.vue"
 export default {
     name: "RecipeList",
     components: {
+        NcButton,
+        NcEmptyContent,
         NcMultiselect,
         RecipeCard,
+        RecipeIcon,
         RecipeListKeywordCloud,
     },
     props: {
@@ -115,6 +186,12 @@ export default {
         }
     },
     computed: {
+        /**
+         * True, if the recipe list is shown for a selected category or the 'undefined' category and not "All recipes".
+         */
+        isCategorySelected() {
+            return this.$route.path.substring(1, 9) === "category"
+        },
         /**
          * An array of all keywords in all recipes. These are neither sorted nor unique
          */
@@ -324,5 +401,9 @@ export default {
     width: 100%;
     flex-direction: row;
     flex-wrap: wrap;
+}
+
+.p-4 {
+    padding: 1.5rem !important;
 }
 </style>


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope
Adds some info for empty cookbooks (no recipes) for, e.g., first-time users on how to get started.

<img width="300" alt="Screenshot 2023-10-29 at 20 58 07" src="https://github.com/nextcloud/cookbook/assets/7623143/3b4c757c-34f6-46a2-8d02-791d968d3fef">

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
