### PR TITLE
Handle fractional ingredients (Fixes #2004)

### DIFF
--- a/.changelog/current/2421-fix-fraction-ingrediants.md
+++ b/.changelog/current/2421-fix-fraction-ingrediants.md
@@ -1,0 +1,4 @@
+# Fixes
+
+- Fraction calculation keeps fractions if possible
+

--- a/src/js/yieldCalculator.js
+++ b/src/js/yieldCalculator.js
@@ -63,7 +63,17 @@ function recalculateIngredients(ingredients, currentYield, originalYield) {
 
             const decimalAmount = wholeNumberPart + numerator / denominator;
             let newAmount = (decimalAmount / originalYield) * currentYield;
-            newAmount = newAmount.toFixed(2).replace(/[.]00$/, '');
+            const newWholeNumberPart = parseInt(newAmount, 10);
+            let newNumerator = (newAmount - newWholeNumberPart) * 16;
+            if (Number.isInteger(newNumerator)) {
+                const gcd = (a, b) => b ? gcd(b, a % b) : a;
+                let div = gcd(newNumerator, 16);
+                newNumerator /= div;
+                let newDenominator = 16 / div;
+                newAmount = (newWholeNumberPart ? newWholeNumberPart + ' ' : '') + newNumerator + '/' + newDenominator;
+            } else {
+                newAmount = newAmount.toFixed(2).replace(/[.]00$/, '');
+            }
 
             const newIngredient = ingredient.replace(fractionMatch, newAmount);
             return newIngredient;

--- a/src/js/yieldCalculator.js
+++ b/src/js/yieldCalculator.js
@@ -60,8 +60,8 @@ function recalculateIngredients(ingredients, currentYield, originalYield) {
             const wholeNumberPart = wholeNumberPartRaw
                 ? parseInt(wholeNumberPartRaw, 10)
                 : 0;
-            let numerator = 0,
-                denominator = 0;
+            let numerator = 0;
+            let denominator = 0;
             // Unicode fraction
             if (numeratorRaw == null) {
                 [numerator, denominator] = fractionMatch
@@ -78,11 +78,14 @@ function recalculateIngredients(ingredients, currentYield, originalYield) {
             const newWholeNumberPart = parseInt(newAmount, 10);
             let newNumerator = (newAmount - newWholeNumberPart) * 16;
             if (Number.isInteger(newNumerator)) {
-                const gcd = (a, b) => b ? gcd(b, a % b) : a;
-                let div = gcd(newNumerator, 16);
+                const gcd = (a, b) => (b ? gcd(b, a % b) : a);
+                const div = gcd(newNumerator, 16);
                 newNumerator /= div;
-                let newDenominator = 16 / div;
-                newAmount = (newWholeNumberPart ? newWholeNumberPart + ' ' : '') + newNumerator + '/' + newDenominator;
+                const newDenominator = 16 / div;
+                const prefix = newWholeNumberPart
+                    ? `${newWholeNumberPart} `
+                    : '';
+                newAmount = `${prefix}${newNumerator}/${newDenominator}`;
             } else {
                 newAmount = newAmount.toFixed(2).replace(/[.]00$/, '');
             }

--- a/src/js/yieldCalculator.js
+++ b/src/js/yieldCalculator.js
@@ -2,15 +2,16 @@
     The ingredientFractionRegExp is used to identify fractions in the string.
     This is used to exclude strings that contain fractions from being valid.
 */
-const fractionRegExp = /^((\d+\s+)?(\d+)\s*\/\s*(\d+)).*/;
+const fractionRegExp = /^((\d+\s+)?(?:\p{No}|(\d+)\s*\/\s*(\d+))).*/u;
 
 function isValidIngredientSyntax(ingredient) {
     /*
-        The ingredientSyntaxRegExp checks whether the ingredient string starts with a number,
-        possibly followed by a fractional part or a fraction. Then there should be a space
-        and then any sequence of characters.
+        The ingredientSyntaxRegExp checks whether the ingredient string starts with a fraction,
+        or a whole part and fraction, or a decimal.
+        It may optionally have a unit but must be proceeded by a single whitespace and further text.
     */
-    const ingredientSyntaxRegExp = /^(?:\d+(?:\.\d+)?(?:\/\d+)?)\s?.*$/;
+    const ingredientSyntaxRegExp =
+        /^(?:(?:\d+\s)?(?:\d+\/\d+|\p{No})|\d+(?:\.\d+)?)[a-zA-z]*\s.*$/;
 
     /*
         The ingredientMultipleSeperatorsRegExp is used to check whether the string contains
@@ -47,6 +48,7 @@ function recalculateIngredients(ingredients, currentYield, originalYield) {
 
         const matches = ingredient.match(fractionRegExp);
 
+        // Fraction
         if (matches) {
             const [
                 ,
@@ -58,8 +60,18 @@ function recalculateIngredients(ingredients, currentYield, originalYield) {
             const wholeNumberPart = wholeNumberPartRaw
                 ? parseInt(wholeNumberPartRaw, 10)
                 : 0;
-            const numerator = parseInt(numeratorRaw, 10);
-            const denominator = parseInt(denominatorRaw, 10);
+            let numerator = 0,
+                denominator = 0;
+            // Unicode fraction
+            if (numeratorRaw == null) {
+                [numerator, denominator] = fractionMatch
+                    .normalize('NFKD')
+                    .split('\u2044')
+                    .map((x) => parseInt(x, 10));
+            } else {
+                numerator = parseInt(numeratorRaw, 10);
+                denominator = parseInt(denominatorRaw, 10);
+            }
 
             const decimalAmount = wholeNumberPart + numerator / denominator;
             let newAmount = (decimalAmount / originalYield) * currentYield;
@@ -79,6 +91,7 @@ function recalculateIngredients(ingredients, currentYield, originalYield) {
             return newIngredient;
         }
 
+        // Decimal
         if (isValidIngredientSyntax(ingredient)) {
             const possibleUnit = ingredient
                 .split(' ')[0]


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

My solution to #2004. This handles 16ths, else falls back to decimal. I think this is a nice balance between using some fractions, without ending up with stupid denominators.

## Concerns/issues

Will only work if the initial ingredient is given as a fraction. If it's a decimal, or just a whole number, will still remain decimal. Maybe it would make sense to convert everything to fractions where possible, but then maybe not. Perhaps being able to change the behavior in settings would be useful, idk. Also, by design does not do 1/3, 1/5, etc. I don't mind this, in fact I would prefer this way, but I guess in the end it's not up to me.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
