### PR TITLE
Fix/1970 cooking prep and total time are not filled during edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   [#1965](https://github.com/nextcloud/cookbook/pull/1965) @seyfeb
 - Replace eye icon with close icon for cancelling recipe edit
   [#1971](https://github.com/nextcloud/cookbook/pull/1971) @seyfeb
+- Fill prep, cook, and total time in `RecipeEdit` after loading
+  [#1973](https://github.com/nextcloud/cookbook/pull/1973) @seyfeb
 
 ### Maintenance
 - Add PHP lint checker to ensure valid (legacy) PHP syntax

--- a/src/components/FormComponents/EditTimeField.vue
+++ b/src/components/FormComponents/EditTimeField.vue
@@ -49,7 +49,6 @@ const hours = ref(null);
  */
 const minutes = ref(null);
 
-
 // Methods
 
 const handleInput = () => {
@@ -67,7 +66,7 @@ const handleInput = () => {
 };
 
 const setLocalValueFromProps = () => {
-    if(props.value?.time) {
+    if (props.value?.time) {
         [hours.value, minutes.value] = props.value.time;
     }
 };
@@ -76,13 +75,11 @@ const setLocalValueFromProps = () => {
 
 watch(() => props.value, setLocalValueFromProps);
 
-
 // Vue lifecycle
 
 onMounted(() => {
     setLocalValueFromProps();
 });
-
 </script>
 
 <script>

--- a/src/components/FormComponents/EditTimeField.vue
+++ b/src/components/FormComponents/EditTimeField.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 
 const emit = defineEmits(['input']);
 
@@ -49,12 +49,8 @@ const hours = ref(null);
  */
 const minutes = ref(null);
 
-watch(
-    () => props.value,
-    () => {
-        [hours.value, minutes.value] = props.value.time;
-    },
-);
+
+// Methods
 
 const handleInput = () => {
     minutes.value = minutes.value ? minutes.value : 0;
@@ -69,6 +65,24 @@ const handleInput = () => {
         paddedTime: `PT${hoursPadded}H${minutesPadded}M`,
     });
 };
+
+const setLocalValueFromProps = () => {
+    if(props.value?.time) {
+        [hours.value, minutes.value] = props.value.time;
+    }
+};
+
+// Watchers
+
+watch(() => props.value, setLocalValueFromProps);
+
+
+// Vue lifecycle
+
+onMounted(() => {
+    setLocalValueFromProps();
+});
+
 </script>
 
 <script>


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Show the initial values of cooking, prep, and total time in the recipe editor.

Closes #1970 

## Concerns/issues

Based on #1950


## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
