### PR TITLE
Feat/507 add citation field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 - Toast with success/error message after trying to copy ingredients [#2040](https://github.com/nextcloud/cookbook/pull/2040) @seyfeb
 - Seconds can now be specified for recipe times [#2014](https://github.com/nextcloud/cookbook/pull/2014) @seyfeb
+- Added support for citation field [#2023](https://github.com/nextcloud/cookbook/pull/2023) @seyfeb
 
 ### Fixed
 - Prevent yield calculation for ## as ingredient headline [#1998](https://github.com/nextcloud/cookbook/pull/1998) @j0hannesr0th

--- a/src/components/FormComponents/EditInputField.vue
+++ b/src/components/FormComponents/EditInputField.vue
@@ -1,6 +1,6 @@
 <template>
     <fieldset>
-        <label>
+        <label :id="inputLabelId">
             {{ fieldLabel }}
         </label>
         <textarea
@@ -9,6 +9,7 @@
             "
             ref="inputField"
             v-model="content"
+            :aria-labelledby="inputLabelId"
             @input="handleInput"
             @keydown="keyDown"
             @keyup="handleSuggestionsPopupKeyUp"
@@ -23,6 +24,7 @@
                 ref="inputField"
                 v-model="content"
                 :type="props.fieldType"
+                :aria-labelledby="inputLabelId"
                 @input="handleInput"
                 @keydown="keyDown"
                 @keyup="handleSuggestionsPopupKeyUp"
@@ -88,6 +90,12 @@ const suggestionsData = ref(null);
  * @type {import('vue').Ref<string>}
  */
 const content = ref(props.value);
+
+/**
+ * Unique identifier used for identifying the input label for accessibility reasons.
+ * @type {import('vue').Ref<string>}
+ */
+const inputLabelId = ref(`input-label-${Math.floor(Math.random() * 10000000)}`);
 
 // deconstruct composable
 const {

--- a/src/components/FormComponents/EditInputField.vue
+++ b/src/components/FormComponents/EditInputField.vue
@@ -9,7 +9,9 @@
             "
             ref="inputField"
             v-model="content"
+            :placeholder="placeholder"
             :aria-labelledby="inputLabelId"
+            :aria-placeholder="placeholder"
             @input="handleInput"
             @keydown="keyDown"
             @keyup="handleSuggestionsPopupKeyUp"
@@ -24,7 +26,9 @@
                 ref="inputField"
                 v-model="content"
                 :type="props.fieldType"
+                :placeholder="placeholder"
                 :aria-labelledby="inputLabelId"
+                :aria-placeholder="placeholder"
                 @input="handleInput"
                 @keydown="keyDown"
                 @keyup="handleSuggestionsPopupKeyUp"
@@ -65,6 +69,10 @@ const props = defineProps({
         type: Boolean,
         default: false,
         required: false,
+    },
+    placeholder: {
+        type: String,
+        default: '',
     },
     suggestionOptions: {
         type: Array,

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -17,6 +17,15 @@
                 :suggestion-options="allRecipeOptions"
             />
             <EditInputField
+                v-model="recipe['citation']"
+                :field-type="'text'"
+                :field-label="t('cookbook', 'Source')"
+                :placeholder="
+                    // TRANSLATORS Example (placeholder) name for a citation of the recipe's source
+                    t('cookbook', 'Grandma Betty')
+                "
+            />
+            <EditInputField
                 v-model="recipe['url']"
                 :field-type="'url'"
                 :field-label="t('cookbook', 'URL')"
@@ -201,6 +210,7 @@ const recipe = ref({
     id: 0,
     name: '',
     description: '',
+    citation: '',
     url: '',
     image: '',
     prepTime: '',
@@ -531,6 +541,7 @@ const initEmptyRecipe = () => {
         id: 0,
         name: null,
         description: '',
+        citation: '',
         url: '',
         image: '',
         prepTime: '',

--- a/src/components/RecipeView/RecipeView.vue
+++ b/src/components/RecipeView/RecipeView.vue
@@ -14,9 +14,18 @@
                 </div>
 
                 <div class="meta">
-                    <h2 class="heading">{{ $store.state.recipe.name }}</h2>
+                    <div class="heading">
+                        <h2 class="mb-0">{{ $store.state.recipe.name }}</h2>
+                        <p v-if="$store.state.recipe.citation">
+                            {{
+                                // TRANSLATORS Indicates citation/source of recipe. Ex. "by Grandma Betty"
+                                t('cookbook', 'by')
+                            }}
+                            <span>{{ $store.state.recipe.citation }}</span>
+                        </p>
+                    </div>
                     <div class="details">
-                        <div v-if="recipe.keywords.length">
+                        <div v-if="recipe.keywords.length" class="mb-3">
                             <ul v-if="recipe.keywords.length">
                                 <RecipeKeyword
                                     v-for="(keyword, idx) in recipe.keywords"
@@ -816,6 +825,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.mb-0 {
+    margin-bottom: 0 !important;
+}
+.mb-3 {
+    margin-bottom: 0.75rem !important;
+}
 .wrapper {
     width: 100%;
 }
@@ -873,6 +888,7 @@ export default {
 
 .heading {
     margin-top: 12px;
+    margin-bottom: 1rem;
 }
 
 .dates {

--- a/src/components/RecipeView/RecipeView.vue
+++ b/src/components/RecipeView/RecipeView.vue
@@ -828,9 +828,11 @@ export default {
 .mb-0 {
     margin-bottom: 0 !important;
 }
+
 .mb-3 {
     margin-bottom: 0.75rem !important;
 }
+
 .wrapper {
     width: 100%;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Adds support for the `citation` property (https://schema.org/citation) to recipe editor and viewer.

Example with `citation: "Peter Pan"`

<img width="450" alt="Screenshot 2023-12-23 at 18 10 20" src="https://github.com/nextcloud/cookbook/assets/7623143/1365bf16-1c85-496d-9b22-1c4c72bc792a">


Closes #507 

## Concerns/issues

Possible UI/UX option: Make citation text an anchor if `URL` property is set. This would make for a cleaner look (no URL is shown). Caveats: What if URL is set, but no `citation` field?

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
