### PR TITLE
Fix/1590 recipe id in stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
   [#1896](https://github.com/nextcloud/cookbook/pull/1896) @seyfeb
 - Less strict character matching when filtering `RecipeList`, ignoring accents and some letters. Closes [#1870]((https://github.com/nextcloud/cookbook/issues/1870))
   [#1896](https://github.com/nextcloud/cookbook/pull/1896) @seyfeb
+- Make API interface cleaner by only using string identifiers for recipes
+  [#1909](https://github.com/nextcloud/cookbook/pull/1909) @christianlupus
 
 ### Maintenance
 - Preparation for migration to vue.js 3
@@ -105,6 +107,10 @@
   [#1873](https://github.com/nextcloud/cookbook/pull/1873) @dependabot
 - Use non-deprecated prop name for navigation items
   [#1893](https://github.com/nextcloud/cookbook/pull/1893) @christianlupus
+
+### Deprecated
+- Old integer-based ids should no longer be used.
+  [#1909](https://github.com/nextcloud/cookbook/pull/1909) @christianlupus
 
 
 ## 0.10.2 - 2023-03-24

--- a/cookbook.code-workspace
+++ b/cookbook.code-workspace
@@ -23,11 +23,11 @@
 			".github/actions/run-tests/volumes/output/**/*": true,
 			".github/actions/run-tests/volumes/postgres/**/*": true,
 			".github/actions/run-tests/volumes/nextcloud/custom_apps/cookbook/**/*": true,
-			".github/actions/run-tests/volumes/**/*": true
+			".github/actions/run-tests/volumes/**/*": true,
+			".hook-checkout/**/*": true
 		},
 		"files.watcherExclude": {
-			".github/actions/run-tests/volumes/nextcloud/custom_apps/cookbook/**/*": true,
-			".github/actions/run-tests/volumes/nextcloud/**/*": true
+			".github/actions/run-tests/volumes/**/*": true
 		},
 		//"intelephense.trace.server": "message",
 		"intelephense.files.exclude": [
@@ -43,6 +43,7 @@
 			"**/vendor/**/vendor/**",
 			// "3rdparty/**"
 			".github/actions/**",
+			".hook-checkout/**"
 		],
 		"cSpell.words": [
 			"Nextcloud"

--- a/lib/Controller/Implementation/RecipeImplementation.php
+++ b/lib/Controller/Implementation/RecipeImplementation.php
@@ -5,7 +5,7 @@ namespace OCA\Cookbook\Controller\Implementation;
 use OCA\Cookbook\Exception\NoRecipeNameGivenException;
 use OCA\Cookbook\Exception\RecipeExistsException;
 use OCA\Cookbook\Helper\AcceptHeaderParsingHelper;
-use OCA\Cookbook\Helper\Filter\RecipeJSONOutputFilter;
+use OCA\Cookbook\Helper\Filter\Output\RecipeJSONOutputFilter;
 use OCA\Cookbook\Helper\RestParameterParser;
 use OCA\Cookbook\Service\DbCacheService;
 use OCA\Cookbook\Service\RecipeService;

--- a/lib/Controller/Implementation/RecipeImplementation.php
+++ b/lib/Controller/Implementation/RecipeImplementation.php
@@ -6,6 +6,7 @@ use OCA\Cookbook\Exception\NoRecipeNameGivenException;
 use OCA\Cookbook\Exception\RecipeExistsException;
 use OCA\Cookbook\Helper\AcceptHeaderParsingHelper;
 use OCA\Cookbook\Helper\Filter\Output\RecipeJSONOutputFilter;
+use OCA\Cookbook\Helper\Filter\Output\RecipeStubFilter;
 use OCA\Cookbook\Helper\RestParameterParser;
 use OCA\Cookbook\Service\DbCacheService;
 use OCA\Cookbook\Service\RecipeService;
@@ -28,12 +29,15 @@ class RecipeImplementation {
 	private $restParser;
 	/** @var RecipeJSONOutputFilter */
 	private $outputFilter;
+	/** @var RecipeStubFilter */
+	private $stubFilter;
 	/** @var AcceptHeaderParsingHelper */
 	private $acceptHeaderParser;
 	/** @var IRequest */
 	private $request;
 	/** @var IL10N */
 	private $l;
+
 
 	public function __construct(
 		IRequest $request,
@@ -42,6 +46,7 @@ class RecipeImplementation {
 		IURLGenerator $iURLGenerator,
 		RestParameterParser $restParameterParser,
 		RecipeJSONOutputFilter $recipeJSONOutputFilter,
+		RecipeStubFilter $stubFilter,
 		AcceptHeaderParsingHelper $acceptHeaderParsingHelper,
 		IL10N $iL10N
 	) {
@@ -51,6 +56,7 @@ class RecipeImplementation {
 		$this->urlGenerator = $iURLGenerator;
 		$this->restParser = $restParameterParser;
 		$this->outputFilter = $recipeJSONOutputFilter;
+		$this->stubFilter = $stubFilter;
 		$this->acceptHeaderParser = $acceptHeaderParsingHelper;
 		$this->l = $iL10N;
 	}
@@ -69,6 +75,8 @@ class RecipeImplementation {
 		foreach ($recipes as $i => $recipe) {
 			$recipes[$i]['imageUrl'] = $this->urlGenerator->linkToRoute('cookbook.recipe.image', ['id' => $recipe['recipe_id'], 'size' => 'thumb']);
 			$recipes[$i]['imagePlaceholderUrl'] = $this->urlGenerator->linkToRoute('cookbook.recipe.image', ['id' => $recipe['recipe_id'], 'size' => 'thumb16']);
+
+			$recipes[$i] = $this->stubFilter->apply($recipes[$i]);
 		}
 		return new JSONResponse($recipes, Http::STATUS_OK);
 	}

--- a/lib/Helper/Filter/DB/AbstractRecipeFilter.php
+++ b/lib/Helper/Filter/DB/AbstractRecipeFilter.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace OCA\Cookbook\Helper\Filter;
+namespace OCA\Cookbook\Helper\Filter\DB;
 
 use OCA\Cookbook\Exception\InvalidRecipeException;
 use OCP\Files\File;
 
 /**
- * An abstract filter on a recipe JSON.
+ * An abstract filter on a recipe.
  *
  * A filter should have a single purpose that is serves and implement this interface
  */
-abstract class AbstractJSONFilter {
+interface AbstractRecipeFilter {
 	/**
 	 * Filter the given recipe according to the filter class specification.
 	 *
@@ -18,22 +18,9 @@ abstract class AbstractJSONFilter {
 	 * In order to signal if the JSON file needs updating, the return value must be true if and only if the recipe was changed.
 	 *
 	 * @param array $json The recipe data as array
+	 * @param File $recipe The file containing the recipe for further processing
 	 * @return bool true, if and only if the recipe was changed
 	 * @throws InvalidRecipeException if the recipe was not correctly filtered
 	 */
-	abstract public function apply(array &$json): bool;
-
-	/**
-	 * @param string|int|float|array $value
-	 */
-	protected function setJSONValue(array &$json, string $key, string|int|float|array $value): bool {
-		if (!array_key_exists($key, $json)) {
-			$json[$key] = $value;
-			return true;
-		} elseif ($json[$key] !== $value) {
-			$json[$key] = $value;
-			return true;
-		}
-		return false;
-	}
+	public function apply(array &$json, File $recipe): bool;
 }

--- a/lib/Helper/Filter/DB/NormalizeRecipeFileFilter.php
+++ b/lib/Helper/Filter/DB/NormalizeRecipeFileFilter.php
@@ -31,7 +31,8 @@ class NormalizeRecipeFileFilter {
 
 		foreach ($this->filters as $filter) {
 			/** @var AbstractRecipeFilter $filter */
-			$changed |= $filter->apply($json, $recipeFile);
+			$ret = $filter->apply($json, $recipeFile);
+			$changed = $changed || $ret;
 		}
 
 		if ($changed && $updateFiles) {

--- a/lib/Helper/Filter/DB/NormalizeRecipeFileFilter.php
+++ b/lib/Helper/Filter/DB/NormalizeRecipeFileFilter.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace OCA\Cookbook\Helper\Filter;
+namespace OCA\Cookbook\Helper\Filter\DB;
 
-use OCA\Cookbook\Helper\Filter\DB\RecipeDatesFilter;
 use OCP\Files\File;
 
 class NormalizeRecipeFileFilter {

--- a/lib/Helper/Filter/DB/RecipeDatesFilter.php
+++ b/lib/Helper/Filter/DB/RecipeDatesFilter.php
@@ -3,7 +3,6 @@
 namespace OCA\Cookbook\Helper\Filter\DB;
 
 use DateTime;
-use OCA\Cookbook\Helper\Filter\AbstractRecipeFilter;
 use OCP\Files\File;
 
 /**

--- a/lib/Helper/Filter/JSON/AbstractJSONFilter.php
+++ b/lib/Helper/Filter/JSON/AbstractJSONFilter.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace OCA\Cookbook\Helper\Filter;
+namespace OCA\Cookbook\Helper\Filter\JSON;
 
 use OCA\Cookbook\Exception\InvalidRecipeException;
 use OCP\Files\File;
 
 /**
- * An abstract filter on a recipe.
+ * An abstract filter on a recipe JSON.
  *
  * A filter should have a single purpose that is serves and implement this interface
  */
-interface AbstractRecipeFilter {
+abstract class AbstractJSONFilter {
 	/**
 	 * Filter the given recipe according to the filter class specification.
 	 *
@@ -18,9 +18,22 @@ interface AbstractRecipeFilter {
 	 * In order to signal if the JSON file needs updating, the return value must be true if and only if the recipe was changed.
 	 *
 	 * @param array $json The recipe data as array
-	 * @param File $recipe The file containing the recipe for further processing
 	 * @return bool true, if and only if the recipe was changed
 	 * @throws InvalidRecipeException if the recipe was not correctly filtered
 	 */
-	public function apply(array &$json, File $recipe): bool;
+	abstract public function apply(array &$json): bool;
+
+	/**
+	 * @param string|int|float|array $value
+	 */
+	protected function setJSONValue(array &$json, string $key, string|int|float|array $value): bool {
+		if (!array_key_exists($key, $json)) {
+			$json[$key] = $value;
+			return true;
+		} elseif ($json[$key] !== $value) {
+			$json[$key] = $value;
+			return true;
+		}
+		return false;
+	}
 }

--- a/lib/Helper/Filter/JSON/CleanCategoryFilter.php
+++ b/lib/Helper/Filter/JSON/CleanCategoryFilter.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCA\Cookbook\Helper\TextCleanupHelper;
 
 /**

--- a/lib/Helper/Filter/JSON/ExtractImageUrlFilter.php
+++ b/lib/Helper/Filter/JSON/ExtractImageUrlFilter.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 

--- a/lib/Helper/Filter/JSON/FixDescriptionFilter.php
+++ b/lib/Helper/Filter/JSON/FixDescriptionFilter.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCA\Cookbook\Helper\TextCleanupHelper;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;

--- a/lib/Helper/Filter/JSON/FixDurationsFilter.php
+++ b/lib/Helper/Filter/JSON/FixDurationsFilter.php
@@ -3,7 +3,6 @@
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
 use OCA\Cookbook\Exception\InvalidDurationException;
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCA\Cookbook\Helper\ISO8601DurationHelper;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;

--- a/lib/Helper/Filter/JSON/FixImageSchemeFilter.php
+++ b/lib/Helper/Filter/JSON/FixImageSchemeFilter.php
@@ -3,7 +3,6 @@
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
 use OCA\Cookbook\Exception\InvalidRecipeException;
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCP\IL10N;
 
 /**

--- a/lib/Helper/Filter/JSON/FixIngredientsFilter.php
+++ b/lib/Helper/Filter/JSON/FixIngredientsFilter.php
@@ -3,7 +3,6 @@
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
 use OCA\Cookbook\Exception\InvalidRecipeException;
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCA\Cookbook\Helper\TextCleanupHelper;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;

--- a/lib/Helper/Filter/JSON/FixInstructionsFilter.php
+++ b/lib/Helper/Filter/JSON/FixInstructionsFilter.php
@@ -3,7 +3,6 @@
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
 use OCA\Cookbook\Exception\InvalidRecipeException;
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCA\Cookbook\Helper\TextCleanupHelper;
 use OCA\Cookbook\Service\JsonService;
 use OCP\IL10N;

--- a/lib/Helper/Filter/JSON/FixKeywordsFilter.php
+++ b/lib/Helper/Filter/JSON/FixKeywordsFilter.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCA\Cookbook\Helper\TextCleanupHelper;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;

--- a/lib/Helper/Filter/JSON/FixNutritionFilter.php
+++ b/lib/Helper/Filter/JSON/FixNutritionFilter.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 

--- a/lib/Helper/Filter/JSON/FixRecipeYieldFilter.php
+++ b/lib/Helper/Filter/JSON/FixRecipeYieldFilter.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 

--- a/lib/Helper/Filter/JSON/FixToolsFilter.php
+++ b/lib/Helper/Filter/JSON/FixToolsFilter.php
@@ -3,7 +3,6 @@
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
 use OCA\Cookbook\Exception\InvalidRecipeException;
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCA\Cookbook\Helper\TextCleanupHelper;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;

--- a/lib/Helper/Filter/JSON/FixUrlFilter.php
+++ b/lib/Helper/Filter/JSON/FixUrlFilter.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 

--- a/lib/Helper/Filter/JSON/JSONFilter.php
+++ b/lib/Helper/Filter/JSON/JSONFilter.php
@@ -1,22 +1,6 @@
 <?php
 
-namespace OCA\Cookbook\Helper\Filter;
-
-use OCA\Cookbook\Helper\Filter\JSON\CleanCategoryFilter;
-use OCA\Cookbook\Helper\Filter\JSON\ExtractImageUrlFilter;
-use OCA\Cookbook\Helper\Filter\JSON\FixDescriptionFilter;
-use OCA\Cookbook\Helper\Filter\JSON\FixDurationsFilter;
-use OCA\Cookbook\Helper\Filter\JSON\FixImageSchemeFilter;
-use OCA\Cookbook\Helper\Filter\JSON\FixIngredientsFilter;
-use OCA\Cookbook\Helper\Filter\JSON\FixInstructionsFilter;
-use OCA\Cookbook\Helper\Filter\JSON\FixKeywordsFilter;
-use OCA\Cookbook\Helper\Filter\JSON\FixNutritionFilter;
-use OCA\Cookbook\Helper\Filter\JSON\FixRecipeYieldFilter;
-use OCA\Cookbook\Helper\Filter\JSON\FixToolsFilter;
-use OCA\Cookbook\Helper\Filter\JSON\FixUrlFilter;
-use OCA\Cookbook\Helper\Filter\JSON\RecipeIdTypeFilter;
-use OCA\Cookbook\Helper\Filter\JSON\RecipeNameFilter;
-use OCA\Cookbook\Helper\Filter\JSON\SchemaConformityFilter;
+namespace OCA\Cookbook\Helper\Filter\JSON;
 
 class JSONFilter {
 	/** @var AbstractJSONFilter[] */

--- a/lib/Helper/Filter/JSON/RecipeIdCopyFilter.php
+++ b/lib/Helper/Filter/JSON/RecipeIdCopyFilter.php
@@ -2,8 +2,6 @@
 
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
-
 /**
  * Copy the id from the recipe_id to the id field if there is no id present so far.
  */

--- a/lib/Helper/Filter/JSON/RecipeIdTypeFilter.php
+++ b/lib/Helper/Filter/JSON/RecipeIdTypeFilter.php
@@ -2,8 +2,6 @@
 
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
-
 /**
  * Fix the data type of the id of a recipe.
  *

--- a/lib/Helper/Filter/JSON/RecipeNameFilter.php
+++ b/lib/Helper/Filter/JSON/RecipeNameFilter.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
 use OCA\Cookbook\Helper\TextCleanupHelper;
 
 /**

--- a/lib/Helper/Filter/JSON/SchemaConformityFilter.php
+++ b/lib/Helper/Filter/JSON/SchemaConformityFilter.php
@@ -2,8 +2,6 @@
 
 namespace OCA\Cookbook\Helper\Filter\JSON;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
-
 /**
  * Make sure the schema.org standard annotations are present in the JSON object.
  */

--- a/lib/Helper/Filter/Output/EnsureNutritionPresentFilter.php
+++ b/lib/Helper/Filter/Output/EnsureNutritionPresentFilter.php
@@ -2,7 +2,7 @@
 
 namespace OCA\Cookbook\Helper\Filter\Output;
 
-use OCA\Cookbook\Helper\Filter\AbstractJSONFilter;
+use OCA\Cookbook\Helper\Filter\JSON\AbstractJSONFilter;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 

--- a/lib/Helper/Filter/Output/RecipeJSONOutputFilter.php
+++ b/lib/Helper/Filter/Output/RecipeJSONOutputFilter.php
@@ -3,6 +3,7 @@
 namespace OCA\Cookbook\Helper\Filter\Output;
 
 use OCP\Files\File;
+use OCA\Cookbook\Helper\Filter\JSON\AbstractJSONFilter;
 
 class RecipeJSONOutputFilter {
 	/** @var array */

--- a/lib/Helper/Filter/Output/RecipeJSONOutputFilter.php
+++ b/lib/Helper/Filter/Output/RecipeJSONOutputFilter.php
@@ -2,8 +2,8 @@
 
 namespace OCA\Cookbook\Helper\Filter\Output;
 
-use OCP\Files\File;
 use OCA\Cookbook\Helper\Filter\JSON\AbstractJSONFilter;
+use OCP\Files\File;
 
 class RecipeJSONOutputFilter {
 	/** @var array */

--- a/lib/Helper/Filter/Output/RecipeJSONOutputFilter.php
+++ b/lib/Helper/Filter/Output/RecipeJSONOutputFilter.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace OCA\Cookbook\Helper\Filter;
+namespace OCA\Cookbook\Helper\Filter\Output;
 
-use OCA\Cookbook\Helper\Filter\Output\EnsureNutritionPresentFilter;
 use OCP\Files\File;
 
 class RecipeJSONOutputFilter {

--- a/lib/Helper/Filter/Output/RecipeStubFilter.php
+++ b/lib/Helper/Filter/Output/RecipeStubFilter.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace OCA\Cookbook\Helper\Filter;
+namespace OCA\Cookbook\Helper\Filter\Output;
 
+use OCA\Cookbook\Helper\Filter\JSON\AbstractJSONFilter;
 use OCA\Cookbook\Helper\Filter\JSON\RecipeIdCopyFilter;
 use OCA\Cookbook\Helper\Filter\JSON\RecipeIdTypeFilter;
 

--- a/lib/Service/DbCacheService.php
+++ b/lib/Service/DbCacheService.php
@@ -4,7 +4,7 @@ namespace OCA\Cookbook\Service;
 
 use OCA\Cookbook\Db\RecipeDb;
 use OCA\Cookbook\Exception\InvalidJSONFileException;
-use OCA\Cookbook\Helper\Filter\NormalizeRecipeFileFilter;
+use OCA\Cookbook\Helper\Filter\DB\NormalizeRecipeFileFilter;
 use OCA\Cookbook\Helper\UserConfigHelper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\File;

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -10,7 +10,7 @@ use OCA\Cookbook\Exception\NoRecipeNameGivenException;
 use OCA\Cookbook\Exception\RecipeExistsException;
 use OCA\Cookbook\Exception\UserFolderNotWritableException;
 use OCA\Cookbook\Helper\FileSystem\RecipeNameHelper;
-use OCA\Cookbook\Helper\Filter\JSONFilter;
+use OCA\Cookbook\Helper\Filter\JSON\JSONFilter;
 use OCA\Cookbook\Helper\ImageService\ImageSize;
 use OCA\Cookbook\Helper\UserConfigHelper;
 use OCA\Cookbook\Helper\UserFolderHelper;

--- a/tests/Integration/Helper/Filter/JSON/RecipeFixIdsTest.php
+++ b/tests/Integration/Helper/Filter/JSON/RecipeFixIdsTest.php
@@ -3,7 +3,7 @@
 namespace OCA\Cookbook\tests\Integration\Helper\Filter\JSON;
 
 use OCA\Cookbook\AppInfo\Application;
-use OCA\Cookbook\Helper\Filter\RecipeStubFilter;
+use OCA\Cookbook\Helper\Filter\Output\RecipeStubFilter;
 use PHPUnit\Framework\TestCase;
 
 class RecipeFixIdsTest extends TestCase {
@@ -30,11 +30,17 @@ class RecipeFixIdsTest extends TestCase {
 		$expected = $stub;
 		$expected['recipe_id'] = 123;
 		$expected['id'] = '123';
-		yield [$src, $expected];
+		yield 'only numeric recipe_id' => [$src, $expected];
+
+		$src['recipe_id'] = $expected['recipe_id'] = '123';
+		yield 'only string recipe_id' => [$src, $expected];
 
 		$src['id'] = '234';
 		$expected['id'] = '234';
-		yield [$src, $expected];
+		yield 'with string id' => [$src, $expected];
+
+		$src['recipe_id'] = $expected['recipe_id'] = 123;
+		yield 'mixed string and int id recipe_id' => [$src, $expected];
 	}
 
 	/**

--- a/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
+++ b/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
@@ -7,7 +7,7 @@ use OCA\Cookbook\Controller\Implementation\RecipeImplementation;
 use OCA\Cookbook\Exception\NoRecipeNameGivenException;
 use OCA\Cookbook\Exception\RecipeExistsException;
 use OCA\Cookbook\Helper\AcceptHeaderParsingHelper;
-use OCA\Cookbook\Helper\Filter\RecipeJSONOutputFilter;
+use OCA\Cookbook\Helper\Filter\Output\RecipeJSONOutputFilter;
 use OCA\Cookbook\Helper\RestParameterParser;
 use OCA\Cookbook\Service\DbCacheService;
 use OCA\Cookbook\Service\RecipeService;

--- a/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
+++ b/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
@@ -8,6 +8,7 @@ use OCA\Cookbook\Exception\NoRecipeNameGivenException;
 use OCA\Cookbook\Exception\RecipeExistsException;
 use OCA\Cookbook\Helper\AcceptHeaderParsingHelper;
 use OCA\Cookbook\Helper\Filter\Output\RecipeJSONOutputFilter;
+use OCA\Cookbook\Helper\Filter\Output\RecipeStubFilter;
 use OCA\Cookbook\Helper\RestParameterParser;
 use OCA\Cookbook\Service\DbCacheService;
 use OCA\Cookbook\Service\RecipeService;
@@ -41,6 +42,8 @@ class RecipeImplementationTest extends TestCase {
 	private $restParser;
 	/** @var RecipeJSONOutputFilter|MockObject */
 	private $recipeFilter;
+	/** @var RecipeStubFilter|MockObject */
+	private $stubFilter;
 	/** @var AcceptHeaderParsingHelper|MockObject */
 	private $acceptHeaderParser;
 
@@ -58,6 +61,7 @@ class RecipeImplementationTest extends TestCase {
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->restParser = $this->createMock(RestParameterParser::class);
 		$this->recipeFilter = $this->createMock(RecipeJSONOutputFilter::class);
+		$this->stubFilter = $this->createMock(RecipeStubFilter::class);
 		$this->acceptHeaderParser = $this->createMock(AcceptHeaderParsingHelper::class);
 
 		/** @var IL10N|Stub */
@@ -71,6 +75,7 @@ class RecipeImplementationTest extends TestCase {
 			$this->urlGenerator,
 			$this->restParser,
 			$this->recipeFilter,
+			$this->stubFilter,
 			$this->acceptHeaderParser,
 			$l
 		);
@@ -684,6 +689,8 @@ class RecipeImplementationTest extends TestCase {
 			$size = $params['size'];
 			return "/path/to/controller/$id/$size";
 		}));
+
+		$this->stubFilter->method('apply')->willReturnArgument(0);
 
 		/**
 		 * @var JSONResponse $ret

--- a/tests/Unit/Helper/Filter/JSONFilterTest.php
+++ b/tests/Unit/Helper/Filter/JSONFilterTest.php
@@ -14,10 +14,10 @@ use OCA\Cookbook\Helper\Filter\JSON\FixNutritionFilter;
 use OCA\Cookbook\Helper\Filter\JSON\FixRecipeYieldFilter;
 use OCA\Cookbook\Helper\Filter\JSON\FixToolsFilter;
 use OCA\Cookbook\Helper\Filter\JSON\FixUrlFilter;
+use OCA\Cookbook\Helper\Filter\JSON\JSONFilter;
 use OCA\Cookbook\Helper\Filter\JSON\RecipeIdTypeFilter;
 use OCA\Cookbook\Helper\Filter\JSON\RecipeNameFilter;
 use OCA\Cookbook\Helper\Filter\JSON\SchemaConformityFilter;
-use OCA\Cookbook\Helper\Filter\JSONFilter;
 use PHPUnit\Framework\TestCase;
 
 class JSONFilterTest extends TestCase {

--- a/tests/Unit/Helper/Filter/NormalizeRecipeFileFilterTest.php
+++ b/tests/Unit/Helper/Filter/NormalizeRecipeFileFilterTest.php
@@ -2,8 +2,8 @@
 
 namespace OCA\Cookbook\tests\Unit\Helper\Filter;
 
+use OCA\Cookbook\Helper\Filter\DB\NormalizeRecipeFileFilter;
 use OCA\Cookbook\Helper\Filter\DB\RecipeDatesFilter;
-use OCA\Cookbook\Helper\Filter\NormalizeRecipeFileFilter;
 use OCP\Files\File;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Helper/Filter/RecipeJSONOutputFilterTest.php
+++ b/tests/Unit/Helper/Filter/RecipeJSONOutputFilterTest.php
@@ -3,7 +3,7 @@
 namespace OCA\Cookbook\tests\Unit\Helper\Filter;
 
 use OCA\Cookbook\Helper\Filter\Output\EnsureNutritionPresentFilter;
-use OCA\Cookbook\Helper\Filter\RecipeJSONOutputFilter;
+use OCA\Cookbook\Helper\Filter\Output\RecipeJSONOutputFilter;
 use PHPUnit\Framework\TestCase;
 
 class RecipeJSONOutputFilterTest extends TestCase {


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

This should provide a unique interface by adding a string entry `id` both to the stubs and to the full recipes.

Closes #1590

## Concerns/issues

_None_

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
