### PR TITLE
Use underscores to prevent trailing dot in folder names

### DIFF
--- a/.changelog/current/2343-no-dot-at-end-of-file-name.md
+++ b/.changelog/current/2343-no-dot-at-end-of-file-name.md
@@ -1,0 +1,3 @@
+# Fixed
+
+- Prevent dot at end of file/folder name when abbreviating

--- a/lib/Helper/FileSystem/RecipeNameHelper.php
+++ b/lib/Helper/FileSystem/RecipeNameHelper.php
@@ -36,7 +36,7 @@ class RecipeNameHelper {
 		$recipeName = preg_replace($pattern, '_', $recipeName);
 
 		if (strlen($recipeName) > 100) {
-			$recipeName = substr($recipeName, 0, 97) . '...';
+			$recipeName = substr($recipeName, 0, 97) . '___';
 		}
 
 		return $recipeName;

--- a/tests/Unit/Helper/FileSystem/RecipeNameHelperTest.php
+++ b/tests/Unit/Helper/FileSystem/RecipeNameHelperTest.php
@@ -30,9 +30,9 @@ class RecipeNameHelperFilter extends TestCase {
 			'95 chars' => ["{$ninetyChars}12345", "{$ninetyChars}12345"],
 			'99 chars' => ["{$ninetyChars}123456789", "{$ninetyChars}123456789"],
 			'100 chars' => ["{$ninetyChars}1234567890", "{$ninetyChars}1234567890"],
-			'101 chars' => ["{$ninetyChars}12345678901", "{$ninetyChars}1234567..."],
-			'102 chars' => ["{$ninetyChars}123456789012", "{$ninetyChars}1234567..."],
-			'105 chars' => ["{$ninetyChars}123456789012345", "{$ninetyChars}1234567..."],
+			'101 chars' => ["{$ninetyChars}12345678901", "{$ninetyChars}1234567___"],
+			'102 chars' => ["{$ninetyChars}123456789012", "{$ninetyChars}1234567___"],
+			'105 chars' => ["{$ninetyChars}123456789012345", "{$ninetyChars}1234567___"],
 			'special chars' => ['a/b:c?d!e"f|g\\h\'i^j&k#l', 'a_b_c_d_e_f_g_h_i_j_k_l'],
 		];
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Closes #2332

## Concerns/issues

There could be name clashes if the first 97 chars of two recipes are equal.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
