### PR TITLE
Fix: remove client 'nook' from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   [#1989](https://github.com/nextcloud/cookbook/pull/1989) @seyfeb
 - Fix wrong type definition in OpenAPI specs
   [#2232](https://github.com/nextcloud/cookbook/pull/2232) @Leptopoda
+- Removed no longer existing app Nook
+  [#2225](https://github.com/nextcloud/cookbook/pull/2225) @Leptopoda
 
 ### Maintenance
 - Add Typescript support

--- a/docs/user/clients/Index.md
+++ b/docs/user/clients/Index.md
@@ -1,6 +1,6 @@
 ## Clients 
 
-The app works generally in any modern browser. Additionally, there are some more specialized clients available, including mobile apps for Android and iOS..
+The app works generally in any modern browser. Additionally, there are some more specialized clients available, including mobile apps for Android and iOS.
 
 ## 📱 Mobile Applications
 The currently available clients are in no particular order:
@@ -9,7 +9,6 @@ The currently available clients are in no particular order:
 |------------------------------------------------------|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [Nextcloud Cookbook][micmun-nextcloud-cookbook]      | [MicMun][micmun]     | [<img src="img/f-droid.png" alt="Get it on F-Droid" height="50">][micmun-nextcloud-cookbook-fdroid] [<img src="img/g-play.png" alt="Get it on Google Play" height="50">][micmun-nextcloud-cookbook-play-store]                                                                                                                         |
 | [Nextcloud Cookbook][teifun2-nextcloud-cookbook]     | [Teifun2][teifun2]   | [<img src="img/f-droid.png" alt="Get it on F-Droid" height="50">][teifun2-nextcloud-cookbook-fdroid] [<img src="img/g-play.png" alt="Get it on Google Play" height="50">][teifun2-nextcloud-cookbook-play-store] [<img src="img/ios-store.svg" alt="Download on the App Store" height="35">][teifun2-nextcloud-cookbook-ios-app-store] |
-| Nook                                                 |                      | [<img src="img/g-play.png" alt="Get it on Google Play" height="50">][nook-play-store]                                                                                                                                                                                                                                                  |
 | [Nextcloud Cookbook][lneugebauer-nextcloud-cookbook] | [lneugebauer][]      | [<img src="img/f-droid.png" alt="Get it on F-Droid" height="50">][lneugebauer-nextcloud-cookbook-fdroid] [<img src="img/g-play.png" alt="Get it on Google Play" height="50">][lneugebauer-nextcloud-cookbook-play-store]                                                                                                               |
 | [Cookbook Client][teifun2-nextcloud-cookbook]        | [VincentMeilinger][] | [<img src="img/ios-store.svg" alt="Download on the App Store" height="35">][teifun2-nextcloud-cookbook-ios-app-store]                                                                                                                                                                                                                  |
 
@@ -28,9 +27,6 @@ The currently available clients are in no particular order:
 [teifun2-nextcloud-cookbook-fdroid]: <https://f-droid.org/en/packages/com.nextcloud_cookbook_flutter/> (Nextcloud Cookbook F-Droid)
 [teifun2-nextcloud-cookbook-play-store]: <https://play.google.com/store/apps/details?id=com.nextcloud_cookbook_flutter&hl=en_US&gl=US> (Nextcloud Cookbook Google Play Store)
 [teifun2-nextcloud-cookbook-ios-app-store]: <https://apps.apple.com/us/app/nextcloud-cookbook/id1619926634?itsct=apps_box_badge&amp;itscg=30200> (Nextcloud Cookbook iOS App Store)
-
-<!-- Nook -->
-[nook-play-store]: <https://play.google.com/store/apps/details?id=org.capacitor.cookbook.app> (Nook Google Play Store)
 
 <!-- lneugebauer -->
 [lneugebauer]: <https://github.com/lneugebauer>


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

The PR removes the client 'nook' from the clients page since it is not longer available. The link to the Play Store does not work and also with a search I could not find it. 

## Concerns/issues

_Is the PR potentially cause any issues that might be of interest? Any other issues to be tought of?_

No

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ ] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
