### PR TITLE
Switch to non-deprecated props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@
   [#1843](https://github.com/nextcloud/cookbook/pull/1843) @christianlupus
 - Update helper dependency for DB testing
   [#1873](https://github.com/nextcloud/cookbook/pull/1873) @dependabot
+- Use non-deprecated prop name for navigation items
+  [#1893](https://github.com/nextcloud/cookbook/pull/1893) @christianlupus
 
 
 ## 0.10.2 - 2023-03-24

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -22,7 +22,7 @@
             </NcActionInput>
 
             <NcAppNavigationItem
-                :title="t('cookbook', 'All recipes')"
+                :name="t('cookbook', 'All recipes')"
                 icon="icon-category-organization"
                 :to="'/'"
             >
@@ -34,7 +34,7 @@
             </NcAppNavigationItem>
 
             <NcAppNavigationItem
-                :title="t('cookbook', 'Uncategorized recipes')"
+                :name="t('cookbook', 'Uncategorized recipes')"
                 icon="icon-category-organization"
                 :to="'/category/_/'"
             >
@@ -54,7 +54,7 @@
                 v-for="(cat, idx) in categories"
                 :key="cat + idx"
                 :ref="'app-navi-cat-' + idx"
-                :title="cat.name"
+                :name="cat.name"
                 :icon="'icon-category-files'"
                 :to="'/category/' + cat.name"
                 :editable="true"


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

The `title` prop of the `NcAppNavigationItem` is deprecated and should be replaced by the `name` prop. This PR will do so.

## Concerns/issues

None known.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
