### PR TITLE
Add workaround by defining label outside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   [#2099](https://github.com/nextcloud/cookbook/pull/2099) @j0hannesr0th
 - Output correct stubs for tags, search and categories in the API
   [#2270](https://github.com/nextcloud/cookbook/pull/2270) @christianlupus
+- Fix warning in browser console
+  [#2281](https://github.com/nextcloud/cookbook/pull/2281) @christianlupus
 
 ### Documentation
 - Improve  structure of `README.md`

--- a/src/components/List/RecipeFilterControlsInline.vue
+++ b/src/components/List/RecipeFilterControlsInline.vue
@@ -33,6 +33,7 @@
                     input-id="categoriesFilterInput"
                     :options="uniqueCategories"
                     :loading="isLoading"
+                    :label-outside="true"
                     :close-on-select="false"
                     :multiple="true"
                     :no-wrap="true"
@@ -96,6 +97,7 @@
                     :placeholder="t('cookbook', 'All keywords')"
                     :aria-label="t('cookbook', 'Keywords')"
                     :aria-placeholder="t('cookbook', 'All keywords')"
+                    :label-outside="true"
                     style="max-width: 25%"
                     @input="submitFilters"
                 >

--- a/src/components/List/RecipeSortSelect.vue
+++ b/src/components/List/RecipeSortSelect.vue
@@ -4,6 +4,7 @@
         class="recipes-sorting-dropdown mr-4"
         :clearable="false"
         label="selectedLabel"
+        :label-outside="true"
         :multiple="false"
         :searchable="false"
         :placeholder="t('cookbook', 'Select order')"


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Currently, there is a error logged in the browser when opening the recipe list:

![grafik](https://github.com/nextcloud/cookbook/assets/8202922/98fb43a3-0af3-447f-b86a-af81e24cdaaf)

This PR just sets `labelOutside` to true to quite the warning.

## Concerns/issues

This is just a workaround until the new frontend is in place.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
