### PR TITLE
Fix/1966 change abort icon during editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   [#1963](https://github.com/nextcloud/cookbook/pull/1963) @seyfeb
 - Fix searching recipes by string.
   [#1965](https://github.com/nextcloud/cookbook/pull/1965) @seyfeb
+- Replace eye icon with close icon for cancelling recipe edit
+  [#1971](https://github.com/nextcloud/cookbook/pull/1971) @seyfeb
 
 ### Maintenance
 - Add PHP lint checker to ensure valid (legacy) PHP syntax

--- a/src/components/AppControls/AppControls.vue
+++ b/src/components/AppControls/AppControls.vue
@@ -93,15 +93,15 @@
             <NcActionInput
                 icon="icon-quota"
                 :value="filterValue"
-                @update:value="updateFilters"
                 aria-label="Filter current recipes"
+                @update:value="updateFilters"
             >
                 <template #icon>
                     <FilterIcon :size="20" />
                 </template>
                 {{ t('cookbook', 'Filter') }}
             </NcActionInput>
-            <NcActionInput @submit="search" aria-label="Search recipes">
+            <NcActionInput aria-label="Search recipes" @submit="search">
                 <template #icon>
                     <SearchIcon :size="20" />
                 </template>

--- a/src/components/AppControls/AppControls.vue
+++ b/src/components/AppControls/AppControls.vue
@@ -142,7 +142,7 @@
                         "
                         :size="20"
                     />
-                    <eye-icon v-else :size="20" />
+                    <AbortIcon v-else :size="20" />
                 </template>
             </NcActionButton>
             <NcActionButton
@@ -206,7 +206,7 @@ import LoadingIcon from 'icons/Loading.vue';
 import CheckmarkIcon from 'icons/Check.vue';
 import FilterIcon from 'icons/FilterOutline.vue';
 import PrinterIcon from 'icons/Printer.vue';
-import EyeIcon from 'icons/Eye.vue';
+import AbortIcon from 'icons/Close.vue';
 import ContentDuplicateIcon from 'icons/ContentDuplicate.vue';
 import SearchIcon from 'icons/Magnify.vue';
 


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Replaces eye with close icon in recipe editor for cancelling edit.

Closes #1966 

## Concerns/issues

Depends on #1950 

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
