### PR TITLE
fix: yield not set calculation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   [#2015](https://github.com/nextcloud/cookbook/pull/2015) @seyfeb
 - Prevent recalculation algorithm if no yield is given
   [#2003](https://github.com/nextcloud/cookbook/pull/2003) @j0hannesr0th
+- Fix yield not set calculation error
+  [#2099](https://github.com/nextcloud/cookbook/pull/2099) @j0hannesr0th
 
 ### Documentation
 - Improve  structure of `README.md`

--- a/src/components/RecipeView/RecipeView.vue
+++ b/src/components/RecipeView/RecipeView.vue
@@ -184,7 +184,7 @@
                             <span class="icon-error" />
                             {{
                                 // prettier-ignore
-                                t("cookbook", "The ingredient cannot be recalculated due to incorrect syntax. Please change it to this syntax: amount unit ingredient. Examples: 200 g carrots or 1 pinch of salt")
+                                t("cookbook", "The ingredient cannot be recalculated due to incorrect syntax. Please ensure the syntax follows this format: amount unit ingredient and that a specific number of portions is set for this function to work correctly. Examples: 200 g carrots or 1 pinch of salt.")
                             }}
                         </div>
                     </section>

--- a/src/js/yieldCalculator.js
+++ b/src/js/yieldCalculator.js
@@ -41,6 +41,10 @@ function recalculateIngredients(ingredients, currentYield, originalYield) {
             return ingredient;
         }
 
+        if (!Number.isInteger(originalYield) || originalYield < 1) {
+            return ingredient;
+        }
+
         const matches = ingredient.match(fractionRegExp);
 
         if (matches) {


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

Fixes #1986

Thanks for the video @christianlupus - I haven't knew that I can click "servings" to disable them. When trying to reproduce it I just haven't set it and it was "1" by default.

![image](https://github.com/nextcloud/cookbook/assets/36242595/713a7a35-e5a8-4842-b8b3-af6b0ac7086e)


_Please write, what the PR is about and what it does or should do. This does not need to be very long._

none.

_Is the PR potentially cause any issues that might be of interest? Any other issues to be tought of?_

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
