### PR TITLE
Feat/1961 feedback for ingredient copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Added
+- Toast with success/error message after trying to copy ingredients [#2040](https://github.com/nextcloud/cookbook/pull/2040) @seyfeb
+
 ### Fixed
 - Prevent yield calculation for ## as ingredient headline [#1998](https://github.com/nextcloud/cookbook/pull/1998) @j0hannesr0th
 - Add missing translatable string for recipe-creation button in empty list view [#2015](https://github.com/nextcloud/cookbook/pull/2015) @seyfeb

--- a/src/components/RecipeView/RecipeView.vue
+++ b/src/components/RecipeView/RecipeView.vue
@@ -363,6 +363,7 @@ import { showSimpleAlertModal } from 'cookbook/js/modals';
 import yieldCalculator from 'cookbook/js/yieldCalculator';
 import ContentCopyIcon from 'icons/ContentCopy.vue';
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js';
+import { showError, showSuccess } from '@nextcloud/dialogs';
 import { useStore } from '../../store';
 import emitter from '../../bus';
 import { parseDateTime } from '../../composables/dateTimeHandling';
@@ -633,14 +634,27 @@ const changeRecipeYield = (increase = true) => {
     recipeYield.value += increase ? 1 : -1;
 };
 
+function showCopySuccess(item) {
+    showSuccess(t('cookbook', '{item} copied to clipboard', { item }));
+}
+function showCopyError(item) {
+    showError(t('cookbook', 'Copying {item} to clipboard failed', { item }));
+}
+
 const copyIngredientsToClipboard = () => {
     const ingredientsToCopy = scaledIngredients.value.join('\n');
 
     if (navigator.clipboard) {
         navigator.clipboard
             .writeText(ingredientsToCopy)
-            .then(() => log.info('JSON array copied to clipboard'))
-            .catch((err) => log.error('Failed to copy JSON array: ', err));
+            .then(() => {
+                log.info('JSON array copied to clipboard');
+                showCopySuccess(t('cookbook', 'Ingredients'));
+            })
+            .catch((err) => {
+                log.error('Failed to copy JSON array: ', err);
+                showCopyError(t('cookbook', 'ingredients'));
+            });
     } else {
         // fallback solution
         const input = document.createElement('textarea');
@@ -654,11 +668,14 @@ const copyIngredientsToClipboard = () => {
             const successful = document.execCommand('copy');
             if (successful) {
                 log.info('JSON array copied to clipboard');
+                showCopySuccess(t('cookbook', 'Ingredients'));
             } else {
                 log.error('Failed to copy JSON array');
+                showCopyError(t('cookbook', 'ingredients'));
             }
         } catch (err) {
             log.error('Failed to copy JSON array: ', err);
+            showCopyError(t('cookbook', 'ingredients'));
         }
         document.body.removeChild(input);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Add a toast message after trying to copy ingredients to the clipboard. This provides the user with some feedback to ensure him that the button click was registered and actually did something.

Closes #1961 

## Concerns/issues

_None_

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
