### PR TITLE
Allow for UTF chars in the file name without breaking the backend

### DIFF
--- a/.changelog/current/2346-utf-file-names-allow-abbreviation.md
+++ b/.changelog/current/2346-utf-file-names-allow-abbreviation.md
@@ -1,0 +1,3 @@
+# Fixed
+
+- Fix abbreviation of long file names even with UTF chars

--- a/lib/Helper/FileSystem/RecipeNameHelper.php
+++ b/lib/Helper/FileSystem/RecipeNameHelper.php
@@ -15,6 +15,9 @@ class RecipeNameHelper {
 	/** @var LoggerInterface */
 	private $logger;
 
+	/** @var int */
+	protected const MAX_LEN = 100;
+
 	public function __construct(
 		IL10N $l,
 		LoggerInterface $logger
@@ -35,8 +38,8 @@ class RecipeNameHelper {
 		$pattern = '/[\\/:?!"\\\\\'|&^#]/';
 		$recipeName = preg_replace($pattern, '_', $recipeName);
 
-		if (strlen($recipeName) > 100) {
-			$recipeName = substr($recipeName, 0, 97) . '___';
+		if (mb_strlen($recipeName) > self::MAX_LEN) {
+			$recipeName = mb_substr($recipeName, 0, self::MAX_LEN - 3) . '___';
 		}
 
 		return $recipeName;

--- a/tests/Unit/Helper/FileSystem/RecipeNameHelperTest.php
+++ b/tests/Unit/Helper/FileSystem/RecipeNameHelperTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class RecipeNameHelperFilter extends TestCase {
+class RecipeNameHelperTest extends TestCase {
 	/** @var RecipeNameHelper */
 	private $dut;
 
@@ -34,6 +34,7 @@ class RecipeNameHelperFilter extends TestCase {
 			'102 chars' => ["{$ninetyChars}123456789012", "{$ninetyChars}1234567___"],
 			'105 chars' => ["{$ninetyChars}123456789012345", "{$ninetyChars}1234567___"],
 			'special chars' => ['a/b:c?d!e"f|g\\h\'i^j&k#l', 'a_b_c_d_e_f_g_h_i_j_k_l'],
+			'greek chars' => ["Τραγανή granola χωρίς ζάχαρη με ό,τι ξηρούς καρπούς & αποξηραμένα φρούτα έχεις στο ντουλάπι σου", "Τραγανή granola χωρίς ζάχαρη με ό,τι ξηρούς καρπούς _ αποξηραμένα φρούτα έχεις στο ντουλάπι σου"],
 		];
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Closes #2228

## Concerns/issues

None

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
