### PR TITLE
Fix/1962 error when changing rescan period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   [#1944](https://github.com/nextcloud/cookbook/pull/1944) @j0hannesr0th
 - Update compatibility of app to NC28
   [#1950](https://github.com/nextcloud/cookbook/pull/1950) @christianlupus
+- **Settings:** Don't show error when update interval field is empty while typing.
+  [#1963](https://github.com/nextcloud/cookbook/pull/1963) @seyfeb
 
 ### Maintenance
 - Add PHP lint checker to ensure valid (legacy) PHP syntax

--- a/src/components/Modals/SettingsDialog.vue
+++ b/src/components/Modals/SettingsDialog.vue
@@ -301,6 +301,7 @@ watch(
             return;
         }
         try {
+            if (newVal === '') return;
             await api.config.updateInterval.update(newVal);
             await store.dispatch('refreshConfig');
         } catch {


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Fixes the error message shown when the update interval field in the settings window is empty.

## Concerns/issues

Unfocusing the field does not show a warning, however then the value simply remains unchanged. In the future general form validation capabilities might be helpful (for the settings but also recipe editing), but afaik not supported by Nextcloud vue component by the time of writing.

Closes #1962 

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change

Depends on #1950