### PR TITLE
Create new method for changelog handling

### DIFF
--- a/.changelog/current/1989-auto-generated.md
+++ b/.changelog/current/1989-auto-generated.md
@@ -1,0 +1,3 @@
+### Documentation
+
+- Improve  structure of `README.md`

--- a/.changelog/current/1998-auto-generated.md
+++ b/.changelog/current/1998-auto-generated.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Prevent yield calculation for ## as ingredient headline

--- a/.changelog/current/2003-auto-generated.md
+++ b/.changelog/current/2003-auto-generated.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Prevent recalculation algorithm if no yield is given

--- a/.changelog/current/2014-auto-generated.md
+++ b/.changelog/current/2014-auto-generated.md
@@ -1,0 +1,7 @@
+### Added
+
+- Seconds can now be specified for recipe times
+
+### Fixed
+
+- Improved styling of times in recipe view

--- a/.changelog/current/2015-auto-generated.md
+++ b/.changelog/current/2015-auto-generated.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Add missing translatable string for recipe-creation button in empty list view

--- a/.changelog/current/2037-auto-generated.md
+++ b/.changelog/current/2037-auto-generated.md
@@ -1,0 +1,3 @@
+### Added
+
+- New filter UI in recipe lists

--- a/.changelog/current/2040-auto-generated.md
+++ b/.changelog/current/2040-auto-generated.md
@@ -1,0 +1,3 @@
+### Added
+
+- Toast with success/error message after trying to copy ingredients

--- a/.changelog/current/2059-auto-generated.md
+++ b/.changelog/current/2059-auto-generated.md
@@ -1,0 +1,3 @@
+### Maintenance
+
+- Add Typescript support

--- a/.changelog/current/2099-auto-generated.md
+++ b/.changelog/current/2099-auto-generated.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix yield not set calculation error

--- a/.changelog/current/2122-auto-generated.md
+++ b/.changelog/current/2122-auto-generated.md
@@ -1,0 +1,3 @@
+### Maintenance
+
+- Update coding standards

--- a/.changelog/current/2141-auto-generated.md
+++ b/.changelog/current/2141-auto-generated.md
@@ -1,0 +1,3 @@
+### Maintenance
+
+- Update eslint config for typescript

--- a/.changelog/current/2142-auto-generated.md
+++ b/.changelog/current/2142-auto-generated.md
@@ -1,0 +1,3 @@
+### Maintenance
+
+- Update NPM and Node version

--- a/.changelog/current/2188-auto-generated.md
+++ b/.changelog/current/2188-auto-generated.md
@@ -1,0 +1,3 @@
+### Maintenance
+
+- Update vue plugin for eslint with typescript

--- a/.changelog/current/2225-auto-generated.md
+++ b/.changelog/current/2225-auto-generated.md
@@ -1,0 +1,3 @@
+### Documentation
+
+- Removed no longer existing app Nook

--- a/.changelog/current/2232-auto-generated.md
+++ b/.changelog/current/2232-auto-generated.md
@@ -1,0 +1,3 @@
+### Documentation
+
+- Fix wrong type definition in OpenAPI specs

--- a/.changelog/current/2250-auto-generated.md
+++ b/.changelog/current/2250-auto-generated.md
@@ -1,0 +1,3 @@
+### Maintenance
+
+- Import NC core components correctly

--- a/.changelog/current/2270-auto-generated.md
+++ b/.changelog/current/2270-auto-generated.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Output correct stubs for tags, search and categories in the API

--- a/.changelog/current/2279-auto-generated.md
+++ b/.changelog/current/2279-auto-generated.md
@@ -1,0 +1,3 @@
+### Maintenance
+
+- Update nextcloud router

--- a/.changelog/current/2281-auto-generated.md
+++ b/.changelog/current/2281-auto-generated.md
@@ -1,0 +1,7 @@
+### Maintenance
+
+- Update typescript
+
+### Fixed
+
+- Fix warning in browser console

--- a/.changelog/current/2287-auto-generated.md
+++ b/.changelog/current/2287-auto-generated.md
@@ -1,0 +1,4 @@
+
+### Fixed
+
+- Fix warning in browser console for edits

--- a/.changelog/current/2291-update-changelog.md
+++ b/.changelog/current/2291-update-changelog.md
@@ -1,3 +1,3 @@
-### Maintenacne
+### Maintenance
 
 - Update changlog process to allow for backports

--- a/.changelog/current/2291-update-changelog.md
+++ b/.changelog/current/2291-update-changelog.md
@@ -1,0 +1,3 @@
+### Maintenacne
+
+- Update changlog process to allow for backports

--- a/.changelog/prefix.md
+++ b/.changelog/prefix.md
@@ -1,0 +1,14 @@
+## Note on incomplete changelogs
+
+Please note that the changelog in this branch is not complete.
+This is due to the way, how the changelog file is managed and generated.
+
+To be precise:
+Releses on parallel development branches will not appear in this CHANGELOG.
+Instead have a look at the correpsonding branches for an appropriate CHANGELOG.
+
+Also note, that the releases on this repository are not the actual releases of the cookbook.
+The releases are stored for technical reasins in the repository [christianlupus-nextcloud/cookbook-releases](https://github.com/christianlupus-nextcloud/cookbook-releases).
+Sorry for the inconvience.
+
+

--- a/.changelog/prefix.md
+++ b/.changelog/prefix.md
@@ -1,7 +1,11 @@
-## Note on incomplete changelogs
+## Note on incomplete changelogs and releases
 
 Please note that the changelog in this branch is not complete.
 This is due to the way, how the changelog file is managed and generated.
+
+Any changes to the branch not yet released are not guaranteed to be part of the changelog file.
+This file is auto-generated during the release process.
+See also the other files in `.changelog/current` for all merged changes since the last release.
 
 To be precise:
 Releses on parallel development branches will not appear in this CHANGELOG.

--- a/.changelog/versions/v0.10.0.md
+++ b/.changelog/versions/v0.10.0.md
@@ -1,0 +1,14 @@
+## 0.10.0 - 2022-11-06
+
+### Changed
+- Update app to be compatible with Nextcloud server version 25 @christianlupus
+
+### Fixed
+- Allow import of recipes with HowToSections
+  [#1255](https://github.com/nextcloud/cookbook/pull/1255) @christianlupus
+
+### Changed
+- Add an app configuration (settings modal) to replace the one in the sidebar
+  [#1258](https://github.com/nextcloud/cookbook/pull/1258) @MarcelRobitaille
+
+

--- a/.changelog/versions/v0.10.1.md
+++ b/.changelog/versions/v0.10.1.md
@@ -1,0 +1,14 @@
+## 0.10.1 - 2022-11-09
+
+### Fixed
+- Fix printing in app to show all pages with NC25
+  [#1327](https://github.com/nextcloud/cookbook/pull/1327) @christianlupus
+- Critical security issue fixed related to vue-loader
+
+### Maintenance
+- Cleaned up some minor code issues and updated some dependencies
+  [#1321](https://github.com/nextcloud/cookbook/pull/1321) @christianlupus
+- Make issue-template selection description clearer
+  [1323](https://github.com/nextcloud/cookbook/pull/1323) @seyfeb
+
+

--- a/.changelog/versions/v0.10.2.md
+++ b/.changelog/versions/v0.10.2.md
@@ -1,0 +1,44 @@
+## 0.10.2 - 2023-03-24
+
+### Changed
+- Make info block visibility configurable
+  [1404](https://github.com/nextcloud/cookbook/pull/1404) @MarcelRobitaille
+
+### Fixed
+- Make "None" category string translatable
+  [#1323](https://github.com/nextcloud/cookbook/pull/1344) @seyfeb
+- Import was no longer possible as the handling of native events caused a glitch
+  [#1442](https://github.com/nextcloud/cookbook/pull/1442) @christianlupus
+- Reorder arrows are no longer hidden
+  [#1446](https://github.com/nextcloud/cookbook/pull/1446) @christianlupus
+- Add network logging for responses, not only requests
+  [1405](https://github.com/nextcloud/cookbook/pull/1405) @MarcelRobitaille
+- Make the server api compliant
+  [#1464](https://github.com/nextcloud/cookbook/pull/1464) @leptopoda
+- Fix string in translations
+  [#1549](https://github.com/nextcloud/cookbook/pull/1549) @silopolis
+- Mark app compatible with NC26
+
+### Maintenance
+- Update dependency for GitHub pages builder
+- Fix package.json sort order
+- Migrate the dev environment to [docker-dev by Julius Haertl](https://github.com/juliushaertl/nextcloud-docker-dev)
+  [#1440](https://github.com/nextcloud/cookbook/pull/1440) @christianlupus
+- Fix the build environment after regression
+  [#1442](https://github.com/nextcloud/cookbook/pull/1442) @christianlupus
+- Use logging framework throughout the complete app
+  [1459](https://github.com/nextcloud/cookbook/pull/1459) @MarcelRobitaille
+
+### Documentation
+- Fixed some issues in the API description #1419 and #1461 @leptopoda
+- Improve API description for better code-generation #1461 @leptopoda
+- Fix security issue in GitHub pages with path insertion
+  [#1457](https://github.com/nextcloud/cookbook/pull/1457) @christianlupus
+- Add quick start guide for backend testing
+  [#1466](https://github.com/nextcloud/cookbook/pull/1466) @MarcelRobitaille
+- Fixed some typos in the OpenAPI specification @leptopoda
+- Add operation ids to all external API endpoints
+- Improve API description for better code-generation #1461 @leptopoda
+- Removed some inconsitencies in the documentation of the API
+
+

--- a/.changelog/versions/v0.10.3.md
+++ b/.changelog/versions/v0.10.3.md
@@ -1,0 +1,120 @@
+## 0.10.3 - 2023-12-04
+
+### Added
+- Add yield calculator
+  [#1573](https://github.com/nextcloud/cookbook/pull/1573) @j0hannesr0th
+- Add copy to clipboard action for ingredients
+  [#1602](https://github.com/nextcloud/cookbook/pull/1602) @j0hannesr0th
+- Enhance recipe recalculation algorithm
+  [#1723](https://github.com/nextcloud/cookbook/pull/1723) @j0hannesr0th
+- Enhance recipe recalculation algorithm
+  [#1723](https://github.com/nextcloud/cookbook/pull/1743) @j0hannesr0th
+- Add Android client to README
+  [#1767](https://github.com/nextcloud/cookbook/pull/1767) @lneugebauer
+- Show info for empty cookbook or categories in recipe overview
+  [#1866](https://github.com/nextcloud/cookbook/pull/1866) @seyfeb
+- Allow editing existing recipe as new (see [1867](https://github.com/nextcloud/cookbook/issues/1867)) 
+  [#1866](https://github.com/nextcloud/cookbook/pull/1866) @seyfeb
+- Replace checkmark with strikethrough for recipe ingredients
+  [#1910](https://github.com/nextcloud/cookbook/pull/1910) @j0hannesr0th
+
+### Fixed
+- Fix translation string to not contain quotes
+  [#1582](https://github.com/nextcloud/cookbook/pull/1582) @roliverio
+- Make time input fields wider to view multiple digits in chrome
+  [#1687](https://github.com/nextcloud/cookbook/pull/1687) @christianlupus
+- Prevent popup from falsely showing during loading of the app
+  [#1764](https://github.com/nextcloud/cookbook/pull/1764) @christianlupus
+- Fix unclear error message if recipe is already existing
+  [#1770](https://github.com/nextcloud/cookbook/pull/1770) @SethFalco
+- Restore dialog to select files
+  [#1832](https://github.com/nextcloud/cookbook/pull/1832) @christianlupus
+- Provide id of recipe stub in API endpoints as well to make API consistend with recipe API
+  [#1834](https://github.com/nextcloud/cookbook/pull/1834) @christianlupus
+- Hide the button to copy ingredients unless there are some ingredients to copy
+  [#1844](https://github.com/nextcloud/cookbook/pull/1844) @christianlupus
+- Allow single tool in JSON+LD import, fixes #1641
+  [#1864](https://github.com/nextcloud/cookbook/pull/1844) @seyfeb
+- Allow parsing more ISO 8601 duration strings. See issue [#1749](https://github.com/nextcloud/cookbook/issues/1749)
+  [#1871](https://github.com/nextcloud/cookbook/pull/1871) @seyfeb
+- Load config at app loading only once and do not rewrite complete config
+  [#1892](https://github.com/nextcloud/cookbook/pull/1892) @christianlupus
+- Fix English grammar in translatable string
+  [#1907](https://github.com/nextcloud/cookbook/pull/1907) @rakekniven
+- Fix flashing pages on fast internet connections. See [#1891]((https://github.com/nextcloud/cookbook/issues/1891))
+  [#1896](https://github.com/nextcloud/cookbook/pull/1896)
+ [#1918](https://github.com/nextcloud/cookbook/pull/1918)@seyfeb
+- Less strict character matching when filtering `RecipeList`, ignoring accents and some letters. Closes [#1870]((https://github.com/nextcloud/cookbook/issues/1870))
+  [#1896](https://github.com/nextcloud/cookbook/pull/1896) @seyfeb
+- Make API interface cleaner by only using string identifiers for recipes
+  [#1909](https://github.com/nextcloud/cookbook/pull/1909) @christianlupus
+- Add filter for timestamps to output canonical ISO8601 timestamps in the form of YYYY-MM-DDTHH:mm:ss±hh:mm See issue [#1543](https://github.com/nextcloud/cookbook/issues/1543)
+  [#1903](https://github.com/nextcloud/cookbook/pull/1903) @seyfeb
+
+### Maintenance
+- Preparation for migration to vue.js 3
+  [#1896](https://github.com/nextcloud/cookbook/pull/1896) @seyfeb
+- Fix URL of Transifex after upstream subdomain change
+  [#1598](https://github.com/nextcloud/cookbook/pull/1598) @rakekniven
+- Fix webpack dev server settings to allow for docker dev environment
+  [#1607](https://github.com/nextcloud/cookbook/pull/1607) @christianlupus
+- Fix alphabetical ordering of PHP imports
+  [#1614](https://github.com/nextcloud/cookbook/pull/1614) @dependabot @christianlupus
+- Remove support for old 0.9.x branch to simplify development (NC v24 is no longer supported)
+  [#1683](https://github.com/nextcloud/cookbook/pull/1683) @christianlupus
+- Update dependencies for Jekyll building
+  [#1684](https://github.com/nextcloud/cookbook/pull/1684) @dependabot @christianlupus
+- Update dependency @nextcloud/event-bus and allow automatic updates of dependencies
+  [#1680](https://github.com/nextcloud/cookbook/pull/1680) @dependabot
+- Fix bug in browser console
+  [#1686](https://github.com/nextcloud/cookbook/pull/1686) @christianlupus
+- Make OpenAPI specs more compatible regarding `@type`
+  [#1700](https://github.com/nextcloud/cookbook/pull/1700) @christianlupus
+- Add psalm run to CI/CD
+  [#1691](https://github.com/nextcloud/cookbook/pull/1691) @christianlupus
+- Fix some comments and updated PHP coding style
+  [#1710](https://github.com/nextcloud/cookbook/pull/1710) @dependabot @christianlupus
+- Update Psalm and fix some introduced issues
+  [#1707](https://github.com/nextcloud/cookbook/pull/1707) @christianlupus
+- Allow remote debugging of the test python scripts
+  [#1713](https://github.com/nextcloud/cookbook/pull/1713) @christianlupus
+- Update PHP dependencies
+  [#1729](https://github.com/nextcloud/cookbook/pull/1729) @dependabot @christianlupus
+- Update Node to new LTS version
+  [#1735](https://github.com/nextcloud/cookbook/pull/1735) @nextcloud-command
+- Update major prettier version
+  [#1746](https://github.com/nextcloud/cookbook/pull/1746) @dependabot @christianlupus
+- Update major stylelint version
+  [#1750](https://github.com/nextcloud/cookbook/pull/1750) @dependabot @christianlupus
+- Fix dev mode with bug introduced by prettier
+  [#1758](https://github.com/nextcloud/cookbook/pull/1758) @christianlupus
+- Update browserlist by nextcloud
+  [#1792](https://github.com/nextcloud/cookbook/pull/1792) @dependabot
+- Fix workaround introduced in #1758
+  [#1802](https://github.com/nextcloud/cookbook/pull/1802) @christianlupus
+- Update lint config
+  [#1783](https://github.com/nextcloud/cookbook/pull/1783) @dependabot
+- Add editorconfig file for better cooperation
+  [#1771](https://github.com/nextcloud/cookbook/pull/1771) @SethFalco
+- Use docker compose for tests by default
+  [#1772](https://github.com/nextcloud/cookbook/pull/1772) @SethFalco
+- Update hooks to avoid cluttering the git repository and speed up a bit
+  [#1803](https://github.com/nextcloud/cookbook/pull/1803) @christianlupus
+- Fix building docker images for CI/automated tests
+  [#1810](https://github.com/nextcloud/cookbook/pull/1810) @christianlupus
+- Reimplement appstore build scripts
+  [#1822](https://github.com/nextcloud/cookbook/pull/1822) @christianlupus
+- Added new description in README to external app
+  [#1837](https://github.com/nextcloud/cookbook/pull/1837) @VincentMeilinger
+- Drop old polyfill code related to global search
+  [#1843](https://github.com/nextcloud/cookbook/pull/1843) @christianlupus
+- Update helper dependency for DB testing
+  [#1873](https://github.com/nextcloud/cookbook/pull/1873) @dependabot
+- Use non-deprecated prop name for navigation items
+  [#1893](https://github.com/nextcloud/cookbook/pull/1893) @christianlupus
+
+### Deprecated
+- Old integer-based ids should no longer be used.
+  [#1909](https://github.com/nextcloud/cookbook/pull/1909) @christianlupus
+
+

--- a/.changelog/versions/v0.11.0.md
+++ b/.changelog/versions/v0.11.0.md
@@ -1,0 +1,40 @@
+## 0.11.0 - 2023-12-14
+
+### Fixed
+- Make app compatible with PHP 7.4
+  [#1931](https://github.com/nextcloud/cookbook/pull/1931) @christianlupus
+- Allow translation of string _Enable debugging_ in settings
+  [#1947](https://github.com/nextcloud/cookbook/pull/1947) @christianlupus
+- Allow translation of string _Enable debugging_ in settings
+  [#1947](https://github.com/nextcloud/cookbook/pull/1947) @christianlupus
+- **Print view:** Hide yield calculator, ingredient-copy button, yield-calculation warnings
+  [#1949](https://github.com/nextcloud/cookbook/pull/1949) @seyfeb
+- fix wrong parsing of recipe yield input
+  [#1944](https://github.com/nextcloud/cookbook/pull/1944) @j0hannesr0th
+- Update compatibility of app to NC28
+  [#1950](https://github.com/nextcloud/cookbook/pull/1950) @christianlupus
+- **Settings:** Don't show error when update interval field is empty while typing.
+  [#1963](https://github.com/nextcloud/cookbook/pull/1963) @seyfeb
+- Fix searching recipes by string.
+  [#1965](https://github.com/nextcloud/cookbook/pull/1965) @seyfeb
+- Replace eye icon with close icon for cancelling recipe edit
+  [#1971](https://github.com/nextcloud/cookbook/pull/1971) @seyfeb
+- Fill prep, cook, and total time in `RecipeEdit` after loading
+  [#1973](https://github.com/nextcloud/cookbook/pull/1973) @seyfeb
+- Strange cursor in input field while editing nutrition data
+  [#1977](https://github.com/nextcloud/cookbook/pull/1977) @christianlupus
+- Remove unclear nutrition option for deleting nutrition info items and replace with designated delete button
+  [#1978](https://github.com/nextcloud/cookbook/pull/1978) @seyfeb
+- Make reordering of nutrition data more smooth
+  [#1979](https://github.com/nextcloud/cookbook/pull/1979) @christianlupus
+
+### Maintenance
+- Add PHP lint checker to ensure valid (legacy) PHP syntax
+  [#1931](https://github.com/nextcloud/cookbook/pull/1931) @christianlupus
+- Add backport script to simplify development
+  [#1935](https://github.com/nextcloud/cookbook/pull/1935) @christianlupus
+- remove constant se in RecipeView
+  [#1942](https://github.com/nextcloud/cookbook/pull/1942) @j0hannesr0th
+- Update dependencies (stylelint-idiomatic-ordering) by @dependabot
+
+

--- a/.changelog/versions/v0.7.10.md
+++ b/.changelog/versions/v0.7.10.md
@@ -1,0 +1,6 @@
+## 0.7.10 - 2021-01-16
+
+### Fixed
+- Replaced function calls only available in PHP 8 with generic ones
+  [#524](https://github.com/nextcloud/cookbook/pull/524) @christianlupus
+

--- a/.changelog/versions/v0.7.6.md
+++ b/.changelog/versions/v0.7.6.md
@@ -1,0 +1,9 @@
+## 0.7.6 - 2020-06-27
+
+### Added
+- Allow forward slashes in ingredients
+  [#272](https://github.com/nextcloud/cookbook/pull/272) @timandrews335
+
+### Fixed
+- Swapping ingredients and instructions cause items been deleted
+  [#278](https://github.com/nextcloud/cookbook/pull/278) @sam-19

--- a/.changelog/versions/v0.7.7.md
+++ b/.changelog/versions/v0.7.7.md
@@ -1,0 +1,6 @@
+## 0.7.7 - 2020-12-10
+
+### Fixed
+- Increase version compatibility to nextcloud 20 @mrzapp
+
+

--- a/.changelog/versions/v0.7.8.md
+++ b/.changelog/versions/v0.7.8.md
@@ -1,0 +1,127 @@
+## 0.7.8 - 2021-01-08
+
+### Added
+- Parse a textual yield field in an imported recipe to a certain degree
+  [#327](https://github.com/nextcloud/cookbook/pull/327) @zwoabier
+- Search and filter for recipes in the web interface
+  [#318](https://github.com/nextcloud/cookbook/pull/318) @sam-19
+- CI: Use github actions to check the latest head against unittests
+  [#346](https://github.com/nextcloud/cookbook/pull/346) @christianlupus
+- CI: Create source code packages for each commit
+  [#346](https://github.com/nextcloud/cookbook/pull/346) @christianlupus
+- Allow for inconsistent schema: Parse instructions as list of elements
+  [#347](https://github.com/nextcloud/cookbook/pull/347) @victorjoos
+- Show button to view all recipes without a category
+  [#362](https://github.com/nextcloud/cookbook/pull/362/) @seyfeb
+- Add a basic changelog to the repository
+  [#366](https://github.com/nextcloud/cookbook/pull/366/) @christianlupus
+- Enforce update of changelog through CI
+  [#366](https://github.com/nextcloud/cookbook/pull/366/) @christianlupus
+- Keyword cloud is displayed in recipe
+  [#373](https://github.com/nextcloud/cookbook/pull/373/) @seyfeb
+- Pasted content with newlines creates new input fields automatically for tools and ingredients in recipe editor
+  [#379](https://github.com/nextcloud/cookbook/pull/379/) @seyfeb
+- Selectable keywords for filtering in recipe lists
+  [#375](https://github.com/nextcloud/cookbook/pull/375/) @seyfeb
+- Service to handle schema.org JSON data in strings easier
+  [#383](https://github.com/nextcloud/cookbook/pull/383/) @christianlupus
+- Unit tests for JSON object service
+  [#387](https://github.com/nextcloud/cookbook/pull/387) @TobiasMie
+- PHP linter and style checker enabled
+  [#390](https://github.com/nextcloud/cookbook/pull/390) @christianlupus
+- Automatic deployment of new releases to the nextcloud app store
+  [#433](https://github.com/nextcloud/cookbook/pull/433) @christianlupus
+- Category and keyword selection from list of existing ones in recipe editor
+  [#402](https://github.com/nextcloud/cookbook/pull/402/) @seyfeb
+- Allow checking of ingredients in web UI
+  [#393](https://github.com/nextcloud/cookbook/pull/393) @christianlupus
+- Support for dateCreated and dateModified field of schema.org Recipe
+  [#377](https://github.com/nextcloud/cookbook/pull/366/) @seyfeb
+- Bundle-Analyzer and Optimization
+  [#403](https://github.com/nextcloud/cookbook/pull/403) @thembeat
+- Nutrition information display and editing
+  [#416](https://github.com/nextcloud/cookbook/pull/416/) @seyfeb
+- Asking user for confirmation when leaving recipe-editor form with changes
+  [#464](https://github.com/nextcloud/cookbook/pull/464/) @seyfeb
+- Exporting the maximal API endpoint version
+  [#487](https://github.com/nextcloud/cookbook/pull/487) @christianlupus
+
+### Changed
+- Switch of project ownership to nextcloud organization in GitHub
+- Change in issue management
+- Changes to `.gitignore` file
+- Translation issues
+- Added available Android apps to README
+- Update dev dependencies to recent phpunit to avoid warnings and issues
+  [#376](https://github.com/nextcloud/cookbook/pull/376) @christianlupus
+- Made the layout more responsive to shift the metadata right of the image in very wide screens
+  [#349](https://github.com/nextcloud/cookbook/pull/349/) @christianlupus
+- Optimization for SVG to reduce the file size
+  [#404](https://github.com/nextcloud/cookbook/pull/404) @thembeat
+- Replace Default Recipe-Thumb and Full Image with SVG
+  [#418](https://github.com/nextcloud/cookbook/pull/418) @thembeat
+- Enhance the CI tests and build valid dist tarballs during the CI runs
+  [#435](https://github.com/nextcloud/cookbook/pull/435) @christianlupus
+- Images in recipe list are lazily loaded
+  [#413](https://github.com/nextcloud/cookbook/pull/413/) @seyfeb
+- Improved keyword filtering in recipe lists
+  [#408](https://github.com/nextcloud/cookbook/pull/408/) @seyfeb
+
+### Fixed
+- Add a min PHP restriction in the metadata
+  [#282](https://github.com/nextcloud/cookbook/issues/282) @mrzapp
+- Make the codebase consistent with the code standards of the main nextcloud team
+  [#295](https://github.com/nextcloud/cookbook/pull/295) @rakekniven
+- Improved tooltips of navigation
+  [#317](https://github.com/nextcloud/cookbook/pull/317) @sam-19
+- Optimize database request for faster access
+  [#297](https://github.com/nextcloud/cookbook/pull/297) @christianlupus
+- Ignore case during sorting of recipes
+  [#333](https://github.com/nextcloud/cookbook/issues/333) @christianlupus
+- CI: Repair codecov file paths for correct linkings
+  [#348](https://github.com/nextcloud/cookbook/pull/348) @christianlupus
+- Make project name compatible with composer 2.0
+  [#352](https://github.com/nextcloud/cookbook/pull/352) @christianlupus
+- Compress nextcloud logs in case of HTML parsing errors during import
+  [#350](https://github.com/nextcloud/cookbook/pull/350) @maxammann
+- Make complete sentence in transifex translation from parts
+  [#358](https://github.com/nextcloud/cookbook/pull/358) @christianlupus
+- Avoid recipe are no longer reachable when user changes locales
+  [#371](https://github.com/nextcloud/cookbook/pull/371) @christianlupus
+- Hide tooltips in printouts
+  [#343](https://github.com/nextcloud/cookbook/pull/343/) @christianlupus
+- Creating new recipe not possible due to null reference
+  [#378](https://github.com/nextcloud/cookbook/pull/378/) @seyfeb
+- Reenabling CI testing with current xdebug 3
+  [#417](https://github.com/nextcloud/cookbook/pull/417/) @christianlupus
+- Corrected code style in appinfo path
+  [#427](https://github.com/nextcloud/cookbook/pull/427) @christianlupus
+- Clear filtered keywords when changing the route, fixes #425
+  [#426](https://github.com/nextcloud/cookbook/pull/426/) @seyfeb
+- Removed typo introduced during refactory cycles
+  [#434](https://github.com/nextcloud/cookbook/pull/434) @christianlupus
+- Update dependency on code style to version 0.4.x
+  [#437](https://github.com/nextcloud/cookbook/pull/437) @christianlupus
+- Corrected bugs in CI system
+  [#447](https://github.com/nextcloud/cookbook/pull/447) @christianlupus
+- Recipe-editing Vue components are not tightly coupled anymore
+  [#386](https://github.com/nextcloud/cookbook/pull/386/) @seyfeb
+- Fixed trying to remove already removed img DOM nodes in image lazyloading, fixes #462
+  [#463](https://github.com/nextcloud/cookbook/pull/463/) @seyfeb
+- Fixed cooking time being removed if recipe is saved, fixes #472
+  [#473](https://github.com/nextcloud/cookbook/pull/473/) @seyfeb
+- Remove keywords from database when a recipe is removed
+  [#478](https://github.com/nextcloud/cookbook/pull/478) @christianlupus
+- Correct CI to allow creation of releases
+  [#482](https://github.com/nextcloud/cookbook/pull/482) @christianlupus
+- New version as reported in the API should be saved in the MainController file and thus checked in
+  [#488](https://github.com/nextcloud/cookbook/pull/488) @christianlupus
+
+### Removed
+- Travis build system
+- Support for PHP 7.2
+- Removed info button (not) showing the last update time from settings menu, fixes #279
+  [#477](https://github.com/nextcloud/cookbook/pull/477/) @seyfeb
+
+
+

--- a/.changelog/versions/v0.7.9.md
+++ b/.changelog/versions/v0.7.9.md
@@ -1,0 +1,30 @@
+## 0.7.9 - 2021-01-15
+
+### Changed
+- Indentation of ingredients depends on existence of subgroups
+  [#512](https://github.com/nextcloud/cookbook/pull/512/) @seyfeb
+- Speed up index of recipes by using computed properties
+  [#513](https://github.com/nextcloud/cookbook/pull/513) @christianlupus
+- Central parsing of parameters for POST/PUT requests to simplify development
+  [#518](https://github.com/nextcloud/cookbook/pull/518) @christianlupus
+- Removed dependencies on the global jQuery
+  [#497](https://github.com/nextcloud/cookbook/pull/497/) @seyfeb
+
+### Fixed
+- Fixed keywords of shared recipes counted multiple times, fixes #491
+  [#493](https://github.com/nextcloud/cookbook/pull/493/) @seyfeb
+- Added basic structure for documentation
+  [#499](https://github.com/nextcloud/cookbook/pull/499) @christianlupus
+- Make categories load recipes against
+  [#500](https://github.com/nextcloud/cookbook/pull/500) @christianlupus
+- Handle recipes without category well
+  [#501](https://github.com/nextcloud/cookbook/pull/500) @christianlupus
+- Allow to save recipes with custom image URLs
+  [#505](https://github.com/nextcloud/cookbook/pull/505) @christianlupus
+- Allow pasting of instructions without newline again
+  [#503](https://github.com/nextcloud/cookbook/pull/503) @christianlupus
+- Updated color and bullets in nutrition information, fixes #510
+  [#511](https://github.com/nextcloud/cookbook/pull/511/) @seyfeb
+- Update README with more clients
+  [#457](https://github.com/nextcloud/cookbook/pull/457) @geeseven
+

--- a/.changelog/versions/v0.8.0.md
+++ b/.changelog/versions/v0.8.0.md
@@ -1,0 +1,68 @@
+## 0.8.0 - 2021-02-14
+
+### Added
+- Markdown rendering for Description
+  [#381](https://github.com/nextcloud/cookbook/pull/381) @thembeat
+- Changing category name for all recipes in a category
+  [#555](https://github.com/nextcloud/cookbook/pull/555/) @seyfeb
+- Functionality to reference other recipes by id in description, tools, ingredients, and instructions
+  [#562](https://github.com/nextcloud/cookbook/pull/562/) @seyfeb
+- Bundle Analyzer documentation
+  [#573](https://github.com/nextcloud/cookbook/pull/573/) @seyfeb
+- Added button to allow adding empty ingredient, instruction, and tool entries above existing ones in editor
+  [#575](https://github.com/nextcloud/cookbook/pull/575/) @seyfeb
+
+### Changed
+- Using computed property in recipe view
+  [#522](https://github.com/nextcloud/cookbook/pull/522/) @seyfeb
+- Split off list/grid of recipes to separate Vue component
+  [#526](https://github.com/nextcloud/cookbook/pull/526/) @seyfeb
+- CSS Cleanup, removed central css styling
+  [#528](https://github.com/nextcloud/cookbook/pull/528/) @seyfeb
+- Timers are hidden when time is zero (prep, cook, total time)
+  [#543](https://github.com/nextcloud/cookbook/pull/543/) @seyfeb
+- Introduced left navigation pane visibility as Vuex state
+  [#544](https://github.com/nextcloud/cookbook/pull/544/) @seyfeb
+- Centralized some recipe tasks (create, update, delete)
+  [#546](https://github.com/nextcloud/cookbook/pull/546/) @seyfeb
+- Added icon for recipes in navigation pane, closes #550
+  [#560](https://github.com/nextcloud/cookbook/pull/560/) @seyfeb
+- Bumped @nextcloud/vue to 3.5.4
+  [#561](https://github.com/nextcloud/cookbook/pull/561/) @seyfeb
+- Bump webpack-merge from 4.2.2 to 5.7.3
+  [#458](https://github.com/nextcloud/cookbook/pull/458/) @seyfeb
+- Bump webpack-cli from 3.3.12 to 4.5.0
+  [#565](https://github.com/nextcloud/cookbook/pull/565/)
+- Enhanced testing interface
+  [#564](https://github.com/nextcloud/cookbook/pull/564) @christianlupus
+- Allow guest users to use the cookbook and avoid nextcloud exception handling
+  [#506](https://github.com/nextcloud/cookbook/pull/506) @christianlupus
+
+### Fixed
+- Added some documentation how to install GH action generated builds
+  [#538](https://github.com/nextcloud/cookbook/pull/538) @christianlupus
+- Fixed problem where timers are not updated after saving recipe edits
+  [#543](https://github.com/nextcloud/cookbook/pull/543/) @seyfeb
+- Fixed overlapping misaligned navigation toggles (as in #534)
+  [#544](https://github.com/nextcloud/cookbook/pull/544/) @seyfeb
+- Refreshing left navigation pane after downloading recipe data, closes #465
+  [#547](https://github.com/nextcloud/cookbook/pull/547/) @seyfeb
+- Check for existing `@context` setting in json checker
+  [#554](https://github.com/nextcloud/cookbook/pull/554) @christianlupus
+- Introduced updating recipe directory to Vuex state, fixes #542
+  [#546](https://github.com/nextcloud/cookbook/pull/546/) @seyfeb
+- Push docker images for different PHP versions
+  [#574](https://github.com/nextcloud/cookbook/pull/574) @christianlupus
+- Enhanced the CI scripts to be more verbose regarding issues
+  [#452](https://github.com/nextcloud/cookbook/pull/452) @christianlupus
+- Code cleanup
+  [#579](https://github.com/nextcloud/cookbook/pull/579) @christianlupus
+- Added label to Dockerfile to be consistent with docker guidelines
+  [#582](https://github.com/nextcloud/cookbook/pull/582) @christianlupus
+- Corrected jekyll documentation
+  [#584](https://github.com/nextcloud/cookbook/pull/584) @christianlupus
+
+### Removed
+- Removal of old contoller no longer in use
+  [#536](https://github.com/nextcloud/cookbook/pull/536) @christianlupus
+

--- a/.changelog/versions/v0.8.1.md
+++ b/.changelog/versions/v0.8.1.md
@@ -1,0 +1,10 @@
+## 0.8.1 - 2021-02-15
+
+### Added
+- Code style checker in Vue files
+  [#581](https://github.com/nextcloud/cookbook/pull/581) @christianlupus
+
+### Fixed
+- Remove look-behind to support Safari users as well
+  [#591](https://github.com/nextcloud/cookbook/pull/591) @christianlupus
+

--- a/.changelog/versions/v0.8.2.md
+++ b/.changelog/versions/v0.8.2.md
@@ -1,0 +1,28 @@
+## 0.8.2 - 2021-03-03
+
+### Fixed
+- Added translation for nutritient-value label placeholder
+  [#596](https://github.com/nextcloud/cookbook/pull/596) @seyfeb
+- Updated dependency of eslint-config-prettier
+  [#603](https://github.com/nextcloud/cookbook/pull/603) @christianlupus
+- Enforce basic code styling using prettier in vue files
+  [#607](https://github.com/nextcloud/cookbook/pull/607) @christianlupus
+- Enforce CSS styling using stylelint
+  [#608](https://github.com/nextcloud/cookbook/pull/608) @christianlupus
+- More code styling, cleanup & minor bugfixes
+  [#615](https://github.com/nextcloud/cookbook/pull/615) @seyfeb
+- Avoid daily issues in personal forks due to missing secrets
+  [#620](https://github.com/nextcloud/cookbook/pull/620) @christianlupus
+- Avoid descending of CS_fixer into non-code folders
+  [#621](https://github.com/nextcloud/cookbook/pull/621) @christianlupus
+- Fixed compatiblity with Nextcloud 21
+  [#605](https://github.com/nextcloud/cookbook/pull/605) @icewind1991
+
+### Deprecated
+- Obsolete routes to old user interface, see `appinfo/routes.php`
+  [#580](https://github.com/nextcloud/cookbook/pull/580) @christianlupus
+
+### Removed
+- Dropped support for NC core version <= 18
+  [#630](https://github.com/nextcloud/cookbook/pull/630) @christianlupus
+

--- a/.changelog/versions/v0.8.3.md
+++ b/.changelog/versions/v0.8.3.md
@@ -1,0 +1,6 @@
+## 0.8.3 - 2021-03-03
+
+### Fixed
+- Corrected compatibility list
+  [#632](https://github.com/nextcloud/cookbook/pull/632) @christianlupus
+

--- a/.changelog/versions/v0.8.4.md
+++ b/.changelog/versions/v0.8.4.md
@@ -1,0 +1,14 @@
+## 0.8.4 - 2021-03-08
+
+### Added
+- Sorting recipes in list by creation and modification date
+  [#623](https://github.com/nextcloud/cookbook/pull/623) @seyfeb
+
+### Fixed
+- Minor errors in displaying ingredients and instructions
+  [#642](https://github.com/nextcloud/cookbook/pull/642) @seyfeb
+- Missing translation
+  [#644](https://github.com/nextcloud/cookbook/pull/644) @seyfeb
+- Recipe-reference popup being shown on the wrong input depending on keyboard layout
+  [#648](https://github.com/nextcloud/cookbook/pull/648) @seyfeb
+

--- a/.changelog/versions/v0.9.0.md
+++ b/.changelog/versions/v0.9.0.md
@@ -1,0 +1,55 @@
+## 0.9.0 - 2021-07-01
+
+### Added
+- Make recipes searchable through unified search
+  [#611](https://github.com/nextcloud/cookbook/pull/611) @PFischbeck
+- Enhanced keyword cloud in recipe list with option to hide/show keywords, enlarge area, and ordering alphabetically
+  [#678](https://github.com/nextcloud/cookbook/pull/678) @seyfeb
+- User documentation
+  [#709](https://github.com/nextcloud/cookbook/pull/709) @seyfeb
+
+### Fixed
+- Calling reindex
+  [#653](https://github.com/nextcloud/cookbook/pull/653) @seyfeb
+- Setting nutrition information on recipes with an array assigned for nutrition
+  [#653](https://github.com/nextcloud/cookbook/pull/653) @seyfeb
+- Fix empty error message upon import
+  [#647](https://github.com/nextcloud/cookbook/pull/647) @christianlupus
+- Update code styling to match with current version of php-cs-fixer
+  [#668](https://github.com/nextcloud/cookbook/pull/668) @christianlupus
+- Fix version of `@nextcloud/capabilities` to `1.0.2`
+  [#672](https://github.com/nextcloud/cookbook/pull/672) @christianlupus
+- Really only show recipe-reference popup on '#'
+  [#676](https://github.com/nextcloud/cookbook/pull/676) @seyfeb
+- Correct styling of PHP files accoring to php-cs-fixer
+  [#692](https://github.com/nextcloud/cookbook/pull/692) @christianlupus
+- Removed explicit dependency of @nextcloud/capabilities
+  [#693](https://github.com/nextcloud/cookbook/pull/693) @christianlupus
+- Add indices to database for all tables
+  [#698](https://github.com/nextcloud/cookbook/pull/698) @christianlupus
+- Codebase maintenance
+  [#699](https://github.com/nextcloud/cookbook/pull/699) @christianlupus
+- Enable stalebot
+  [#700](https://github.com/nextcloud/cookbook/pull/700) @christianlupus
+- Correct error messages when recipe already exists
+  [#702](https://github.com/nextcloud/cookbook/pull/702) @christianlupus
+- Update webpack version to 5.x
+  [#717](https://github.com/nextcloud/cookbook/pull/717) @christianlupus
+- Update sass-loader
+  [#720](https://github.com/nextcloud/cookbook/pull/720) @christianlupus
+- Update compression-webpack-plugin
+  [#721](https://github.com/nextcloud/cookbook/pull/721) @christianlupus
+- Fix array in recipeYields field according to #722
+  [#725](https://github.com/nextcloud/cookbook/pull/725) @christianlupus
+- Fix recipe-editor layout as in #729
+  [#725](https://github.com/nextcloud/cookbook/pull/732) @seyfeb
+- Corrected style of stale bot messages
+  [#749](https://github.com/nextcloud/cookbook/pull/749) @christianlupus
+- Update the screenshots in the appstore
+  [#747](https://github.com/nextcloud/cookbook/pull/747) @mMuck
+- Fix visual issues at device width of 1024px #689
+  [#751](https://github.com/nextcloud/cookbook/pull/751) @christianlupus
+- Removed obsolete dependency on @nextcloud/event-bus
+  [#719](https://github.com/nextcloud/cookbook/pull/719) @christianlupus
+
+

--- a/.changelog/versions/v0.9.1.md
+++ b/.changelog/versions/v0.9.1.md
@@ -1,0 +1,19 @@
+## 0.9.1 - 2021-07-05
+
+### Added
+- OpenAPI specification and documentation of the valid API endpoints
+  [#757](https://github.com/nextcloud/cookbook/pull/757) @christianlupus
+
+### Fixed
+- Correct handling of uploads to codecov
+  [#758](https://github.com/nextcloud/cookbook/pull/758) @christianlupus
+- Added issue template and documentation regarding website support
+  [#759](https://github.com/nextcloud/cookbook/pull/759) @christianlupus
+- Avoid sharing of recipes does break the database upgrade process
+  [#755](https://github.com/nextcloud/cookbook/pull/755) @christianlupus
+
+### Removed
+- Obsolete API routes that are no longer working due to missing files
+  [#757](https://github.com/nextcloud/cookbook/pull/757) @christianlupus
+
+

--- a/.changelog/versions/v0.9.10.md
+++ b/.changelog/versions/v0.9.10.md
@@ -1,0 +1,33 @@
+## 0.9.10 - 2022-03-04
+
+### Added
+- Remove prefix of pasted content for better formatting
+  [#887](https://github.com/nextcloud/cookbook/pull/887) @MarcelRobitaille
+
+### Fixed
+- Added app info XML back to allow automatic translations
+  [#878](https://github.com/nextcloud/cookbook/pull/878) @christianlupus
+- Added unit hints in the labels of the timers
+  [#879](https://github.com/nextcloud/cookbook/pull/879) @christianlupus
+- Allow for multiline text in instructions
+  [#880](https://github.com/nextcloud/cookbook/pull/880) @christianlupus
+- Usage of caches for NPM speedup
+  [#883](https://github.com/nextcloud/cookbook/pull/883) @christianlupus
+- Make the controls sticky on top
+  [#888](https://github.com/nextcloud/cookbook/pull/888) @MarcelRobitaille
+- Cleanup code related to pasting
+  [#886](https://github.com/nextcloud/cookbook/pull/886) @MarcelRobitaille
+- Make height of control header dependant on server CSS variable
+  [#897](https://github.com/nextcloud/cookbook/pull/897) @MarcelRobitaille
+- Fix UI glitch when keyword list is empty
+  [#892](https://github.com/nextcloud/cookbook/pull/892) @MarcelRobitaille
+- Allow switching to new instruction line with Enter key
+  [#890](https://github.com/nextcloud/cookbook/pull/890) @MarcelRobitaille
+- Prevent inserting newline characters in instructions/ingredients/tools when pressing enter
+  [#900](https://github.com/nextcloud/cookbook/pull/900) @MarcelRobitaille
+
+### Documentation
+- Added clarification between categories and keywords for users
+  [#889](https://github.com/nextcloud/cookbook/pull/889) @MarcelRobitaille
+
+

--- a/.changelog/versions/v0.9.11.md
+++ b/.changelog/versions/v0.9.11.md
@@ -1,0 +1,29 @@
+## 0.9.11 - 2022-03-28
+
+### Fixed
+- Reduce complex coupling between event handlers in EditInputGroup.vue
+  [#901](https://github.com/nextcloud/cookbook/pull/901) @MarcelRobitaille
+- Fix bug in NC Vue config that switches input fields to be not full width on mobile
+  [#910](https://github.com/nextcloud/cookbook/pull/910) @MarcelRobitaille
+- Enable hot reloading feature of Vue for simpler development
+  [#909](https://github.com/nextcloud/cookbook/pull/909) @christianlupus
+- Remove some packages from the dependencies to keep the footprint smaller
+  [#912](https://github.com/nextcloud/cookbook/pull/912) @christianlupus
+- Remove deprecation in preparation for Sass 2.0.0
+  [#915](https://github.com/nextcloud/cookbook/pull/915) @MarcelRobitaille
+- Fix regression in #900 to allow inserting links to other recipes again
+  [#914](https://github.com/nextcloud/cookbook/pull/914) @MarcelRobitaille
+- Replace multiple spaces with a single one when pasting
+  [#924](https://github.com/nextcloud/cookbook/pull/924) @MarcelRobitaille
+- Create abstraction class for access to user configuration
+  [#926](https://github.com/nextcloud/cookbook/pull/926) @christianlupus
+- Allow unit test to run against webserver with PHP support
+  [#927](https://github.com/nextcloud/cookbook/pull/927) @christianlupus
+- Enhance the unit test script for more user convinience
+  [#931](https://github.com/nextcloud/cookbook/pull/931) @christianlupus
+
+### Documentation
+- Introduction about how to start coding
+  [#891](https://github.com/nextcloud/cookbook/pull/901) @MarcelRobitaille
+
+

--- a/.changelog/versions/v0.9.12.md
+++ b/.changelog/versions/v0.9.12.md
@@ -1,0 +1,42 @@
+## 0.9.12 - 2022-05-12
+
+### Added
+- Add IDE configuration to codebase to prevent small issues
+  [#978](https://github.com/nextcloud/cookbook/pull/978) @christianlupus
+- Allow client to specify accepted image types
+  [#982](https://github.com/nextcloud/cookbook/pull/982) @christianlupus
+
+### Fixed
+- Refactor the code for image handling to make it testable
+  [#933](https://github.com/nextcloud/cookbook/pull/933) @christianlupus
+- Allow merging of PRs from dependabot with only changes to package-lock.json
+  [#952](https://github.com/nextcloud/cookbook/pull/952) @christianlupus
+- Redirect to login in case of logged out user
+  [#956](https://github.com/nextcloud/cookbook/pull/956) @christianlupus
+- Correct handling of empty recipe name in the backend
+  [#973](https://github.com/nextcloud/cookbook/pull/973) @christianlupus
+- Fix problem with git pre-commit hook dropping files unintentionally
+  [#974](https://github.com/nextcloud/cookbook/pull/974) @christianlupus
+- Removed typo in exception description
+  [#965](https://github.com/nextcloud/cookbook/pull/965) @christianlupus
+- Mark cookbook app as compatible with NC24
+  [#977](https://github.com/nextcloud/cookbook/pull/977) @christianlupus
+- Fix bug that prevent generation of thumbnails when no previous thumbnails are present
+  [#985](https://github.com/nextcloud/cookbook/pull/985) @christianlupus
+
+### Documentation
+- l10n: Corrected some spelling issues
+  [#941](https://github.com/nextcloud/cookbook/pull/941) @Valdnet
+- Enhanced the user documentation by adding some starter's information
+  [#936](https://github.com/nextcloud/cookbook/pull/936) @zorglubu
+- Translate user documentation to French
+  [#936](https://github.com/nextcloud/cookbook/pull/947) @zorglubu
+- Updated French translation
+  [#957](https://github.com/nextcloud/cookbook/pull/957) @zorglubu
+- Add example to OpenAPI specification
+  [#957](https://github.com/nextcloud/cookbook/pull/972) @christianlupus
+
+### Deprecated
+- Method RecipeService::parseRecipeHtml()
+
+

--- a/.changelog/versions/v0.9.13.md
+++ b/.changelog/versions/v0.9.13.md
@@ -1,0 +1,74 @@
+## 0.9.13 - 2022-07-02
+
+### Added
+- Create service class for downloading and extracting JSON
+  [#553](https://github.com/nextcloud/cookbook/pull/553) @christianlupus
+- Show recipe titles for internal references
+  [#1063](https://github.com/nextcloud/cookbook/pull/1063) @christianlupus
+
+### Changed
+- Extracted user folder handling into its own helper class
+  [#1007](https://github.com/nextcloud/cookbook/pull/1007) @christianlupus
+- Switched to cURL for downloading of external files
+  [#1055](https://github.com/nextcloud/cookbook/pull/1055) @christianlupus
+- Rewrite encoding of imported recipes
+  [#1057](https://github.com/nextcloud/cookbook/pull/1057) @christianlupus
+
+### Fixed
+- Fix visual regression in edit mode to prevent overflow of breadcrumbs
+  [#989](https://github.com/nextcloud/cookbook/pull/989) @christianlupus
+- l10n: Changed spelling of MIME
+  [#988](https://github.com/nextcloud/cookbook/pull/988) @rakekniven
+- Move "Categories" caption above list of categories
+  [#1000](https://github.com/nextcloud/cookbook/pull/1000) @seyfeb
+- Reenable the fixup action after deprecation in central repository
+  [#1012](https://github.com/nextcloud/cookbook/pull/1012) @christianlupus
+- Trim recipe name to a maximum length to fit in the database
+  [#1014](https://github.com/nextcloud/cookbook/pull/1014) @christianlupus
+- Correct transifex translations
+  [#1024](https://github.com/nextcloud/cookbook/pull/1024) @christianlupus
+- Correct singular/plural translations
+  [#1026](https://github.com/nextcloud/cookbook/pull/1026) @christianlupus
+- Update eslint-plugin-vue
+- Fix refresh-icon overlays name of recipe
+  [#1033](https://github.com/nextcloud/cookbook/pull/1033) @MarcelRobitaille
+- Reenable PR checks from foreign forks
+  [#1045](https://github.com/nextcloud/cookbook/pull/1045) @christianlupus
+- Prevent access to guzzle client without explicit dependency
+  [#1011](https://github.com/nextcloud/cookbook/pull/1011) @christianlupus
+- Make PHP code styling more strict
+  [#1011](https://github.com/nextcloud/cookbook/pull/1011) @christianlupus
+- Adding some strings to transifex
+  [#1049](https://github.com/nextcloud/cookbook/pull/1049) @christianlupus
+- Removed outdated dependency on v-markdown-editor due to security issues
+  [#1050](https://github.com/nextcloud/cookbook/pull/1050) @christianlupus
+- Migrated node-sass to dart sass
+  [#1051](https://github.com/nextcloud/cookbook/pull/1051) @christianlupus
+- Add the url as a parameter to allow for specialized parsers per website in the backend
+  [#1060](https://github.com/nextcloud/cookbook/pull/1060) @christianlupus
+- Create wrapper in frontend for all API requests
+  [#1061](https://github.com/nextcloud/cookbook/pull/1061) @christianlupus
+
+### Removed
+- Remove deprecated and no longer functional API routes from app
+  [#1065](https://github.com/nextcloud/cookbook/pull/1065) @christianlupus
+
+### Codebase maintenance
+- Removed codecov.io upload of intermediate merge commits during pull requests
+  [#1028](https://github.com/nextcloud/cookbook/issues/1028)
+- Use latest possible NC core for CI tests
+- Introduce migration tests
+- Enable automatically merging of dependabot PRs
+- Add code style checker for package.json
+  [#1053](https://github.com/nextcloud/cookbook/pull/1053) @christianlupus
+- Remove the amount of data uploaded in CI artifacts
+  [#1059](https://github.com/nextcloud/cookbook/pull/1059) @christianlupus
+- Outsource of functions from entry files to helper module
+  [#1062](https://github.com/nextcloud/cookbook/pull/1062) @christianlupus
+
+### Documentation
+- Add documentation on updates of the API endpoints
+  [#1001](https://github.com/nextcloud/cookbook/pull/1001) @christianlupus
+- Fix API specification in accordance with real implementation
+  [#1006](https://github.com/nextcloud/cookbook/pull/1006) @christianlupus
+

--- a/.changelog/versions/v0.9.14.md
+++ b/.changelog/versions/v0.9.14.md
@@ -1,0 +1,63 @@
+## 0.9.14 - 2022-08-29
+
+### Changed
+- Parsing of JSON recipe objects in a cascade of filters
+  [#1097](https://github.com/nextcloud/cookbook/pull/1097) @christianlupus
+- Ordering corrected for mobile and printout versions
+  [#1107](https://github.com/nextcloud/cookbook/pull/1107) @christianlupus
+- Less intrusive sharp popup (suggestion menu for reference autocomplete)
+  [#1098](https://github.com/nextcloud/cookbook/pull/1098) @MarcelRobitaille
+
+### Fixed
+- Prevent slow loading of recipes due to iteration over all files
+  [#1072](https://github.com/nextcloud/cookbook/pull/1072) @christianlupus
+- Fix keyword ordering buttons being clipped by top bar
+  [#1103](https://github.com/nextcloud/cookbook/pull/1103) @MarcelRobitaille
+- Replace print icon with something better recognizable
+  [#1106](https://github.com/nextcloud/cookbook/pull/1106) @christianlupus
+- Make recipeYield optional
+  [#1108](https://github.com/nextcloud/cookbook/pull/1108) @christianlupus
+- Fix UI glitches caused by improper use of Breadcrumbs component
+  [#1105](https://github.com/nextcloud/cookbook/pull/1105) @MarcelRobitaille
+- Fix typos and styling issues
+  [#1112](https://github.com/nextcloud/cookbook/pull/1112) @christianlupus
+- Fix API endpoint used for updating recipes
+  [#1119](https://github.com/nextcloud/cookbook/pull/1119) @MarcelRobitaille
+- Reactivate step debugging  in PHP
+  [#1160](https://github.com/nextcloud/cookbook/pull/1160) @christianlupus
+- Fix multi-line code entry in some fields during editing
+  [#1162](https://github.com/nextcloud/cookbook/pull/1162) @christianlupus
+- Make the API return correct nutrition information objects for recipes
+  [#1163](https://github.com/nextcloud/cookbook/pull/1163) @christianlupus
+- Allow HowToSteps in recipe instructions during importing
+  [#1165](https://github.com/nextcloud/cookbook/pull/1165) @christianlupus
+- Correct output of getApiVersion
+  [#1175](https://github.com/nextcloud/cookbook/pull/1175) @christianlupus
+
+### Maintenance
+- Add composer.json to version control to have unique installed dependency versions
+  [#1093](https://github.com/nextcloud/cookbook/pull/1093) @christianlupus
+- Update supported PHP versions
+  [#1095](https://github.com/nextcloud/cookbook/pull/1095) @christianlupus
+- Update README with app screenshot and fixed repository links
+  [#1102](https://github.com/nextcloud/cookbook/pull/1102) @MarcelRobitaille
+- Cleaned up entry JS code
+  [#1118](https://github.com/nextcloud/cookbook/pull/1118) @christianlupus
+- Create Python based testing wrapper and enhance workflow script
+  [#1137](https://github.com/nextcloud/cookbook/pull/1137) @christianlupus
+- Update workflow from nextcloud organization template
+  [#1142](https://github.com/nextcloud/cookbook/pull/1142) @christianlupus
+- Remove dependency @nextcloud/auth from explicit dependencies
+  [#1149](https://github.com/nextcloud/cookbook/pull/1149) @christianlupus
+- Fix bug in automated test programs
+  [#1165](https://github.com/nextcloud/cookbook/pull/1165) @christianlupus
+- Update some NPM dependencies and deprecations
+  [#1159](https://github.com/nextcloud/cookbook/pull/1159) @christianlupus
+- Prepare the generation of pre-releases
+  [#1169](https://github.com/nextcloud/cookbook/pull/1169) @christianlupus
+- Corrected usage of npm ci
+  [#1170](https://github.com/nextcloud/cookbook/pull/1170) @christianlupus
+- Reactivate Codecov coverage reporting
+  [#1177](https://github.com/nextcloud/cookbook/pull/1177) @christianlupus
+
+

--- a/.changelog/versions/v0.9.15.md
+++ b/.changelog/versions/v0.9.15.md
@@ -1,0 +1,33 @@
+## 0.9.15 - 2022-09-08
+
+### Added
+- Create structure to run integration tests against a real database
+  [#1195](https://github.com/nextcloud/cookbook/pull/1195) @christianlupus
+
+### Changed
+- Migrate ILogger to LoggerInterface
+  [#1192](https://github.com/nextcloud/cookbook/pull/1192) @miles170
+
+### Fixed
+- Close security issue by enabling CSRF protection on most endpoints
+  [#1190](https://github.com/nextcloud/cookbook/pull/1190) @christianlupus
+- Fix bug in DB access class to prevent PostgreSQL from viewing all recipes of a category
+  [#1195](https://github.com/nextcloud/cookbook/pull/1195) @christianlupus
+- Fix minor bug to make API access consistent with API definitions and internal structure more well-defined
+  [#1195](https://github.com/nextcloud/cookbook/pull/1195) @christianlupus
+
+### Documentation
+- Defining new API interface to fix security issue
+  [#1186](https://github.com/nextcloud/cookbook/pull/1186) @christianlupus
+- Fixed API description w.r.t. return types and examples
+  (see [#1153](https://github.com/nextcloud/cookbook/issues/1153)) @christianlupus
+
+### Deprecated
+- Deprecate NC core version V21
+  [#1195](https://github.com/nextcloud/cookbook/pull/1195) @christianlupus
+
+### Removed
+- Removed support for NC core <= V20
+  [#1195](https://github.com/nextcloud/cookbook/pull/1195) @christianlupus
+
+

--- a/.changelog/versions/v0.9.16.md
+++ b/.changelog/versions/v0.9.16.md
@@ -1,0 +1,68 @@
+## 0.9.16 - 2022-10-26
+
+This version was removed from the app store as it was triggered by accident by a GitHub action going wild.
+Nevertheless, the changes involved in this version are documented here as well.
+The changed will be duplicated to the next release as this release should not be installed by productive systems.
+
+### Added
+- Add alarm sound to timers
+  [#1120](https://github.com/nextcloud/cookbook/pull/1120) @MarcelRobitaille
+
+### Changed
+- Create build script for GitHub pages with GitHub actions to allow for custom building
+  [#1203](https://github.com/nextcloud/cookbook/pull/1203) @christianlupus
+- Added a new client and badges to the readme @TheMBeat
+- Replace native alert and confirm dialogs with custom ones from nextcloud vue
+  [#1261](https://github.com/nextcloud/cookbook/pull/1261) @MarcelRobitaille
+- Store imported HTML file for future enhanced parsing
+  [#1267](https://github.com/nextcloud/cookbook/pull/1267) @christianlupus
+
+### Fixed
+- Added new public page styling in preparation for NC25
+  [#1201](https://github.com/nextcloud/cookbook/pull/1201) @christianlupus
+- Fix API endpoint helpers to enforce JSON answers and minor styling enhancements
+  [#1202](https://github.com/nextcloud/cookbook/pull/1202) @christianlupus
+- Fix XPath to allow for microdata parsing with multiple adjacent schema objects in HTML code
+  [#1220](https://github.com/nextcloud/cookbook/pull/1220) @christianlupus
+- Fix filters for array-valued entries in recipes
+  [#1222](https://github.com/nextcloud/cookbook/pull/1222) @christianlupus
+- Add overlay when app navigation is open
+  [1122](https://github.com/nextcloud/cookbook/pull/1122) @MarcelRobitaille
+- Add filter to prevent special chars in folder names
+  [#1268](https://github.com/nextcloud/cookbook/pull/1268) @christianlupus
+- Fix bug with websites that provide array of schema entries
+  [#1282](https://github.com/nextcloud/cookbook/pull/1282) @christianlupus
+
+### Maintenance
+- Use the pre-built database images for MySQL and PostgreSQL tests
+  [#1204](https://github.com/nextcloud/cookbook/pull/1204) @christianlupus
+- Update stylelint-config-idiomatic and fix code styling
+  [#1224](https://github.com/nextcloud/cookbook/pull/1224) @christianlupus
+- Remove obsolete code from Recipe service class
+  [#1226](https://github.com/nextcloud/cookbook/pull/1226) @christianlupus
+- Allow for PlantUML diagrams in documentation
+  [#1229](https://github.com/nextcloud/cookbook/pull/1229) @christianlupus
+- Remove deprecated `::v-deep` CSS syntax @christianlupus
+- Disable webpack bundle analyzer plugin by default to speed up development cycle
+  [#1263](https://github.com/nextcloud/cookbook/pull/1263) @MarcelRobitaille
+- Update github actions
+  [1269](https://github.com/nextcloud/cookbook/pull/1269)
+  [1270](https://github.com/nextcloud/cookbook/pull/1270)
+  [1271](https://github.com/nextcloud/cookbook/pull/1271)
+  [1273](https://github.com/nextcloud/cookbook/pull/1273)
+  [1274](https://github.com/nextcloud/cookbook/pull/1274)
+  [1277](https://github.com/nextcloud/cookbook/pull/1277)
+- Prepare the GitHub action scripts to be compatible with the upcoming version split in version 0.10.0
+  [#1285](https://github.com/nextcloud/cookbook/pull/1285) @christianlupus
+- Add logging to diagnose bugs in production
+  [#1283](https://github.com/nextcloud/cookbook/pull/1283) @MarcelRobitaille
+
+### Documentation
+- Fix bad writing
+  [#1256](https://github.com/nextcloud/cookbook/pull/1256) @MarcelRobitaille
+
+### Removed
+- Remove the deprecated endpoints from version 0.9.15
+  [#1200](https://github.com/nextcloud/cookbook/pull/1200) @christianlupus
+
+

--- a/.changelog/versions/v0.9.17.md
+++ b/.changelog/versions/v0.9.17.md
@@ -1,0 +1,68 @@
+## 0.9.17 - 2022-10-31
+
+### Added
+- Add alarm sound to timers
+  [#1120](https://github.com/nextcloud/cookbook/pull/1120) @MarcelRobitaille
+- Allow import of recipes with HowToSections
+  [#1300](https://github.com/nextcloud/cookbook/pull/1300) @christianlupus
+
+### Changed
+- Create build script for GitHub pages with GitHub actions to allow for custom building
+  [#1203](https://github.com/nextcloud/cookbook/pull/1203) @christianlupus
+- Added a new client and badges to the readme @TheMBeat
+- Replace native alert and confirm dialogs with custom ones from nextcloud vue
+  [#1261](https://github.com/nextcloud/cookbook/pull/1261) @MarcelRobitaille
+- Store imported HTML file for future enhanced parsing
+  [#1267](https://github.com/nextcloud/cookbook/pull/1267) @christianlupus
+
+### Fixed
+- Added new public page styling in preparation for NC25
+  [#1201](https://github.com/nextcloud/cookbook/pull/1201) @christianlupus
+- Fix API endpoint helpers to enforce JSON answers and minor styling enhancements
+  [#1202](https://github.com/nextcloud/cookbook/pull/1202) @christianlupus
+- Fix XPath to allow for microdata parsing with multiple adjacent schema objects in HTML code
+  [#1220](https://github.com/nextcloud/cookbook/pull/1220) @christianlupus
+- Fix filters for array-valued entries in recipes
+  [#1222](https://github.com/nextcloud/cookbook/pull/1222) @christianlupus
+- Add overlay when app navigation is open
+  [1122](https://github.com/nextcloud/cookbook/pull/1122) @MarcelRobitaille
+- Add filter to prevent special chars in folder names
+  [#1268](https://github.com/nextcloud/cookbook/pull/1268) @christianlupus
+- Fix bug with websites that provide array of schema entries
+  [#1282](https://github.com/nextcloud/cookbook/pull/1282) @christianlupus
+
+### Maintenance
+- Use the pre-built database images for MySQL and PostgreSQL tests
+  [#1204](https://github.com/nextcloud/cookbook/pull/1204) @christianlupus
+- Update stylelint-config-idiomatic and fix code styling
+  [#1224](https://github.com/nextcloud/cookbook/pull/1224) @christianlupus
+- Remove obsolete code from Recipe service class
+  [#1226](https://github.com/nextcloud/cookbook/pull/1226) @christianlupus
+- Allow for PlantUML diagrams in documentation
+  [#1229](https://github.com/nextcloud/cookbook/pull/1229) @christianlupus
+- Remove deprecated `::v-deep` CSS syntax @christianlupus
+- Disable webpack bundle analyzer plugin by default to speed up development cycle
+  [#1263](https://github.com/nextcloud/cookbook/pull/1263) @MarcelRobitaille
+- Update github actions
+  [1269](https://github.com/nextcloud/cookbook/pull/1269)
+  [1270](https://github.com/nextcloud/cookbook/pull/1270)
+  [1271](https://github.com/nextcloud/cookbook/pull/1271)
+  [1273](https://github.com/nextcloud/cookbook/pull/1273)
+  [1274](https://github.com/nextcloud/cookbook/pull/1274)
+  [1277](https://github.com/nextcloud/cookbook/pull/1277)
+- Prepare the GitHub action scripts to be compatible with the upcoming version split in version 0.10.0
+  [#1285](https://github.com/nextcloud/cookbook/pull/1285) @christianlupus
+- Add logging to diagnose bugs in production
+  [#1283](https://github.com/nextcloud/cookbook/pull/1283) @MarcelRobitaille
+- Log every network request
+  [#1291](https://github.com/nextcloud/cookbook/pull/1291) @MarcelRobitaille
+
+### Documentation
+- Fix bad writing
+  [#1256](https://github.com/nextcloud/cookbook/pull/1256) @MarcelRobitaille
+
+### Removed
+- Remove the deprecated endpoints from version 0.9.15
+  [#1200](https://github.com/nextcloud/cookbook/pull/1200) @christianlupus
+
+

--- a/.changelog/versions/v0.9.2.md
+++ b/.changelog/versions/v0.9.2.md
@@ -1,0 +1,13 @@
+## 0.9.2 - 2021-08-09
+
+### Added
+- Added debugging helpers in the CI scripts
+  [#774](https://github.com/nextcloud/cookbook/pull/774) @christianlupus
+
+### Fixed
+- Fixed changes from #774 and minor extensions
+  [#775](https://github.com/nextcloud/cookbook/pull/775) @christianlupus
+- Clean tables from old, redundant, and non-unique data to allow migrations (see #762 #763)
+  [#776](https://github.com/nextcloud/cookbook/pull/776) @christianlupus
+
+

--- a/.changelog/versions/v0.9.3.md
+++ b/.changelog/versions/v0.9.3.md
@@ -1,0 +1,25 @@
+## 0.9.3 - 2021-09-26
+
+### Added
+- Added unit tests for controllers
+  [#790](https://github.com/nextcloud/cookbook/pull/790) @christianlupus
+- Added CI test to check for open todo tags in the source code
+  [#791](https://github.com/nextcloud/cookbook/pull/791) @christianlupus
+
+### Fixed
+- Mark app as compatible with Nextcloud 22
+  [#778](https://github.com/nextcloud/cookbook/pull/778) @christianlupus
+- Usage of PHAR-based PHPUnit to avoid dependency on nikic/php-parser and dependency conflicts
+  [#780](https://github.com/nextcloud/cookbook/pull/780) @christianlupus
+- Extracted abstract class for migration testing and added tests code for existing migrations
+  [#783](https://github.com/nextcloud/cookbook/pull/783) @christianlupus
+- Reactivate step debugging in automated testing
+  [#784](https://github.com/nextcloud/cookbook/pull/784) @christianlupus
+- Added test result to PR messages
+  [#788](https://github.com/nextcloud/cookbook/pull/788) @christianlupus
+
+### Removed
+- Removed app info XML file to avoid confusion
+  [#778](https://github.com/nextcloud/cookbook/pull/778) @christianlupus
+
+

--- a/.changelog/versions/v0.9.4.md
+++ b/.changelog/versions/v0.9.4.md
@@ -1,0 +1,9 @@
+## 0.9.4 - 2021-09-29
+
+### Fixed
+- Failed database caching in case of ill-formatted json file (category/keyword)
+  [#797](https://github.com/nextcloud/cookbook/pull/797) @christianlupus
+- Added Nook app in README
+  [#798](https://github.com/nextcloud/cookbook/pull/798) @christianlupus
+
+

--- a/.changelog/versions/v0.9.5.md
+++ b/.changelog/versions/v0.9.5.md
@@ -1,0 +1,17 @@
+## 0.9.5 - 2021-10-15
+
+### Fixed
+- Fix empty Category
+  [#805](https://github.com/nextcloud/cookbook/pull/805) @jotoeri
+- Fix CI test scripts
+  [#809](https://github.com/nextcloud/cookbook/pull/809) @christianlupus
+- Update stylelint-config-prettier
+  [#807](https://github.com/nextcloud/cookbook/pull/807) @christianlupus
+- Correct unit testing for dependabot and forked branches
+  [#811](https://github.com/nextcloud/cookbook/pull/811) @christianlupus
+- Updated codecov parser to binary version (fix #810)
+  [#813](https://github.com/nextcloud/cookbook/pull/813) @christianlupus
+- Allow bot user to push to stable branch
+  [#812](https://github.com/nextcloud/cookbook/pull/812) @christianlupus
+
+

--- a/.changelog/versions/v0.9.6.md
+++ b/.changelog/versions/v0.9.6.md
@@ -1,0 +1,17 @@
+## 0.9.6 - 2021-10-18
+
+### Added
+- Save button at the bottom of the edit page
+  [#818](https://github.com/nextcloud/cookbook/pull/818) @christianlupus
+
+### Fixed
+- Usage of PAT for deployment action
+  [#815](https://github.com/nextcloud/cookbook/pull/815) @christianlupus
+- Correct usage of EXIF data to rotate thumb images accordingly
+  [#816](https://github.com/nextcloud/cookbook/pull/816) @christianlupus
+- Trim spaces from names of imported recipes
+  [#817](https://github.com/nextcloud/cookbook/pull/817) @christianlupus
+- Fixed regression in #805
+  [#820](https://github.com/nextcloud/cookbook/pull/820) @christianlupus
+
+

--- a/.changelog/versions/v0.9.7.md
+++ b/.changelog/versions/v0.9.7.md
@@ -1,0 +1,31 @@
+## 0.9.7 - 2021-11-26
+
+### Added
+- Add placeholder text to make clear URLs can be used as image source
+  [#835](https://github.com/nextcloud/cookbook/pull/835) @seyfeb
+
+### Fixed
+- CI build always builds docker images from scratch
+  [#823](https://github.com/nextcloud/cookbook/pull/823) @christianlupus
+- Fix test script after update in docker-compose
+  [#833](https://github.com/nextcloud/cookbook/pull/833) @christianlupus
+- Update NPM during automatic building to latest version ([#837](https://github.com/nextcloud/cookbook/issues/837))
+  [#839](https://github.com/nextcloud/cookbook/pull/839) @christianlupus
+- Downgrade eslint to meet peer dependencies ([#838](https://github.com/nextcloud/cookbook/issues/838))
+  [#839](https://github.com/nextcloud/cookbook/pull/839) @christianlupus
+- Fix bug in Makefile to simplify development
+  [#839](https://github.com/nextcloud/cookbook/pull/839) @christianlupus
+- Update eslint and dependencies
+  [#848](https://github.com/nextcloud/cookbook/pull/848) @christianlupus
+- Update PHP CS-Fixer
+  [#849](https://github.com/nextcloud/cookbook/pull/849) @christianlupus
+- Update git hooks to not delay commits too much
+  [#851](https://github.com/nextcloud/cookbook/pull/851) @christianlupus
+- Update git hooks to run all tests even if some fail
+  [#856](https://github.com/nextcloud/cookbook/pull/856) @christianlupus
+- Make strings recoverable by transifex parser
+  [#860](https://github.com/nextcloud/cookbook/pull/860) @christianlupus
+- Allow arrays in stored JSON recipe files for the keywords
+  [#859](https://github.com/nextcloud/cookbook/pull/859) @christianlupus
+
+

--- a/.changelog/versions/v0.9.8.md
+++ b/.changelog/versions/v0.9.8.md
@@ -1,0 +1,7 @@
+## 0.9.8 - 2021-12-05
+
+### Fixed
+- Update comaptible version to contain v23
+  [#864](https://github.com/nextcloud/cookbook/pull/864) @christianlupus
+
+

--- a/.changelog/versions/v0.9.9.md
+++ b/.changelog/versions/v0.9.9.md
@@ -1,0 +1,13 @@
+## 0.9.9 - 2022-01-13
+
+### Fixed
+- Update NPM plugins to enhance build process
+  [#868](https://github.com/nextcloud/cookbook/pull/868) @christianlupus
+- Removed missing CSS link in guest template
+  [#869](https://github.com/nextcloud/cookbook/pull/869) @christianlupus
+- Avoid usage of deprecated JS function
+  [#870](https://github.com/nextcloud/cookbook/pull/870) @christianlupus
+- Added some translations manually
+  (see also [#875](https://github.com/nextcloud/cookbook/issues/875)) @nickvergessen
+
+

--- a/.github/workflows/pull-checks.yml
+++ b/.github/workflows/pull-checks.yml
@@ -14,38 +14,96 @@ jobs:
             -   name: Checkout the app
                 uses: actions/checkout@v4
                 with:
-                    fetch-depth: 2
+                    filter: "blob:none"
+                    fetch-depth: 0
             
             -   name: Get the diff
                 id: diff
                 run: |
-                    git diff HEAD~1 -- CHANGELOG.md
-                    lines=$(git diff HEAD~1 -- CHANGELOG.md | wc -l)
-                    echo "lines=$lines" >> $GITHUB_OUTPUT
+                    filename_prefix=".changelog/current/${{ github.event.number }}-"
+                    git diff HEAD~1 --name-only -- $filename_prefix* > /tmp/changed-cl-files
+                    echo "Possibly matching changelog files:"
+                    cat /tmp/changed-cl-files
+                    num_lines=$(wc -l /tmp/changed-cl-files)
+                    if [ "$num_lines" -gt 1 ]
+                    then
+                    {
+                        echo "### Too many changelog files match"
+                        echo ""
+                        echo "There are too many changelog entries found for the PR #${{ github.event.number }} found."
+                        echo "There must be only one entry."
+                        echo ""
+                        echo "The following entries were found:"
+                        echo ""
+                        sed 's@^@- @' /tmp/changed-cl-files
+                        echo ""
+                        echo "Please fix this manually."
+                    } > $GITHUB_STEP_SUMMARY
+                    exit 1
+                    fi
+                    echo "num_lines=$(wc -l /tmp/changed-cl-files)" >> $GITHUB_OUTPUT
             
             -   name: Get all changed file names
                 id: file-names
                 run: |
-                    lines="$(git diff HEAD~1 --name-only)"
+                    git diff HEAD~1 --name-only > /tmp/changed-files-in-pr
                     echo "Changed files:"
-                    echo "$lines"
-                    totalcnt="$(echo "$lines" | wc -l)"
+                    cat /tmp/changed-files-in-pr
+                    totalcnt="$(cat /tmp/changed-files-in-pr | wc -l)"
                     echo "totalcount=$totalcnt" >> $GITHUB_OUTPUT
                     #
-                    cnt="$(echo "$lines" | grep -v '^package-lock.json$' | grep -v '^composer.lock$' | grep -v '^\.github/workflows/' | grep -v '^docs/Gemfile.lock' | wc -l)"
+                    cat /tmp/changed-files-in-pr | grep -v '^package-lock.json$' | grep -v '^composer.lock$' | grep -v '^\.github/workflows/' | grep -v '^docs/Gemfile.lock' > /tmp/relevant-files-in-pr
+                    cnt="$(cat /tmp/relevant-files-in-pr  | wc -l)"
                     echo "num=$cnt" >> $GITHUB_OUTPUT
                     #
                     echo "That are $totalcnt changed files. After reducing the number there are $cnt files left."
 
-            -   name: Error/warn if the number of diff lines is zero
+            -   name: Error/warn if no changelog entry was found
                 run: |
                     if [ ${{ steps.file-names.outputs.num }} -gt 0 ]; then
-                    echo "::error file=CHANGELOG.md::There was no change in the changelog detected. Please fill in a valid entry into that file."
+                    echo "::error::There was no change in the changelog detected. Please fill in a valid entry into that file."
+                    {
+                        echo "### No changelog was found"
+                        echo ""
+                        echo "You have in total ${{ steps.file-names.outputs.totalcount }} file(s) changed in the pull request."
+                        echo "From these, there are ${{ steps.file-names.outputs.num }} file(s) which make a changelog entry mandatory."
+                        echo "These files are:"
+                        echo ""
+                        sed 's@^@- @' /tmp/relevant-files-in-pr
+                        echo ""
+                        echo "Please provide a file `.changelog/current/${{ github.event.number }}-foo` where you can set the text `foo` as you like."
+                        echo "A good suggestion is to summarize the PR's content and to replace any non-chars with dashes."
+                        echo "An example file name could be `.changelog/current/1234-update-nc-release-script`.
+                    } > $GITHUB_STEP_SUMMARY
                     exit 1
                     else
                     echo "::warning file=CHANGELOG.md::There was no change in the changelog detected. There are in total ${{ steps.file-names.outputs.totalcount }} changed files."
+                    {
+                        echo "### No changelog was needed"
+                        echo ""
+                        echo "No changelog entry was found so far."
+                        echo "This is okay, as no files have been modified that would require a changelog entry."
+                        echo "You might consider if adding a changelog entry would be benefical as significant changes have been made."
+                    } > $GITHUB_STEP_SUMMARY
                     fi
-                if: ${{ steps.diff.outputs.lines == 0 }}
+                if: ${{ steps.diff.outputs.num_lines == 0 }}
+            -   name: Install Python package
+                run: pip install --user virtualenv pipenv
+            -   name: Test creation of changelog
+                run: |
+                    cd .helpers/changelog
+                    virtualenv venv
+                    source venv/bin/activate
+                    pipenv sync
+                    echo "${{ secrets.GITHUB_TOKEN }}" > token
+                    {
+                        echo ""
+                        echo "### Output of changelog generation"
+                        echo ""
+                        echo '```'
+                    } >> $GITHUB_STEP_SUMMARY
+                    ./create-changelog-prerelease.sh --token token ../../.changelog/current/* 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+                    echo '```' >> $GITHUB_STEP_SUMMARY
     
     todo-checker:
         name: Check for added todo messages

--- a/.github/workflows/pull-checks.yml
+++ b/.github/workflows/pull-checks.yml
@@ -102,7 +102,7 @@ jobs:
                         echo ""
                         echo '```'
                     } >> $GITHUB_STEP_SUMMARY
-                    ./create-changelog-prerelease.sh --token token --ci ../../.changelog/current/* 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+                    ./create-changelog-prerelease.sh --token token --ci --pr ${{ github.event.number }} ../../.changelog/current/* 2>&1 | tee -a $GITHUB_STEP_SUMMARY
                     echo '```' >> $GITHUB_STEP_SUMMARY
     
     todo-checker:

--- a/.github/workflows/pull-checks.yml
+++ b/.github/workflows/pull-checks.yml
@@ -98,12 +98,12 @@ jobs:
                     echo "${{ secrets.GITHUB_TOKEN }}" > token
                     {
                         echo ""
-                        echo "### Output of changelog generation"
+                        echo "### Output of changelog generation unreleased section"
                         echo ""
                         echo '```'
+                        python -m changelog_builder --token token --ci --pr ${{ github.event.number }} ../../.changelog/current/* 2>&1
+                        echo '```'
                     } >> $GITHUB_STEP_SUMMARY
-                    ./create-changelog-prerelease.sh --token token --ci --pr ${{ github.event.number }} ../../.changelog/current/* 2>&1 | tee -a $GITHUB_STEP_SUMMARY
-                    echo '```' >> $GITHUB_STEP_SUMMARY
     
     todo-checker:
         name: Check for added todo messages

--- a/.github/workflows/pull-checks.yml
+++ b/.github/workflows/pull-checks.yml
@@ -102,7 +102,7 @@ jobs:
                         echo ""
                         echo '```'
                     } >> $GITHUB_STEP_SUMMARY
-                    ./create-changelog-prerelease.sh --token token ../../.changelog/current/* 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+                    ./create-changelog-prerelease.sh --token token --ci ../../.changelog/current/* 2>&1 | tee -a $GITHUB_STEP_SUMMARY
                     echo '```' >> $GITHUB_STEP_SUMMARY
     
     todo-checker:

--- a/.helpers/changelog/.gitignore
+++ b/.helpers/changelog/.gitignore
@@ -1,0 +1,3 @@
+/venv/
+__pycache__/
+/token

--- a/.helpers/changelog/Pipfile
+++ b/.helpers/changelog/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+coloredlogs = "*"
+toml = "*"
+requests = "*"
+gitpython = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.11"

--- a/.helpers/changelog/Pipfile.lock
+++ b/.helpers/changelog/Pipfile.lock
@@ -1,0 +1,201 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "203fa4a7b5c38751864f391d83716cb86277bfb970698a6ad8197a3dee7eb4a2"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.11"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
+                "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2024.2.2"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027",
+                "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087",
+                "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786",
+                "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8",
+                "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09",
+                "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185",
+                "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574",
+                "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e",
+                "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519",
+                "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898",
+                "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269",
+                "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3",
+                "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f",
+                "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6",
+                "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8",
+                "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a",
+                "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73",
+                "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc",
+                "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714",
+                "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2",
+                "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc",
+                "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce",
+                "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d",
+                "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e",
+                "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6",
+                "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269",
+                "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
+                "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d",
+                "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a",
+                "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4",
+                "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77",
+                "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d",
+                "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0",
+                "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed",
+                "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068",
+                "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac",
+                "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25",
+                "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8",
+                "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab",
+                "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26",
+                "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2",
+                "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db",
+                "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f",
+                "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5",
+                "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99",
+                "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c",
+                "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d",
+                "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811",
+                "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa",
+                "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a",
+                "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03",
+                "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b",
+                "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04",
+                "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c",
+                "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001",
+                "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458",
+                "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389",
+                "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99",
+                "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985",
+                "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537",
+                "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238",
+                "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f",
+                "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d",
+                "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796",
+                "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a",
+                "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143",
+                "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8",
+                "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c",
+                "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5",
+                "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5",
+                "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711",
+                "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4",
+                "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6",
+                "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c",
+                "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7",
+                "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4",
+                "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b",
+                "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae",
+                "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12",
+                "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c",
+                "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae",
+                "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8",
+                "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887",
+                "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b",
+                "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4",
+                "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f",
+                "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
+                "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33",
+                "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519",
+                "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.3.2"
+        },
+        "coloredlogs": {
+            "hashes": [
+                "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934",
+                "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==15.0.1"
+        },
+        "gitdb": {
+            "hashes": [
+                "sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4",
+                "sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.0.11"
+        },
+        "gitpython": {
+            "hashes": [
+                "sha256:35f314a9f878467f5453cc1fee295c3e18e52f1b99f10f6cf5b1682e968a9e7c",
+                "sha256:eec7ec56b92aad751f9912a73404bc02ba212a23adb2c7098ee668417051a1ff"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.43"
+        },
+        "humanfriendly": {
+            "hashes": [
+                "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477",
+                "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==10.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
+                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.7"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
+                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==2.31.0"
+        },
+        "smmap": {
+            "hashes": [
+                "sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62",
+                "sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==5.0.1"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
+                "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.1"
+        }
+    },
+    "develop": {}
+}

--- a/.helpers/changelog/changelog_builder/__init__.py
+++ b/.helpers/changelog/changelog_builder/__init__.py
@@ -55,6 +55,8 @@ def main():
 
 			if data['state'] != 'closed':
 				_l.error('The PR %d is not closed but has a changelog attached. This might be an inconsistency in the code. Skipping it.', pr)
+				if args.ci:
+					exit(1)
 				dropPrs.append(pr)
 				continue
 			

--- a/.helpers/changelog/changelog_builder/__init__.py
+++ b/.helpers/changelog/changelog_builder/__init__.py
@@ -1,0 +1,157 @@
+import logging
+import coloredlogs
+import subprocess
+import datetime
+
+from . import cli
+from . import parser
+from . import github
+
+_l = logging.getLogger(__name__)
+coloredlogs.install(level=logging.DEBUG, logger=_l)
+logLevelMap = {
+	0: logging.WARNING,
+	1: logging.INFO,
+}
+
+def main():
+	args = cli.parseParams()
+	_l.setLevel(logLevelMap.get(args.verbose, logging.DEBUG))
+	_l.debug('Found arguments %s', args)
+
+	p = parser.Parser()
+
+	def parseFiles():
+		prs = {}
+		for filename in args.files:
+			prNumber, author, sections = p.parse(filename)
+			prs[prNumber] = {
+				'author': author,
+				'sections': sections
+			}
+		return prs
+	
+	prs = parseFiles()
+	_l.debug('Found data in files: %s', prs)
+
+	def fixByUpstream(prs):
+		with open(args.token) as fp:
+			token = fp.read().strip()
+
+		for pr in prs.keys():
+			_l.debug('Fetching data for PR %d', pr)
+			with github.getGitHubPullInformation(pr, token) as res:
+				if res.status_code >= 400:
+					_l.error('Cannot read pull request information for PR %d', pr)
+					raise Exception('No data available')
+				
+				data = res.json()
+
+			_l.log(5, 'Result %s', data)
+			
+			if prs[pr]['author'] is None:
+				ghAuthor = f'@{data["user"]["login"]}'
+				if ghAuthor.endswith('[bot]'):
+					ghAuthor = ghAuthor[:-5]
+				prs[pr]['author'] = ghAuthor
+			
+			prs[pr]['merge_sha'] = data['merge_commit_sha']
+
+		return prs
+
+	prs = fixByUpstream(prs)	
+	_l.debug('Fixed data: %s', prs)
+
+	def getSortedPRIds():
+		mergeMap = {}
+		for pr in prs:
+			mergeMap[prs[pr]['merge_sha']] = pr
+		
+		_l.debug('Found merge map: %s', mergeMap)
+
+		gitLog = ['git', 'log', '--topo-order', '--pretty=format:%H'] + [prs[pr]['merge_sha'] for pr in prs]
+		_l.debug('Command to execute: %s', gitLog)
+		proc = subprocess.run(gitLog, text=True, capture_output=True)
+		proc.check_returncode()
+
+		procLines = proc.stdout.split('\n')
+
+		mergeOrder = []
+		for procLine in procLines:
+			if procLine in mergeMap:
+				prId = mergeMap[procLine]
+				_l.debug('Found PR %d in topo sorted list', prId)
+				mergeOrder.append(prId)
+		mergeOrder.reverse()
+		return mergeOrder
+	
+	mergeOrder = getSortedPRIds()
+	_l.debug('Sorted PRs: %s', mergeOrder)
+
+	def getTotalChangelog():
+		sections = {}
+		for prId in mergeOrder:
+			pr = prs[prId]
+			for section, sectionEntries in pr['sections'].items():
+				if section not in sections:
+					_l.debug('Section %s not found in sections. Creating it.', section)
+					sections[section] = []
+				
+				for entry in sectionEntries:
+					sections[section].append(
+						(prId, entry, pr['author'])
+					)
+		return sections
+	
+	totalSections = getTotalChangelog()
+	_l.debug('All merged changelog entries: %s', totalSections)
+
+	def getSectionOrdering():
+		knownSections = ('Added', 'Changed', 'Fixed', 'Deprecated', 'Removed', 'Documentation', 'Maintenance')
+		# knownSectoinsSet = set(knownSections)
+		foundSectionsSet = set(totalSections.keys())
+		foundKnownSections = [x for x in knownSections if x in foundSectionsSet]
+		foundUnknownSectionsSet = foundSectionsSet.difference(knownSections)
+		foundUnknownSections = list(foundUnknownSectionsSet)
+		foundUnknownSections.sort()
+
+		if len(foundUnknownSectionsSet) > 0:
+			_l.warning('Unknown sections were found: %s', foundUnknownSectionsSet)
+			interestingsPRIds = []
+			for unknownSection in foundUnknownSectionsSet:
+				interestingsPRIds += [entry[0] for entry in totalSections[unknownSection]]
+			interestingsPRIds.sort()
+			_l.info('Have a look at these PRs: %s', interestingsPRIds)
+		
+		return foundKnownSections + foundUnknownSections
+	
+	sectionList = getSectionOrdering()
+	
+	def getSectionContent():
+		lines = []
+		if args.tag is not None:
+			date = datetime.date.isoformat(datetime.date.today())
+			lines.append(f"## {args.tag} - %s" % date)
+		
+		for section in sectionList:
+			lines.append('')
+			lines.append(f'### {section}')
+			lines.append('')
+
+			for prId, entryLines, author in totalSections[section]:
+				firstLine = True
+				for l in entryLines:
+					if firstLine:
+						lines.append(f'- {l}')
+						firstLine = False
+					else:
+						lines.append(f'  {l}')
+				lines.append(f'  [#{prId}](https://github.com/nextcloud/cookbook/pull/{prId}) {author}')
+		
+		lines.append('')
+		lines.append('')
+
+		return '\n'.join(lines)
+
+	sectionContent = getSectionContent()
+	print(sectionContent)

--- a/.helpers/changelog/changelog_builder/__main__.py
+++ b/.helpers/changelog/changelog_builder/__main__.py
@@ -1,0 +1,3 @@
+import changelog_builder
+
+changelog_builder.main()

--- a/.helpers/changelog/changelog_builder/cli.py
+++ b/.helpers/changelog/changelog_builder/cli.py
@@ -7,6 +7,7 @@ def parseParams():
 	parser.add_argument('-t', '--token', required=True, help='The file containing the token to use when making API requests.')
 	parser.add_argument('--tag', help='The version to tag this with')
 	parser.add_argument('--ci', action='store_true', help='Make the script more restrictive for use in CI.')
+	parser.add_argument('--pr', help='Define the PR number if run in a pull_request check')
 	
 	parser.add_argument('-v', '--verbose', default=0, action='count')
 	return parser.parse_args()

--- a/.helpers/changelog/changelog_builder/cli.py
+++ b/.helpers/changelog/changelog_builder/cli.py
@@ -6,6 +6,7 @@ def parseParams():
 	parser.add_argument('files', nargs='+')
 	parser.add_argument('-t', '--token', required=True, help='The file containing the token to use when making API requests.')
 	parser.add_argument('--tag', help='The version to tag this with')
+	parser.add_argument('--ci', action='store_true', help='Make the script more restrictive for use in CI.')
 	
 	parser.add_argument('-v', '--verbose', default=0, action='count')
 	return parser.parse_args()

--- a/.helpers/changelog/changelog_builder/cli.py
+++ b/.helpers/changelog/changelog_builder/cli.py
@@ -1,0 +1,11 @@
+import argparse
+
+def parseParams():
+	parser = argparse.ArgumentParser()
+
+	parser.add_argument('files', nargs='+')
+	parser.add_argument('-t', '--token', required=True, help='The file containing the token to use when making API requests.')
+	parser.add_argument('--tag', help='The version to tag this with')
+	
+	parser.add_argument('-v', '--verbose', default=0, action='count')
+	return parser.parse_args()

--- a/.helpers/changelog/changelog_builder/github.py
+++ b/.helpers/changelog/changelog_builder/github.py
@@ -1,0 +1,9 @@
+import requests
+
+def getGitHubPullInformation(pr: int, token: str):
+	url = f'https://api.github.com/repos/nextcloud/cookbook/pulls/{pr}'
+	headers= {
+		'Authorization': f'Bearer {token}'
+	}
+	res = requests.get(url, headers=headers)
+	return res

--- a/.helpers/changelog/changelog_builder/parser.py
+++ b/.helpers/changelog/changelog_builder/parser.py
@@ -59,6 +59,7 @@ class MarkdownParser:
 		matcherAuthor = self._reAuthors.fullmatch(line)
 		if matcherAuthor is not None:
 			self._author = matcherAuthor.group(1)
+			return
 		
 		if not self._headerMatched(line):
 			self._l.error('No heading line is defined')

--- a/.helpers/changelog/changelog_builder/parser.py
+++ b/.helpers/changelog/changelog_builder/parser.py
@@ -1,0 +1,156 @@
+import json
+import toml
+import logging
+import re
+import os
+
+class ParserInvalidException(Exception):
+	def __init__(self, *args):
+		super().__init__(*args)
+
+class MarkdownParser:
+	
+	STATE_INIT = 1
+	STATE_SECTION_STARTED = 2
+	STATE_SECTION_RUNNING = 3
+
+	def __init__(self):
+		self._l = logging.getLogger(__name__)
+		self._reAuthors = re.compile('Authors?:\W+(.*)')
+		self._reHeader = re.compile('#+\W+(.*)')
+
+		self._state = None
+
+		self._author = None
+		self._header = None
+		self._lines = None
+		self._sections = None
+	
+	def parse(self, filename: str):
+		self._l.debug('Parsing %s with MarkdownParser', filename)
+
+		if not filename.endswith('.md'):
+			raise ParserInvalidException('No markdown file')
+		
+		with open(filename) as fp:
+			self._state = self.STATE_INIT
+			self._author = None
+			self._sections = {}
+
+			stateMap = {
+				self.STATE_INIT: lambda line: self._parseInit(line),
+				self.STATE_SECTION_STARTED: lambda line: self._parseStartedSection(line),
+				self.STATE_SECTION_RUNNING: lambda line: self._parseRunningSection(line),
+			}
+
+			for line in fp.readlines():
+				strippedLine = line.rstrip()
+				if strippedLine == '':
+					continue
+
+				self._l.debug('Parsing line "%s"', strippedLine)
+				stateMap[self._state](strippedLine)
+			self._pushLinesToStruct()
+		
+		self._l.debug('Found datastructure: %s', self._sections)
+		return self._author, self._sections
+	
+	def _parseInit(self, line: str):
+		matcherAuthor = self._reAuthors.fullmatch(line)
+		if matcherAuthor is not None:
+			self._author = matcherAuthor.group(1)
+		
+		if not self._headerMatched(line):
+			self._l.error('No heading line is defined')
+			raise ParserInvalidException()
+
+	def _headerMatched(self, line: str):
+		matcherHeader = self._reHeader.fullmatch(line)
+		if matcherHeader is None:
+			return False
+		
+		self._pushLinesToStruct()
+
+		self._header = matcherHeader.group(1)
+		self._state = self.STATE_SECTION_STARTED
+		self._lines = []
+		self._l.debug('Started section %s', self._header)
+
+		return True
+	
+	def _parseStartedSection(self, line: str):
+		if self._headerMatched(line):
+			# There is nothing in this section. We do not need to finish anything
+			return
+		
+		lineSnippet = self._getListSnippet(line)
+		if lineSnippet is None:
+			self._l.error('Starting section %s with a non-list element', self._header)
+			raise ParserInvalidException()
+		
+		self._l.debug('Adding line snippet "%s"', lineSnippet)
+		self._lines.append(lineSnippet)
+		self._state = self.STATE_SECTION_RUNNING
+	
+	def _getListSnippet(self, line):
+		if not ( line.startswith('-') or line.startswith('*') ):
+			return None
+		
+		lineSnippet = line[1:].strip()
+		return lineSnippet
+
+	def _parseRunningSection(self, line: str):
+		if self._headerMatched(line):
+			return
+
+		listSnippet = self._getListSnippet(line)
+		if listSnippet is None:
+			self._l.debug('Appending line as no new snippet')
+			self._lines.append(line.strip())
+		else:
+			self._l.debug('New list snippet found.')
+			self._pushLinesToStruct()
+
+			self._lines = [listSnippet]
+
+	def _pushLinesToStruct(self):
+		if self._lines is None:
+			return
+		
+		if len(self._lines) == 0:
+			self._l.debug('Not pushing lines to the struct as no lines are present')
+			return
+
+		self._l.debug('Pushing lines to the structure')
+		sectionList = self._sections.get(self._header, [])
+		sectionList.append(self._lines)
+		self._sections[self._header] = sectionList
+		self._lines = []
+
+class Parser:
+	def __init__(self):
+		self._l = logging.getLogger(__name__)
+		self._parsers = (
+			MarkdownParser(),
+		)
+		self._rePrNumber = re.compile('([0-9]+)-.*')
+	
+	def parse(self, path: str):
+		self._l.info('Parsing file %s', path)
+
+		filename = os.path.basename(path)
+		matcher = self._rePrNumber.fullmatch(filename)
+		if matcher is None:
+			self._l.error('The filename %s does not contain a valid  PR number at the beginning.', filename)
+			raise ParserInvalidException('Cannot extract PR number from filename')
+
+		prNumber = int(matcher.group(1))
+
+		for p in self._parsers:
+			try:
+				author, sections = p.parse(path)
+				return prNumber, author, sections
+			except ParserInvalidException:
+				self._l.debug('Parser rejected file.')
+		
+		raise ParserInvalidException('No parser was found')

--- a/.helpers/changelog/create-changelog-prerelease.sh
+++ b/.helpers/changelog/create-changelog-prerelease.sh
@@ -1,18 +1,19 @@
-#!/bin/sh
+#!/bin/sh -e
 
 localdir="$(dirname "$0")"
 
 versions_dir="$localdir/../../.changelog/versions"
-shift
 
 . .helpers/changelog/venv/bin/activate
 
-echo "## [Unreleased]"
+changelog="$localdir/../../CHANGELOG.md"
+
+echo "## [Unreleased]" > "$changelog"
 
 (
 	export PYTHONPATH="$(pwd)/.helpers/changelog"
 	python -m changelog_builder "$@"
-)
+) >> "$localdir/../../CHANGELOG.md"
 
-find "$versions_dir" -type f | sort -Vr | xargs -n 1 cat > "$localdir/../../CHANGELOG.md"
+find "$versions_dir" -type f | sort -Vr | xargs -n 1 cat >> "$localdir/../../CHANGELOG.md"
 

--- a/.helpers/changelog/create-changelog-prerelease.sh
+++ b/.helpers/changelog/create-changelog-prerelease.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
 
-if [ $# -lt 1 ]
-then
-	echo "Please give the path to the old changelog snippets"
-	exit 1
-fi
+localdir="$(dirname "$0")"
 
-versions_dir="$1"
+versions_dir="$localdir/../../.changelog/versions"
 shift
 
 . .helpers/changelog/venv/bin/activate
@@ -18,5 +14,5 @@ echo "## [Unreleased]"
 	python -m changelog_builder "$@"
 )
 
-find "$versions_dir" -type f | sort -Vr | xargs -n 1 cat
+find "$versions_dir" -type f | sort -Vr | xargs -n 1 cat > "$localdir/../../CHANGELOG.md"
 

--- a/.helpers/changelog/create-changelog-prerelease.sh
+++ b/.helpers/changelog/create-changelog-prerelease.sh
@@ -8,7 +8,9 @@ versions_dir="$localdir/../../.changelog/versions"
 
 changelog="$localdir/../../CHANGELOG.md"
 
-echo "## [Unreleased]" > "$changelog"
+cat "$localdir/../../.changelog/prefix.md" > "$changelog"
+
+echo "## [Unreleased]" >> "$changelog"
 
 (
 	export PYTHONPATH="$(pwd)/.helpers/changelog"

--- a/.helpers/changelog/create-changelog-prerelease.sh
+++ b/.helpers/changelog/create-changelog-prerelease.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+if [ $# -lt 1 ]
+then
+	echo "Please give the path to the old changelog snippets"
+	exit 1
+fi
+
+versions_dir="$1"
+shift
+
+. .helpers/changelog/venv/bin/activate
+
+echo "## [Unreleased]"
+
+(
+	export PYTHONPATH="$(pwd)/.helpers/changelog"
+	python -m changelog_builder "$@"
+)
+
+find "$versions_dir" -type f | sort -Vr | xargs -n 1 cat
+

--- a/.helpers/changelog/create-changelog-prerelease.sh
+++ b/.helpers/changelog/create-changelog-prerelease.sh
@@ -4,7 +4,7 @@ localdir="$(dirname "$0")"
 
 versions_dir="$localdir/../../.changelog/versions"
 
-. .helpers/changelog/venv/bin/activate
+. "$localdir/venv/bin/activate"
 
 changelog="$localdir/../../CHANGELOG.md"
 

--- a/.helpers/changelog/create-changelog-release.sh
+++ b/.helpers/changelog/create-changelog-release.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+if [ $# -lt 2 ]
+then
+	echo "Please give the path to the old changelog snippets"
+	exit 1
+fi
+
+versions_dir="$1"
+new_version="$2"
+shift 2
+
+. .helpers/changelog/venv/bin/activate
+
+echo "## [Unreleased]"
+
+(
+	export PYTHONPATH="$(pwd)/.helpers/changelog"
+	python -m changelog_builder "$@"
+) > ".changelog/versions/v$new_version.md"
+
+rm .changelog/current/*
+
+find "$versions_dir" -type f | sort -Vr | xargs -n 1 cat
+

--- a/.helpers/changelog/create-changelog-release.sh
+++ b/.helpers/changelog/create-changelog-release.sh
@@ -1,25 +1,29 @@
 #!/bin/sh
 
-if [ $# -lt 2 ]
+if [ $# -lt 1 ]
 then
 	echo "Please give the path to the old changelog snippets"
 	exit 1
 fi
 
-versions_dir="$1"
-new_version="$2"
-shift 2
+localdir="$(dirname "$0")"
+
+versions_dir="$localdir/../../.changelog/versions"
+new_version="$1"
+shift
 
 . .helpers/changelog/venv/bin/activate
 
 echo "## [Unreleased]"
+echo ""
+echo ""
 
 (
 	export PYTHONPATH="$(pwd)/.helpers/changelog"
-	python -m changelog_builder "$@"
+	python -m changelog_builder --tag "$new_version" "$@"
 ) > ".changelog/versions/v$new_version.md"
 
 rm .changelog/current/*
 
-find "$versions_dir" -type f | sort -Vr | xargs -n 1 cat
+find "$versions_dir" -type f | sort -Vr | xargs -n 1 cat > "$localdir/../../CHANGELOG.md"
 

--- a/.helpers/changelog/create-changelog-release.sh
+++ b/.helpers/changelog/create-changelog-release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 if [ $# -lt 1 ]
 then
@@ -14,9 +14,11 @@ shift
 
 . .helpers/changelog/venv/bin/activate
 
-echo "## [Unreleased]"
-echo ""
-echo ""
+changelog="$localdir/../../CHANGELOG.md"
+
+echo "## [Unreleased]" > "$changelog"
+echo "" >> "$changelog"
+echo "" >> "$changelog"
 
 (
 	export PYTHONPATH="$(pwd)/.helpers/changelog"
@@ -25,5 +27,5 @@ echo ""
 
 rm .changelog/current/*
 
-find "$versions_dir" -type f | sort -Vr | xargs -n 1 cat > "$localdir/../../CHANGELOG.md"
+find "$versions_dir" -type f | sort -Vr | xargs -n 1 cat >> "$changelog"
 

--- a/.helpers/changelog/create-changelog-release.sh
+++ b/.helpers/changelog/create-changelog-release.sh
@@ -16,7 +16,9 @@ shift
 
 changelog="$localdir/../../CHANGELOG.md"
 
-echo "## [Unreleased]" > "$changelog"
+cat "$localdir/../../.changelog/prefix.md" > "$changelog"
+
+echo "## [Unreleased]" >> "$changelog"
 echo "" >> "$changelog"
 echo "" >> "$changelog"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,7 +243,7 @@
 - Use logging framework throughout the complete app
   [1459](https://github.com/nextcloud/cookbook/pull/1459) @MarcelRobitaille
 
-## Documentation
+### Documentation
 - Fixed some issues in the API description #1419 and #1461 @leptopoda
 - Improve API description for better code-generation #1461 @leptopoda
 - Fix security issue in GitHub pages with path insertion
@@ -514,72 +514,6 @@ The changed will be duplicated to the next release as this release should not be
   [#1170](https://github.com/nextcloud/cookbook/pull/1170) @christianlupus
 - Reactivate Codecov coverage reporting
   [#1177](https://github.com/nextcloud/cookbook/pull/1177) @christianlupus
-
-
-## 0.9.14-beta2 - 2022-08-24
-
-### Fixed
-- Correct output of getApiVersion
-  [#1175](https://github.com/nextcloud/cookbook/pull/1175) @christianlupus
-
-
-## 0.9.14-beta1 - 2022-08-23
-
-### Changed
-- Parsing of JSON recipe objects in a cascade of filters
-  [#1097](https://github.com/nextcloud/cookbook/pull/1097) @christianlupus
-- Ordering corrected for mobile and printout versions
-  [#1107](https://github.com/nextcloud/cookbook/pull/1107) @christianlupus
-- Less intrusive sharp popup (suggestion menu for reference autocomplete)
-  [#1098](https://github.com/nextcloud/cookbook/pull/1098) @MarcelRobitaille
-
-### Fixed
-- Prevent slow loading of recipes due to iteration over all files
-  [#1072](https://github.com/nextcloud/cookbook/pull/1072) @christianlupus
-- Fix keyword ordering buttons being clipped by top bar
-  [#1103](https://github.com/nextcloud/cookbook/pull/1103) @MarcelRobitaille
-- Replace print icon with something better recognizable
-  [#1106](https://github.com/nextcloud/cookbook/pull/1106) @christianlupus
-- Make recipeYield optional
-  [#1108](https://github.com/nextcloud/cookbook/pull/1108) @christianlupus
-- Fix UI glitches caused by improper use of Breadcrumbs component
-  [#1105](https://github.com/nextcloud/cookbook/pull/1105) @MarcelRobitaille
-- Fix typos and styling issues
-  [#1112](https://github.com/nextcloud/cookbook/pull/1112) @christianlupus
-- Fix API endpoint used for updating recipes
-  [#1119](https://github.com/nextcloud/cookbook/pull/1119) @MarcelRobitaille
-- Reactivate step debugging  in PHP
-  [#1160](https://github.com/nextcloud/cookbook/pull/1160) @christianlupus
-- Fix multi-line code entry in some fields during editing
-  [#1162](https://github.com/nextcloud/cookbook/pull/1162) @christianlupus
-- Make the API return correct nutrition information objects for recipes
-  [#1163](https://github.com/nextcloud/cookbook/pull/1163) @christianlupus
-- Allow HowToSteps in recipe instructions during importing
-  [#1165](https://github.com/nextcloud/cookbook/pull/1165) @christianlupus
-
-### Maintenance
-- Add composer.json to version control to have unique installed dependency versions
-  [#1093](https://github.com/nextcloud/cookbook/pull/1093) @christianlupus
-- Update supported PHP versions
-  [#1095](https://github.com/nextcloud/cookbook/pull/1095) @christianlupus
-- Update README with app screenshot and fixed repository links
-  [#1102](https://github.com/nextcloud/cookbook/pull/1102) @MarcelRobitaille
-- Cleaned up entry JS code
-  [#1118](https://github.com/nextcloud/cookbook/pull/1118) @christianlupus
-- Create Python based testing wrapper and enhance workflow script
-  [#1137](https://github.com/nextcloud/cookbook/pull/1137) @christianlupus
-- Update workflow from nextcloud organization template
-  [#1142](https://github.com/nextcloud/cookbook/pull/1142) @christianlupus
-- Remove dependency @nextcloud/auth from explicit dependencies
-  [#1149](https://github.com/nextcloud/cookbook/pull/1149) @christianlupus
-- Fix bug in automated test programs
-  [#1165](https://github.com/nextcloud/cookbook/pull/1165) @christianlupus
-- Update some NPM dependencies and deprecations
-  [#1159](https://github.com/nextcloud/cookbook/pull/1159) @christianlupus
-- Prepare the generation of pre-releases
-  [#1169](https://github.com/nextcloud/cookbook/pull/1169) @christianlupus
-- Corrected usage of npm ci
-  [#1170](https://github.com/nextcloud/cookbook/pull/1170) @christianlupus
 
 
 ## 0.9.13 - 2022-07-02
@@ -1006,11 +940,11 @@ The changed will be duplicated to the next release as this release should not be
 - Fixed compatiblity with Nextcloud 21
   [#605](https://github.com/nextcloud/cookbook/pull/605) @icewind1991
 
-## Deprecated
+### Deprecated
 - Obsolete routes to old user interface, see `appinfo/routes.php`
   [#580](https://github.com/nextcloud/cookbook/pull/580) @christianlupus
 
-## Removed
+### Removed
 - Dropped support for NC core version <= 18
   [#630](https://github.com/nextcloud/cookbook/pull/630) @christianlupus
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,40 @@
+## Note on incomplete changelogs and releases
+
+Please note that the changelog in this branch is not complete.
+This is due to the way, how the changelog file is managed and generated.
+
+Any changes to the branch not yet released are not guaranteed to be part of the changelog file.
+This file is auto-generated during the release process.
+See also the other files in `.changelog/current` for all merged changes since the last release.
+
+To be precise:
+Releses on parallel development branches will not appear in this CHANGELOG.
+Instead have a look at the correpsonding branches for an appropriate CHANGELOG.
+
+Also note, that the releases on this repository are not the actual releases of the cookbook.
+The releases are stored for technical reasins in the repository [christianlupus-nextcloud/cookbook-releases](https://github.com/christianlupus-nextcloud/cookbook-releases).
+Sorry for the inconvience.
+
+
 ## [Unreleased]
 
 ### Added
+
 - Toast with success/error message after trying to copy ingredients
-  [#2040](https://github.com/nextcloud/cookbook/pull/2040) @seyfeb
+  [#2040](https://github.com/nextcloud/cookbook/pull/2040) @dependabot
 - Seconds can now be specified for recipe times
   [#2014](https://github.com/nextcloud/cookbook/pull/2014) @seyfeb
 - New filter UI in recipe lists
   [#2037](https://github.com/nextcloud/cookbook/pull/2037) @seyfeb
 
 ### Fixed
+
 - Prevent yield calculation for ## as ingredient headline
   [#1998](https://github.com/nextcloud/cookbook/pull/1998) @j0hannesr0th
-- Improved styling of times in recipe view
-  [#2014](https://github.com/nextcloud/cookbook/pull/2014) @seyfeb
 - Add missing translatable string for recipe-creation button in empty list view
   [#2015](https://github.com/nextcloud/cookbook/pull/2015) @seyfeb
+- Improved styling of times in recipe view
+  [#2014](https://github.com/nextcloud/cookbook/pull/2014) @seyfeb
 - Prevent recalculation algorithm if no yield is given
   [#2003](https://github.com/nextcloud/cookbook/pull/2003) @j0hannesr0th
 - Fix yield not set calculation error
@@ -27,6 +47,7 @@
   [#2287](https://github.com/nextcloud/cookbook/pull/2287) @christianlupus
 
 ### Documentation
+
 - Improve  structure of `README.md`
   [#1989](https://github.com/nextcloud/cookbook/pull/1989) @seyfeb
 - Fix wrong type definition in OpenAPI specs
@@ -35,6 +56,7 @@
   [#2225](https://github.com/nextcloud/cookbook/pull/2225) @shagn
 
 ### Maintenance
+
 - Add Typescript support
   [#2059](https://github.com/nextcloud/cookbook/pull/2059) @seyfeb
 - Update coding standards
@@ -42,7 +64,7 @@
 - Import NC core components correctly
   [#2250](https://github.com/nextcloud/cookbook/pull/2250) @christianlupus
 - Update typescript
-  [#2281](https://github.com/nextcloud/cookbook/pull/2281) @dependabot
+  [#2281](https://github.com/nextcloud/cookbook/pull/2281) @christianlupus
 - Update nextcloud router
   [#2279](https://github.com/nextcloud/cookbook/pull/2279) @dependabot
 - Update NPM and Node version
@@ -51,6 +73,9 @@
   [#2141](https://github.com/nextcloud/cookbook/pull/2141) @dependabot
 - Update vue plugin for eslint with typescript
   [#2188](https://github.com/nextcloud/cookbook/pull/2188) @dependabot
+- Update changlog process to allow for backports
+  [#2291](https://github.com/nextcloud/cookbook/pull/2291) @christianlupus
+
 
 ## 0.11.0 - 2023-12-14
 

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -32,3 +32,5 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
+gem "json"
+gem "webrick", "~> 1.8"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
+    json (2.7.2)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -263,15 +264,18 @@ GEM
     unf_ext (0.0.9.1)
     unicode-display_width (1.8.0)
     uri (0.13.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   github-pages
+  json
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.1.4

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,7 +21,7 @@ build:
 	${BUNDLER} exec jekyll build
 
 watch:
-	${BUNDLER} exec jekyll serve --host ${HOST}
+	${BUNDLER} exec jekyll serve --host ${HOST} --livereload
 
 install:
 	${BUNDLER} install

--- a/docs/dev/changelog.md
+++ b/docs/dev/changelog.md
@@ -1,0 +1,203 @@
+# Management of changelogs
+
+* TOC
+{:toc}
+
+The handling and creation of a changelog is part of the usual development work.
+There are different variants to create sucha a changelog (semi-) automatically.
+Instead, we rely on a script that combines a set of snippets and created the changelog files as needed.
+
+This process requres some user interaction in order to work.
+There is also a checker on the repository in place that will bail out unless the expected file structue is met.
+
+## Day-to-day usage as a developer
+
+There is a special folder `.changelog/current` in the root folder of the repo.
+This folder will have all the snippets for the changelog that are _not yet released_.
+
+Each pull request is obligated to create a file within said folder.
+The file of a pull request must begin with the number of the pull request and a dash.
+For example, let's assume the imaginary pull request 1234 fixes the output of some JSON export.
+The corespoinding snippet would be in the file `.changelog/current/1234-fix-json-output.md`.
+The text `fix-json-output` is generic here and only helps with file management as a human.
+Please try to be as precise and short as possible.
+
+At the time of writing there are only Markdown files (`*.md`) accepted.
+There is the plan to add further file types (JSON, YAML, TOML) in the future.
+
+The developer is responsible for creating an appropriate file in the correct location, filling it with the correct content, and committing/pushing the file.
+The check will block a non-administrative merge of the PR unless an appropriate file has been found.
+
+### Format of basic snippet
+
+A snippet can be rather simple.
+An example could be
+
+```md
+# Fixed
+
+- JSON output for filters adopted to latest API definition
+```
+
+The parser will then collect all snippets, combine them according to their names and creats a Changelog file.
+The above example woulbe be extended by one line containing the PR number and link as well as the PR creator as author:
+
+```md
+...
+### Fixed
+...
+- JSON output for filters adopted to latest API definition
+  [#1234](https://github.com/nextcloud/cookbook/pull/1234) @max.musterman
+...
+```
+
+### Full format snippet in Markdown format
+
+For more advanced cases, more options are there to set.
+Here is an example in Markdown:
+
+```md
+Author: @dependabot @max-muster
+
+# Added
+- New UI eleemnts
+
+# Deprecated
+- Doubled elements in Vue tree
+
+# Unknown
+- Do fancy stuff
+```
+
+This will render something like this:
+```md
+### Added
+...
+- New UI eleemnts
+  [#1234](https://github.com/nextcloud/cookbook/pull/1234) @dependabot @max-muster
+...
+
+### Deprecated
+...
+- Doubled elements in Vue tree
+  [#1234](https://github.com/nextcloud/cookbook/pull/1234) @dependabot @max-muster
+...
+
+### Unknown
+...
+- Do fancy stuff
+  [#1234](https://github.com/nextcloud/cookbook/pull/1234) @dependabot @max-muster
+...
+```
+
+Note that the headings are sorted first the known headings (_Added_, _Changed_, _Fixed_, _Deprecated_, _Removed_, _Documentation_, and _Maintenance_).
+After them, the remaining headings come sorted alphabeticlly.
+
+## Technical background
+
+The actual implementation of the scripts cannot be explained here.
+Instead a rough sketch of thea how things should work are given.
+
+Generally, the Changelog file consissts of basic blocks:
+
+1. An optional prefix
+1. The heading `## [Unreleased]`
+1. Then, it comes the _Unreleased_ things:
+	1. A heading like `### Added` or similar
+	1. The different merged PRs with a one line introduction, a link to the PR, and a reference to the author
+1. The already published releases, each one consisting of:
+	1. A corresponding heading like `## 1.2.3 - YYYY-MM-dd` consisting of version and date
+	1. The actual things in the same manner as the unreleased ones (headings plus list of PRs merged, see № 3.)
+
+The script to build the changelog bases on these building blocks.
+The content is stored in the `.changelog` folder in the root of the repo.
+
+### The new changes (`current`)
+
+In the `.changelog` folder there is a folder called `current`.
+All merged PRs have an appropriate file in this folder.
+
+Speaking in the building blocks, these represent the unreleased stuff.
+
+The final ordering of the entries in the final Changelog depends on the structure of the git history.
+Therefore, to create an ordering, the corresponding merge commits needs to be identified.
+Using the topological ordering of `git log` the relative ordering of the PRs can be derived (see `man git-log` section `--topo-order`).
+
+### Fixed releases (`versions`)
+
+Once, a release is made, no changes are allowed to the corresponding changelog anymore.
+This is realizedby fixing the corresponding part of the Changelog as individual file.
+These version files are located in `.changelog/versions`.
+For example, the version `0.11.0` is located in `.changelog/versions/v0.11.0.md`.
+
+These files are already in the parsed format as the final changelog will be.
+Thus, no parsing is needed here to create the final result of a certain version in the past.
+
+These files should have the corresponding heading already embedded.
+Best is to have two empty lines at the end to get a smooth final markdown changelog file.
+
+### Buidling the complete Changelog file
+
+The complete changelog can now be constructed by concatenation of various files and program outputs.
+The prefix lies in a file `.changelog/prefix.md` and can be used as a first part directly.
+Then, the unreleased stuff follows.
+Here, the heading needs manual intervention and the parsing and data collection can be delegated to a python script located in `.helpers/changelog`.
+The script uses pipenv and has some CLI parameters to be used.
+It outputs on the stdout the content of the `[Unreleased]` section.
+Finally, the different versions need to be appended in reverded versioning order (see `sort -V`).
+
+### Creating of changelogs for relaeses
+
+In order to make the usage as convinient for the dev/admin as possible, there are two scripts `.helpers/changelog/create-changelog-prerelease.sh` and `.helpers/changelog/create-changelog-release.sh`.
+
+**Please be careful:** The latter script will remove files. Please read this section completely before actually calling it.
+
+#### Common options
+
+Both scripts have some options they share.
+
+As the current implementation has to use the GitHub API in order to get some information about the PRs, you could quickly run into rate limiting issues.
+To avoid these, the script assumes, you have a personal access token (PAT) created on GitHub.
+Put the token in some file (e.g. `.changelog/token`) but **do not commit it**.
+You can also put the file outside the repo to be sure, that you do not accidetnially commit the PAT.
+The PAT can be provided as file name to the script using the `-t` (or `--token`) option.
+
+The verbosity can be increased by means of `-v`.
+This can be given multiple times to get more logs.
+
+The option `--ci` makes the script a bit more restrictive to make sure if actually fails in an GitHub action instead of thowing an unheard/unread warning.
+
+Similarly, the `--pr` option is present which takes a (PR) number as argument.
+It instructs the script to ignore any snipet with this PR number during generation of the changelog.
+Instead it is apeended at the very ending.
+This is needed if a PR is not yet merged but the corresponding snippet is already present (in the GitHub action this is the case).
+As the merge commit will not be found, this would otherwise bail out.
+Normally, the dev does not need to give this option.
+
+The script then takes the snippets (_not just the folder of the snippets_) in random order as positional arguments.
+Typically this is something like `./helpers/changelog/create-changelog-prerelease.sh <other options> .changelog/current/*` in bash.
+
+#### Prereleases
+
+The first script (for prereleases) will carry out the steps as [described above](#buidling-the-complete-changelog-file).
+
+The script expects no additional options and will rewrite the `CHANGELOG.md` file completely.
+
+#### Final releases
+
+**Attention: This script will remove data! Make sure, you have everything committed prior to continuing.**
+
+The second script for releases will however create a new version snippet in `.changelog/versions` from the current state of the `.changelog/current` parts.
+After successful creation, the snippets in the current folder are considered obsolete and removed.
+A new release has just been prepared.
+
+This script expectes one additional parameter:
+It needs the verion to create as first positional argument.
+Typically this is something like `./helpers/changelog/create-changelog-release.sh <other options> 0.11.1 .changelog/current/*` in bash.
+The date of the release will be set to the date of today.
+
+After having run the script, the `CHANGELOG.md` is updated as well as the file in `.changelog/versions/v0.11.1.md`.
+You can have a look if it is correclty built.
+If the result has a minor uissue, you might want to edit the version file in `.changelog/versions` directly.
+
+You will have to commit the changes manually as the `.changelog` folder has now some changes in it.

--- a/docs/dev/changelog.md
+++ b/docs/dev/changelog.md
@@ -146,6 +146,16 @@ The script uses pipenv and has some CLI parameters to be used.
 It outputs on the stdout the content of the `[Unreleased]` section.
 Finally, the different versions need to be appended in reverded versioning order (see `sort -V`).
 
+In order for the python script to run, some python packages need tp be present.
+Best is if you create a virtual environment for this program.
+If you do not have the pipenv program available, install it as user by `pip install --user pipenv`.
+You can do this my means of `venv .helpers/changelog/venv` and acticate it by `source .helpers/changelog/venv/bin/activate`.
+Then, you need to install the dependencies:
+Go to the folder `.helpers/changelog` and finally installing the actual dependencies by `pipenv sync`.
+
+You need to activate the venv every time, you start a new shell.
+Otherwiese the dependencies might not be found.
+
 ### Creating of changelogs for relaeses
 
 In order to make the usage as convinient for the dev/admin as possible, there are two scripts `.helpers/changelog/create-changelog-prerelease.sh` and `.helpers/changelog/create-changelog-release.sh`.

--- a/docs/dev/contributing/index.md
+++ b/docs/dev/contributing/index.md
@@ -10,6 +10,7 @@ If you need additional information or find any missing parts, feel free to conta
 The first step, when you want to help with coding on the app, will be to setup your development environment.
 We prepared a [page on the setup](setup) to help you get started with the technical requirements.
 See also the page on [code coverage](code_coverage).
+Please also note that the [changelog process](../changelog) needs some addressing as well.
 
 ## Translating
 Feel free to have a look at the [transifex page on the cookbook app](https://app.transifex.com/nextcloud/nextcloud/cookbook/).

--- a/docs/dev/deployment.md
+++ b/docs/dev/deployment.md
@@ -27,12 +27,48 @@ git checkout -b release/1.2.4 master
 ### Update the changelogs
 
 In the release branch you will have to prepare the changelog file.
-This means, you have to add a new second level heading to the unreleased changes so far.
-You might need to add
-```
-## 1.2.4 - YYYY-mm-dd
-```
-as one of the first few lines with `YYYY-mm-dd` the current date.
+The process depends if you want to create an actual new release or just a pre-release.
+
+Both variants require that a python script is called to build the changelog from the various files.
+Please install this first.
+
+#### Installation of script (onlly once needed)
+
+Go to the folder `.helper/changelog` in a console.
+Create a virtual python environment valled `venv`.
+Typically this can be done by `virtualenv venv` (Linux) or `python -m venv venv` (Windows) in that folder.
+
+#### Update the changelog for a release
+
+There is a convinence script availabe at `.helper/changelog/create-changelog-release.sh`.
+This will call the python script and carry out the actual work for you.
+
+You have to provie at least one option to th script:
+
+1. The version to create. In out example, this would be `1.2.4`.
+
+Any additional parameters are passed to the python script `changelog_bilder` as located in `.helpers/changelog`.
+
+The script will alter a few files in the repository:
+
+1. The files in `.changelog/current` are removed.
+2. A new snippet in `.changelog/versions` called `v1.2.4.md` is created.
+3. The `CHANGELOG.md` in the root folder of the repository is updated appropriately.
+
+Also check if any pending API change is present.
+Update the API changelog (in `/docs/dev/api/changelog/*.md`) accordingly.
+
+Commit the changes.
+Pushing them to GitHub is neither needed nor adviced.
+
+#### Update the changelog for a pre-release
+
+There is a convinence script availabe at `.helper/changelog/create-changelog-prerelease.sh`.
+This will call the python script and carry out the actual work for you.
+
+Any parameters are passed to the python script `changelog_bilder` as located in `.helpers/changelog`.
+
+The script will only update the `CHANGELOG.md` file in the root folder of the repository.
 
 Also check if any pending API change is present.
 Update the API changelog (in `/docs/dev/api/changelog/*.md`) accordingly.
@@ -81,7 +117,7 @@ The following table shows the effect of the parameters if the last version was `
 
 It is also possible to publish a pre-release like `1.4.2-beta1` or `4.0.2-rc1`.
 The user/developer is responsible to provide a valid suffix for the pre-release.
-The created pre-release version is **not permanently stored**.
+The created pre-release version suffix/name is **not permanently stored**.
 
 The reasoning of not storing the last pre-release version is that the next regular release (of whatever version level) must not increase the major/minor/patch version multiple times.
 Also it might be required to change from a patch to minor or from minor to major level updates:

--- a/docs/dev/deployment.md
+++ b/docs/dev/deployment.md
@@ -38,6 +38,10 @@ Go to the folder `.helper/changelog` in a console.
 Create a virtual python environment valled `venv`.
 Typically this can be done by `virtualenv venv` (Linux) or `python -m venv venv` (Windows) in that folder.
 
+Also, you need a personal access token for your GitHub account to prevent API rate limit issues.
+Just create a token and put it in `.helpers/changelog/token`.
+Do not commit this file ever!
+
 #### Update the changelog for a release
 
 There is a convinence script availabe at `.helper/changelog/create-changelog-release.sh`.
@@ -48,6 +52,14 @@ You have to provie at least one option to th script:
 1. The version to create. In out example, this would be `1.2.4`.
 
 Any additional parameters are passed to the python script `changelog_bilder` as located in `.helpers/changelog`.
+
+Please note that the script expects all current snippets as parameters.
+Also, it expects a GitHub personal access token stored in a file.
+So, typically, one would call it like this:
+
+```shell
+./.helpers/changelog/create-changelog-release.sh 1.2.4 --token .helpers/changelog/token .changelog/current/*
+```
 
 The script will alter a few files in the repository:
 
@@ -67,6 +79,14 @@ There is a convinence script availabe at `.helper/changelog/create-changelog-pre
 This will call the python script and carry out the actual work for you.
 
 Any parameters are passed to the python script `changelog_bilder` as located in `.helpers/changelog`.
+
+Please note that the script expects all current snippets as parameters.
+Also, it expects a GitHub personal access token stored in a file.
+So, typically, one would call it like this:
+
+```shell
+./.helpers/changelog/create-changelog-prerelease.sh --token .helpers/changelog/token .changelog/current/*
+```
 
 The script will only update the `CHANGELOG.md` file in the root folder of the repository.
 

--- a/docs/dev/deployment.md
+++ b/docs/dev/deployment.md
@@ -32,7 +32,7 @@ The process depends if you want to create an actual new release or just a pre-re
 Both variants require that a python script is called to build the changelog from the various files.
 Please install this first.
 
-#### Installation of script (onlly once needed)
+#### Installation of script (only once needed)
 
 Go to the folder `.helper/changelog` in a console.
 Create a virtual python environment valled `venv`.
@@ -41,6 +41,13 @@ Typically this can be done by `virtualenv venv` (Linux) or `python -m venv venv`
 Also, you need a personal access token for your GitHub account to prevent API rate limit issues.
 Just create a token and put it in `.helpers/changelog/token`.
 Do not commit this file ever!
+
+#### Activate the virtual environemnt
+
+The venv has a means of enabling it.
+It depends on your shell and OS about the detailed steps.
+For example, in Bash, you have to `source .helpers/changelog/venv/bin/activate`.
+Adjust to your setup.
 
 #### Update the changelog for a release
 

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -9,6 +9,7 @@ If you want to **help contributing**, please see the [page about contributing](c
 
 ## Github related information
 
+- [Notes on the changelog mechanism](changelog)
 - [Automatic deployment of new releases](deployment)
 - [Documentation using github pages](docs)
 - [Using a committed version for testing](use-autobuild)


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Closes #2021

This will provide a way to simplify updates to the changelog. In fact the dev is only required to careate an individual file per PR.

## Concerns/issues

Some things to consider

- [x] Update the workflow script to look for the changlog snippet
- [x] Document the process for authors
- [x] Migrate the `main-0.10.x` branch
- [x] Update the deployment scripts

There is still the open question on how to handle the chronological ordering of the releases (0.10.6 can come after 0.11.0). Should this be respected in the changelog building process? How is this to be stored?

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

I did not change the code base itself, so no issues here.
