### PR TITLE
Fix deprecation of variable expansion

### DIFF
--- a/.changelog/current/2321-deprecation-warning-in-tests.md
+++ b/.changelog/current/2321-deprecation-warning-in-tests.md
@@ -1,0 +1,3 @@
+# Maintenance
+
+- Remove deprecated PHP style from test code

--- a/tests/Unit/Helper/FileSystem/RecipeNameHelperTest.php
+++ b/tests/Unit/Helper/FileSystem/RecipeNameHelperTest.php
@@ -27,12 +27,12 @@ class RecipeNameHelperFilter extends TestCase {
 
 		return [
 			'short name' => ['recipe name', 'recipe name'],
-			'95 chars' => ["${ninetyChars}12345", "${ninetyChars}12345"],
-			'99 chars' => ["${ninetyChars}123456789", "${ninetyChars}123456789"],
-			'100 chars' => ["${ninetyChars}1234567890", "${ninetyChars}1234567890"],
-			'101 chars' => ["${ninetyChars}12345678901", "${ninetyChars}1234567..."],
-			'102 chars' => ["${ninetyChars}123456789012", "${ninetyChars}1234567..."],
-			'105 chars' => ["${ninetyChars}123456789012345", "${ninetyChars}1234567..."],
+			'95 chars' => ["{$ninetyChars}12345", "{$ninetyChars}12345"],
+			'99 chars' => ["{$ninetyChars}123456789", "{$ninetyChars}123456789"],
+			'100 chars' => ["{$ninetyChars}1234567890", "{$ninetyChars}1234567890"],
+			'101 chars' => ["{$ninetyChars}12345678901", "{$ninetyChars}1234567..."],
+			'102 chars' => ["{$ninetyChars}123456789012", "{$ninetyChars}1234567..."],
+			'105 chars' => ["{$ninetyChars}123456789012345", "{$ninetyChars}1234567..."],
 			'special chars' => ['a/b:c?d!e"f|g\\h\'i^j&k#l', 'a_b_c_d_e_f_g_h_i_j_k_l'],
 		];
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

The variable expansion in the form of `"${varName}" in PHP is deprecated. Instead, one uses `"{$varName}". The tests have the old syntax and should be fixed.

## Concerns/issues

_None_

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ ] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
