### PR TITLE
Fix/1408 more consistent UI timer

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,6 +12,7 @@ extends:
 
 globals:
     OC: readonly
+    n: readonly
     t: readonly
 
 rules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ### Added
 - Toast with success/error message after trying to copy ingredients [#2040](https://github.com/nextcloud/cookbook/pull/2040) @seyfeb
+- Seconds can now be specified for recipe times [#2014](https://github.com/nextcloud/cookbook/pull/2014) @seyfeb
 
 ### Fixed
 - Prevent yield calculation for ## as ingredient headline [#1998](https://github.com/nextcloud/cookbook/pull/1998) @j0hannesr0th
+- Improved styling of times in recipe view [#2014](https://github.com/nextcloud/cookbook/pull/2014) @seyfeb
 - Add missing translatable string for recipe-creation button in empty list view [#2015](https://github.com/nextcloud/cookbook/pull/2015) @seyfeb
 
 ### Documentation

--- a/src/components/FormComponents/EditTimeField.vue
+++ b/src/components/FormComponents/EditTimeField.vue
@@ -17,6 +17,15 @@
             placeholder="00"
             @input="handleInput"
         />
+        <span>:</span>
+        <input
+            v-model="seconds"
+            type="number"
+            min="0"
+            max="59"
+            placeholder="00"
+            @input="handleInput"
+        />
     </fieldset>
 </template>
 
@@ -30,7 +39,7 @@ const props = defineProps({
         type: Object,
         required: true,
         default: () => ({
-            time: [null, null],
+            time: [null, null, null],
             paddedTime: null,
         }),
     },
@@ -48,26 +57,32 @@ const hours = ref(null);
  * @type {import('vue').Ref<number>}
  */
 const minutes = ref(null);
+/**
+ * @type {import('vue').Ref<number>}
+ */
+const seconds = ref(null);
 
 // Methods
 
 const handleInput = () => {
+    seconds.value = seconds.value ? seconds.value : 0;
     minutes.value = minutes.value ? minutes.value : 0;
     hours.value = hours.value ? hours.value : 0;
 
     // create padded time string
     const hoursPadded = hours.value.toString().padStart(2, '0');
     const minutesPadded = minutes.value.toString().padStart(2, '0');
+    const secondsPadded = seconds.value.toString().padStart(2, '0');
 
     emit('input', {
-        time: [hours.value, minutes.value],
-        paddedTime: `PT${hoursPadded}H${minutesPadded}M`,
+        time: [hours.value, minutes.value, seconds.value],
+        paddedTime: `PT${hoursPadded}H${minutesPadded}M${secondsPadded}S`,
     });
 };
 
 const setLocalValueFromProps = () => {
     if (props.value?.time) {
-        [hours.value, minutes.value] = props.value.time;
+        [hours.value, minutes.value, seconds.value] = props.value.time;
     }
 };
 

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -27,15 +27,21 @@
             />
             <EditTimeField
                 v-model="prepTime"
-                :field-label="t('cookbook', 'Preparation time (hours:minutes)')"
+                :field-label="
+                    t('cookbook', 'Preparation time (hours:minutes:seconds)')
+                "
             />
             <EditTimeField
                 v-model="cookTime"
-                :field-label="t('cookbook', 'Cooking time (hours:minutes)')"
+                :field-label="
+                    t('cookbook', 'Cooking time (hours:minutes:seconds)')
+                "
             />
             <EditTimeField
                 v-model="totalTime"
-                :field-label="t('cookbook', 'Total time (hours:minutes)')"
+                :field-label="
+                    t('cookbook', 'Total time (hours:minutes:seconds)')
+                "
             />
             <EditMultiselect
                 v-model="recipe['recipeCategory']"
@@ -221,9 +227,9 @@ const formDirty = ref(false);
  * @type {import('vue').Ref<boolean>}
  */
 const savingRecipe = ref(false);
-const prepTime = ref({ time: [0, 0], paddedTime: '' });
-const cookTime = ref({ time: [0, 0], paddedTime: '' });
-const totalTime = ref({ time: [0, 0], paddedTime: '' });
+const prepTime = ref({ time: [0, 0, 0], paddedTime: '' });
+const cookTime = ref({ time: [0, 0, 0], paddedTime: '' });
+const totalTime = ref({ time: [0, 0, 0], paddedTime: '' });
 const allCategories = ref([]);
 /**
  * @type {import('vue').Ref<boolean>}
@@ -517,9 +523,9 @@ const save = async () => {
 };
 
 const initEmptyRecipe = () => {
-    prepTime.value = { time: [0, 0], paddedTime: '' };
-    cookTime.value = { time: [0, 0], paddedTime: '' };
-    totalTime.value = { time: [0, 0], paddedTime: '' };
+    prepTime.value = { time: [0, 0, 0], paddedTime: '' };
+    cookTime.value = { time: [0, 0, 0], paddedTime: '' };
+    totalTime.value = { time: [0, 0, 0], paddedTime: '' };
     // this.nutrition = {}
     recipe.value = {
         id: 0,
@@ -563,27 +569,33 @@ const setup = async () => {
     if (route.params.id) {
         // Parse time values
         let timeComps = recipe.value.prepTime
-            ? recipe.value.prepTime.match(/PT(\d+?)H(\d+?)M/)
+            ? recipe.value.prepTime.match(/PT(\d+?)H(\d+?)M(\d+?)S/)
             : null;
         prepTime.value = {
-            time: timeComps ? [timeComps[1], timeComps[2]] : [0, 0],
+            time: timeComps
+                ? [timeComps[1], timeComps[2], timeComps[3]]
+                : [0, 0, 0],
             paddedTime: recipe.value.prepTime,
         };
 
         timeComps = recipe.value.cookTime
-            ? recipe.value.cookTime.match(/PT(\d+?)H(\d+?)M/)
+            ? recipe.value.cookTime.match(/PT(\d+?)H(\d+?)M(\d+?)S/)
             : null;
         cookTime.value = {
-            time: timeComps ? [timeComps[1], timeComps[2]] : [0, 0],
+            time: timeComps
+                ? [timeComps[1], timeComps[2], timeComps[3]]
+                : [0, 0, 0],
             paddedTime: recipe.value.cookTime,
         };
 
         timeComps = recipe.value.totalTime
-            ? recipe.value.totalTime.match(/PT(\d+?)H(\d+?)M/)
+            ? recipe.value.totalTime.match(/PT(\d+?)H(\d+?)M(\d+?)S/)
             : null;
 
         totalTime.value = {
-            time: timeComps ? [timeComps[1], timeComps[2]] : [0, 0],
+            time: timeComps
+                ? [timeComps[1], timeComps[2], timeComps[3]]
+                : [0, 0, 0],
             paddedTime: recipe.value.totalTime,
         };
 

--- a/src/components/RecipeView/RecipeTimer.vue
+++ b/src/components/RecipeView/RecipeTimer.vue
@@ -185,15 +185,23 @@ const displayTime = computed(() => {
         text += displayHours.value;
     }
     if (
-        (props.value.hours && props.value.hours > 0) ||
-        (props.value.minutes && props.value.minutes > 0)
+        (countdownStarted.value &&
+            ((props.value.hours && props.value.hours > 0) ||
+                (props.value.minutes && props.value.minutes > 0))) ||
+        (!countdownStarted.value &&
+            props.value.minutes &&
+            props.value.minutes > 0)
     ) {
         text += displayMinutes.value;
     }
     if (
-        (props.value.hours && props.value.hours > 0) ||
-        (props.value.minutes && props.value.minutes > 0) ||
-        (props.value.seconds && props.value.seconds > 0)
+        (countdownStarted.value &&
+            ((props.value.hours && props.value.hours > 0) ||
+                (props.value.minutes && props.value.minutes > 0) ||
+                (props.value.seconds && props.value.seconds > 0))) ||
+        (!countdownStarted.value &&
+            props.value.seconds &&
+            props.value.seconds > 0)
     ) {
         text += displaySeconds.value;
     }

--- a/src/components/RecipeView/RecipeTimer.vue
+++ b/src/components/RecipeView/RecipeTimer.vue
@@ -7,7 +7,10 @@
             @click="timerToggle"
         ></button>
         <h4>{{ label }}</h4>
-        <p v-html="displayTime"></p>
+        <div class="timeContainer">
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <p v-html="displayTime"></p>
+        </div>
     </div>
 </template>
 
@@ -244,6 +247,8 @@ export default {
 <style scoped>
 .time {
     position: relative;
+    display: flex;
+    flex-direction: column;
     flex-grow: 1;
     border: 1px solid var(--color-border-dark);
     border-radius: 3px;
@@ -268,7 +273,11 @@ export default {
     font-weight: bold;
 }
 
-.time p {
+.time > .timeContainer {
+    display: flex;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
     padding: 0.5rem;
 }
 
@@ -276,7 +285,7 @@ export default {
 .time :deep(.timerUnit) {
     color: var(--color-text-lighter);
     font-size: 0.8em;
-    margin-inline-end: 0.5rem;
+    margin-inline-end: 0.3em;
 }
 
 @media print {

--- a/src/components/RecipeView/RecipeTimer.vue
+++ b/src/components/RecipeView/RecipeTimer.vue
@@ -126,6 +126,13 @@ const timerToggle = () => {
     }
 };
 
+/**
+ * Add style to the unit of the value.
+ * @param str Complete translated string with value and unit
+ * @param value The value without the unit
+ * @param isPadded If value should be padded with zeros to ensure it has two digits
+ * @returns {string} Complete styled string with value and unit
+ */
 const styleUnit = (str, value, isPadded = true) => {
     // Remove value
     const unit = str.replace(`${value.toString()}`, '');
@@ -173,7 +180,24 @@ const displaySeconds = computed(() => {
 });
 
 const displayTime = computed(() => {
-    return displayHours.value + displayMinutes.value + displaySeconds.value;
+    let text = '';
+    if (props.value.hours && props.value.hours > 0) {
+        text += displayHours.value;
+    }
+    if (
+        (props.value.hours && props.value.hours > 0) ||
+        (props.value.minutes && props.value.minutes > 0)
+    ) {
+        text += displayMinutes.value;
+    }
+    if (
+        (props.value.hours && props.value.hours > 0) ||
+        (props.value.minutes && props.value.minutes > 0) ||
+        (props.value.seconds && props.value.seconds > 0)
+    ) {
+        text += displaySeconds.value;
+    }
+    return text;
 });
 
 // Watchers

--- a/src/components/RecipeView/RecipeTimer.vue
+++ b/src/components/RecipeView/RecipeTimer.vue
@@ -22,7 +22,7 @@ const props = defineProps({
     value: {
         type: Object,
         default() {
-            return { hours: 0, minutes: 0 };
+            return { hours: 0, minutes: 0, seconds: 0 };
         },
     },
     label: {
@@ -68,7 +68,11 @@ const resetTimeDisplay = () => {
     } else {
         minutes.value = 0;
     }
-    seconds.value = 0;
+    if (props.value.seconds) {
+        seconds.value = parseInt(props.value.seconds, 10);
+    } else {
+        seconds.value = 0;
+    }
 };
 
 const onTimerEnd = () => {

--- a/src/components/RecipeView/RecipeTimer.vue
+++ b/src/components/RecipeView/RecipeTimer.vue
@@ -51,7 +51,7 @@ const seconds = ref(0);
 /**
  * @type {import('vue').Ref<boolean>}
  */
-const showFullTime = ref(false);
+const countdownStarted = ref(false);
 // Create a ref for the audio element
 const audio = ref(new Audio());
 
@@ -88,7 +88,7 @@ const onTimerEnd = () => {
         audio.value.pause();
 
         countdown.value = null;
-        showFullTime.value = false;
+        countdownStarted.value = false;
         resetTimeDisplay();
     }, 100);
 };
@@ -97,8 +97,8 @@ const timerToggle = () => {
     // We will switch to full time display the first time this method is invoked.
     // There should probably also be a way to reset the timer other than by letting
     //  it run its course...
-    if (!showFullTime.value) {
-        showFullTime.value = true;
+    if (!countdownStarted.value) {
+        countdownStarted.value = true;
     }
     if (countdown.value === null) {
         countdown.value = window.setInterval(() => {
@@ -128,14 +128,23 @@ const timerToggle = () => {
 // Computed properties
 const displayTime = computed(() => {
     let text = '';
-    if (showFullTime.value) {
-        text += `${hours.value.toString().padStart(2, '0')}:`;
-    } else {
-        text += `${hours.value.toString()}:`;
+    // TRANSLATORS hours part of timer text
+    text += n('cookbook', '{hours}h', '{hours}h', hours.value, {
+        hours: `${hours.value.toString().padStart(2, '0')}`,
+    });
+    // Show during countdown, if value is not 0, or if a value for seconds is given
+    if (countdownStarted.value || minutes.value > 0 || seconds.value > 0) {
+        // TRANSLATORS minutes part of timer text
+        text += n('cookbook', '{minutes}m', '{minutes}m', minutes.value, {
+            minutes: `${minutes.value.toString().padStart(2, '0')}`,
+        });
+        // text += n('cookbook', '%minutes m', '%minutes m', minutes.value);
     }
-    text += minutes.value.toString().padStart(2, '0');
-    if (showFullTime.value) {
-        text += `:${seconds.value.toString().padStart(2, '0')}`;
+    // Show during countdown or if value is not 0
+    if (countdownStarted.value || seconds.value > 0) {
+        text += n('cookbook', '{seconds}s', '{seconds}s', seconds.value, {
+            seconds: `${seconds.value.toString().padStart(2, '0')}`,
+        });
     }
     return text;
 });

--- a/src/components/RecipeView/RecipeView.vue
+++ b/src/components/RecipeView/RecipeView.vue
@@ -112,7 +112,7 @@
                             "
                             :value="recipe.timerPrep"
                             :timer="false"
-                            :label="t('cookbook', 'Preparation time (H:MM)')"
+                            :label="t('cookbook', 'Preparation time')"
                         />
                         <RecipeTimer
                             v-if="
@@ -121,7 +121,7 @@
                             "
                             :value="recipe.timerCook"
                             :timer="true"
-                            :label="t('cookbook', 'Cooking time (H:MM)')"
+                            :label="t('cookbook', 'Cooking time')"
                         />
                         <RecipeTimer
                             v-if="
@@ -130,7 +130,7 @@
                             "
                             :value="recipe.timerTotal"
                             :timer="false"
-                            :label="t('cookbook', 'Total time (H:MM)')"
+                            :label="t('cookbook', 'Total time')"
                         />
                     </div>
                 </div>

--- a/src/components/RecipeView/RecipeView.vue
+++ b/src/components/RecipeView/RecipeView.vue
@@ -457,29 +457,38 @@ const recipe = computed(() => {
     }
 
     if (store.state.recipe.cookTime) {
-        const cookT = store.state.recipe.cookTime.match(/PT(\d+?)H(\d+?)M/);
+        const cookT = store.state.recipe.cookTime.match(
+            /PT(\d+?)H(\d+?)M(\d+?)S/,
+        );
         const hh = parseInt(cookT[1], 10);
         const mm = parseInt(cookT[2], 10);
-        if (hh > 0 || mm > 0) {
-            tmpRecipe.timerCook = { hours: hh, minutes: mm };
+        const ss = parseInt(cookT[3], 10);
+        if (hh > 0 || mm > 0 || ss > 0) {
+            tmpRecipe.timerCook = { hours: hh, minutes: mm, seconds: ss };
         }
     }
 
     if (store.state.recipe.prepTime) {
-        const prepT = store.state.recipe.prepTime.match(/PT(\d+?)H(\d+?)M/);
+        const prepT = store.state.recipe.prepTime.match(
+            /PT(\d+?)H(\d+?)M(\d+?)S/,
+        );
         const hh = parseInt(prepT[1], 10);
         const mm = parseInt(prepT[2], 10);
-        if (hh > 0 || mm > 0) {
-            tmpRecipe.timerPrep = { hours: hh, minutes: mm };
+        const ss = parseInt(prepT[3], 10);
+        if (hh > 0 || mm > 0 || ss > 0) {
+            tmpRecipe.timerPrep = { hours: hh, minutes: mm, seconds: ss };
         }
     }
 
     if (store.state.recipe.totalTime) {
-        const totalT = store.state.recipe.totalTime.match(/PT(\d+?)H(\d+?)M/);
+        const totalT = store.state.recipe.totalTime.match(
+            /PT(\d+?)H(\d+?)M(\d+?)S/,
+        );
         const hh = parseInt(totalT[1], 10);
         const mm = parseInt(totalT[2], 10);
-        if (hh > 0 || mm > 0) {
-            tmpRecipe.timerTotal = { hours: hh, minutes: mm };
+        const ss = parseInt(totalT[3], 10);
+        if (hh > 0 || mm > 0 || ss > 0) {
+            tmpRecipe.timerTotal = { hours: hh, minutes: mm, seconds: ss };
         }
     }
 

--- a/src/guest.js
+++ b/src/guest.js
@@ -26,6 +26,7 @@ Vue.prototype.OC = OC;
 
 // Pass translation engine to Vue
 Vue.prototype.t = window.t;
+Vue.prototype.n = window.n;
 
 const store = useStore();
 

--- a/src/main.js
+++ b/src/main.js
@@ -62,6 +62,7 @@ store.dispatch('refreshConfig');
 
 // Pass translation engine to Vue
 Vue.prototype.t = window.t;
+Vue.prototype.n = window.n;
 
 // Start the app once document is done loading
 Vue.$log.info('Main is done. Creating App.');


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

- Update timer display
  - Remove `H:MM` from label
  - Add units
  - Add support for durations with seconds
- Add possibility to define seconds for time periods in recipe editor 
- Make global i18n `n(...)` function available in JS

Closes #1408. Closes #1747 

<img width="502" alt="Screenshot 2023-12-19 at 14 47 10" src="https://github.com/nextcloud/cookbook/assets/7623143/8d33c80f-5523-4681-825c-2f9808f02896">


## Concerns/issues

_This currently only supports translations to left-to-right languages, i.e., first hours, then minutes, then seconds._

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
