### PR TITLE
Fix bug in CI tests

### DIFF
--- a/.github/workflows/pull-checks.yml
+++ b/.github/workflows/pull-checks.yml
@@ -20,6 +20,10 @@ jobs:
             -   name: Get the diff
                 id: diff
                 run: |
+                    if [ -n "$RUNNER_DEBUG" ]
+                    then
+                    set -x
+                    fi
                     filename_prefix=".changelog/current/${{ github.event.number }}-"
                     git diff HEAD~1 --name-only -- $filename_prefix* > /tmp/changed-cl-files
                     echo "Possibly matching changelog files:"
@@ -46,6 +50,10 @@ jobs:
             -   name: Get all changed file names
                 id: file-names
                 run: |
+                    if [ -n "$RUNNER_DEBUG" ]
+                    then
+                    set -x
+                    fi
                     git diff HEAD~1 --name-only > /tmp/changed-files-in-pr
                     echo "Changed files:"
                     cat /tmp/changed-files-in-pr
@@ -63,6 +71,10 @@ jobs:
 
             -   name: Error/warn if no changelog entry was found
                 run: |
+                    if [ -n "$RUNNER_DEBUG" ]
+                    then
+                    set -x
+                    fi
                     if [ ${{ steps.file-names.outputs.num }} -gt 0 ]; then
                     echo "::error::There was no change in the changelog detected. Please fill in a valid entry into that file."
                     {
@@ -94,6 +106,10 @@ jobs:
                 run: pip install --user virtualenv pipenv
             -   name: Test creation of changelog
                 run: |
+                    if [ -n "$RUNNER_DEBUG" ]
+                    then
+                    set -x
+                    fi
                     cd .helpers/changelog
                     virtualenv venv
                     source venv/bin/activate

--- a/.github/workflows/pull-checks.yml
+++ b/.github/workflows/pull-checks.yml
@@ -24,7 +24,7 @@ jobs:
                     git diff HEAD~1 --name-only -- $filename_prefix* > /tmp/changed-cl-files
                     echo "Possibly matching changelog files:"
                     cat /tmp/changed-cl-files
-                    num_lines=$(wc -l /tmp/changed-cl-files)
+                    num_lines=$(cat /tmp/changed-cl-files | wc -l)
                     if [ "$num_lines" -gt 1 ]
                     then
                     {
@@ -41,7 +41,7 @@ jobs:
                     } > $GITHUB_STEP_SUMMARY
                     exit 1
                     fi
-                    echo "num_lines=$(wc -l /tmp/changed-cl-files)" >> $GITHUB_OUTPUT
+                    echo "num_lines=$(cat /tmp/changed-cl-files | wc -l)" >> $GITHUB_OUTPUT
             
             -   name: Get all changed file names
                 id: file-names

--- a/.github/workflows/pull-checks.yml
+++ b/.github/workflows/pull-checks.yml
@@ -86,9 +86,9 @@ jobs:
                         echo ""
                         sed 's@^@- @' /tmp/relevant-files-in-pr
                         echo ""
-                        echo "Please provide a file `.changelog/current/${{ github.event.number }}-foo` where you can set the text `foo` as you like."
+                        echo 'Please provide a file `.changelog/current/${{ github.event.number }}-foo` where you can set the text `foo` as you like.'
                         echo "A good suggestion is to summarize the PR's content and to replace any non-chars with dashes."
-                        echo "An example file name could be `.changelog/current/1234-update-nc-release-script`.
+                        echo 'An example file name could be `.changelog/current/1234-update-nc-release-script`.'
                     } > $GITHUB_STEP_SUMMARY
                     exit 1
                     else


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

The current CI implementation does not bail out due to a bug in the `wc -l` usage if no changelog was provided.

## Concerns/issues

None

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ ] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
