### PR TITLE
Fix/1945 print view shows irrelevant elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - remove constant se in RecipeView
   [#1942](https://github.com/nextcloud/cookbook/pull/1942) @j0hannesr0th
 
+### Fixed
+- **Print view:** Hide yield calculator, ingredient-copy button, yield-calculation warnings
+  [#1949](https://github.com/nextcloud/cookbook/pull/1949) @seyfeb
 
 ## 0.10.3 - 2023-12-04
 

--- a/src/components/RecipeView/RecipeIngredient.vue
+++ b/src/components/RecipeView/RecipeIngredient.vue
@@ -88,4 +88,10 @@ li > .ingredient {
 li > span.icon-error {
     margin-left: 0.3em;
 }
+
+@media print {
+    li > span.icon-error {
+        display: none;
+    }
+}
 </style>

--- a/src/components/RecipeView/RecipeView.vue
+++ b/src/components/RecipeView/RecipeView.vue
@@ -72,7 +72,10 @@
                                 <strong
                                     >{{ t('cookbook', 'Servings') }}:
                                 </strong>
-                                <span>
+                                <span class="print-only">
+                                    {{ recipeYield }}
+                                </span>
+                                <span class="print-hidden">
                                     <button
                                         :disabled="recipeYield === 1"
                                         @click="changeRecipeYield(false)"
@@ -143,7 +146,7 @@
                             <span>{{ t('cookbook', 'Ingredients') }}</span>
                             <NcButton
                                 v-if="scaledIngredients.length"
-                                class="copy-ingredients"
+                                class="copy-ingredients print-hidden"
                                 :type="'tertiary'"
                                 aria-label="Copy all ingredients to the clipboard"
                                 :title="t('cookbook', 'Copy ingredients')"
@@ -177,7 +180,7 @@
 
                         <div
                             v-if="!ingredientsSyntaxCorrect"
-                            class="ingredient-parsing-error"
+                            class="ingredient-parsing-error print-hidden"
                         >
                             <hr />
                             <span class="icon-error" />
@@ -799,6 +802,10 @@ export default {
     padding: 3rem 0;
 }
 
+.print-only {
+    display: none;
+}
+
 @media print {
     .header {
         display: flex;
@@ -815,6 +822,14 @@ export default {
 
     .header a::after {
         content: '';
+    }
+
+    .print-hidden {
+        display: none !important;
+    }
+
+    .print-only {
+        display: initial !important;
     }
 }
 

--- a/src/components/RecipeView/RecipeView.vue
+++ b/src/components/RecipeView/RecipeView.vue
@@ -168,13 +168,11 @@
                                 :recipe-ingredients-have-subgroups="
                                     recipeIngredientsHaveSubgroups
                                 "
-                                :style="{
-                                    'font-style': ingredientsWithValidSyntax[
-                                        idx
-                                    ]
-                                        ? 'normal'
-                                        : 'italic',
-                                }"
+                                :class="
+                                    ingredientsWithValidSyntax[idx]
+                                        ? ''
+                                        : 'ingredient-highlighted'
+                                "
                             />
                         </ul>
 
@@ -873,6 +871,16 @@ export default {
 
 .copy-ingredients {
     float: right;
+}
+
+.ingredient-highlighted {
+    font-style: italic;
+}
+
+@media print {
+    .ingredient-highlighted {
+        font-style: initial;
+    }
 }
 
 .description {


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

In recipe-print view hide

- yield calculator
- yield-calculation warnings
- ingredient-copy button

Closes #1945

Before
<img width="450" alt="Screenshot 2023-12-07 at 16 53 27" src="https://github.com/nextcloud/cookbook/assets/7623143/a7c996c0-d680-444f-a903-8cd78709b537">

After
<img width="420" alt="Screenshot 2023-12-07 at 16 51 03" src="https://github.com/nextcloud/cookbook/assets/7623143/ae06de6c-36ca-4203-98f4-ae5722780351">

## Concerns/issues

_None_

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
