### PR TITLE
Update link to parser method in README.md

### DIFF
--- a/.changelog/current/2396-update-link-to-parser.md
+++ b/.changelog/current/2396-update-link-to-parser.md
@@ -1,0 +1,2 @@
+# Documentation
+- Fix link to parser method in FAQ

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ A lot of websites are unfortunately not following the schema.org/Recipe standard
 
 <details>
   <summary><b>A website using correct schema.org markup is not being read correctly</b></summary>
-The parser is far from perfect. If you can help out in any way, please [have a look at the parseRecipeHtml() method](https://github.com/nextcloud/nextcloud-cookbook/blob/master/lib/Service/RecipeService.php) and create a pull request with your changes.
+The parser is far from perfect. If you can help out in any way, please <a href="https://github.com/nextcloud/nextcloud-cookbook/blob/master/lib/Service/RecipeExtractionService.php">have a look at the parse() method</a> and create a pull request with your changes.
 </details>
 
 <details>


### PR DESCRIPTION
I recently wanted to work on the recipe parser to add support for some sites I wanted to import recipes from. When
doing so, I noticed the README.md had a very helpful link to the parser in its FAQ section, so I started by following
that; however, while the link was valid, the method referenced did no longer exist. I ended up backing out of the
file referenced in the link and looking around the nearby files, and quickly found a good place to start working on
the recipe parsing call tree.

In this PReq, I update the answer in that FAQ to point to the place I started, since the place it was referencing
previously was presumably removed in some past refactor.

<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Minor update to the README

## Concerns/issues

None

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
