### PR TITLE
Fix/prep time cook time not correctly imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Add Android client to README
   [#1767](https://github.com/nextcloud/cookbook/pull/1767) @lneugebauer
 - Show info for empty cookbook or categories in recipe overview
-  [#1866](https://github.com/nextcloud/cookbook/pull/1767) @seyfeb
+  [#1866](https://github.com/nextcloud/cookbook/pull/1866) @seyfeb
 
 ### Fixed
 - Fix translation string to not contain quotes
@@ -29,6 +29,8 @@
   [#1834](https://github.com/nextcloud/cookbook/pull/1834) @christianlupus
 - Hode the button to copy ingredients unless there are some ingredients to copy
   [#1844](https://github.com/nextcloud/cookbook/pull/1844) @christianlupus
+- Allow parsing more ISO 8601 duration strings. See issue [#1749](https://github.com/nextcloud/cookbook/issues/1749)
+  [#XX](https://github.com/nextcloud/cookbook/pull/XX) @seyfeb
 
 ### Maintenance
 - Fix URL of Transifex after upstream subdomain change

--- a/lib/Helper/ISO8601DurationHelper.php
+++ b/lib/Helper/ISO8601DurationHelper.php
@@ -42,14 +42,30 @@ class ISO8601DurationHelper {
 		throw new InvalidDurationException($this->l->t('Could not parse duration {duration}', ['duration' => $duration]));
 	}
 
+	/**
+	 * Parses the string $duration and checks if it has a valid ISO 8601 duration format. Otherwise throws
+	 * InvalidDurationException.
+	 *
+	 * For reference of ISO 8601, see <a href="https://en.wikipedia.org/wiki/ISO_8601">Wikipedia</a>.
+	 * @param string $duration
+	 * @return string
+	 * @throws InvalidDurationException if $duration does not comply to ISO 8601.
+	 */
 	private function parseIsoFormat(string $duration): string {
-		$pattern = '/^PT(\d+)H(?:(\d+)M(?:(\d+)S)?)?$/';
+		// P (for period) denotes the duration and must be at the start.
+		// The single parts are optional, but the lookahead (?=\d) ensures that there is some time (digit) given.
+		// Years, months, and days are improbable for recipes but so what.. ;) That being said: It's not supported.
+		$pattern = '/^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?$/';
 		$ret = preg_match($pattern, trim($duration), $matches);
 
 		if ($ret === 1) {
-			$hours = (int)$matches[1];
-			$minutes = (int) ($matches[2] ?? 0);
-			$seconds = (int) ($matches[3] ?? 0);
+			// $matches[0] is the complete string (like P1Y2M3DT4H5M6S)
+			// $matches[1] to $matches[3] is years to days (like 1Y 2M 3D)
+			// $matches[5] is the tome part of the string (like T4H5M6S)
+			// $matches[6] to $matches[8] is hours to seconds (like 4H 5M 6S)
+			$hours = (int)$matches[6];
+			$minutes = (int) ($matches[7] ?? 0);
+			$seconds = (int) ($matches[8] ?? 0);
 
 			while ($seconds >= 60) {
 				$seconds -= 60;

--- a/tests/Unit/Helper/ISO8601DurationHelperTest.php
+++ b/tests/Unit/Helper/ISO8601DurationHelperTest.php
@@ -45,6 +45,11 @@ class ISO8601DurationHelperTest extends TestCase {
 			['PT3H', 'PT3H0M0S'],
 			['PT13H0M', 'PT13H0M0S'],
 			['PT0H60M61S', 'PT1H1M1S'],
+			['PT10M', 'PT0H10M0S'],
+			['PT1M', 'PT0H1M0S'],
+			['PT10S', 'PT0H0M10S'],
+			['PT1S', 'PT0H0M1S'],
+			['PT20M1S', 'PT0H20M1S'],
 		];
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Support ISO 8601 formatted strings such as in #1749. Closes #1749.

## Concerns/issues

We might need to revisit this if someone decides to have timers with years, months, or days set. But this should be easy to extend.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
