### PR TITLE
fix: openapi specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 ### Documentation
 - Improve  structure of `README.md`
   [#1989](https://github.com/nextcloud/cookbook/pull/1989) @seyfeb
+- Fix wrong type definition in OpenAPI specs
+  [#2232](https://github.com/nextcloud/cookbook/pull/2232) @Leptopoda
 
 ### Maintenance
 - Add Typescript support

--- a/docs/dev/api/0.1.2/objects.yaml
+++ b/docs/dev/api/0.1.2/objects.yaml
@@ -138,7 +138,7 @@ RecipeStub:
     - type: object
       properties:
         recipe_id:
-          type: int
+          type: integer
           description: |
             The index of the recipe. Note this is a string and might change its appearance in the future.
 


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

`int` is not a valid openapi type so automated tools fail parsing the spec 

## Concerns/issues

N.A.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
