### PR TITLE
Skip changelog generation if there is nothing to be viewed

### DIFF
--- a/.changelog/current/2461-fix-changelog-checker.md
+++ b/.changelog/current/2461-fix-changelog-checker.md
@@ -1,0 +1,2 @@
+# Fixed
+- Prevent failure of changlog builder when parsing dependabot PRs without explicit changelog stub

--- a/.github/workflows/pull-checks.yml
+++ b/.github/workflows/pull-checks.yml
@@ -97,8 +97,9 @@ jobs:
                         echo "### No changelog was needed"
                         echo ""
                         echo "No changelog entry was found so far."
-                        echo "This is okay, as no files have been modified that would require a changelog entry."
-                        echo "You might consider if adding a changelog entry would be benefical as significant changes have been made."
+                        echo -n "This is okay, as no files have been modified that would require a changelog entry. "
+                        echo -n "You might consider if adding a changelog entry would be benefical as significant changes have been made. "
+                        echo 'The changelog should be in a file starting with `.changelog/current/${{ github.event.number }}-`.'
                     } > $GITHUB_STEP_SUMMARY
                     fi
                 if: ${{ steps.diff.outputs.num_lines == 0 }}

--- a/.github/workflows/pull-checks.yml
+++ b/.github/workflows/pull-checks.yml
@@ -104,6 +104,7 @@ jobs:
                 if: ${{ steps.diff.outputs.num_lines == 0 }}
             -   name: Install Python package
                 run: pip install --user virtualenv pipenv
+                if: ${{ steps.diff.outputs.num_lines != 0 }}
             -   name: Test creation of changelog
                 run: |
                     if [ -n "$RUNNER_DEBUG" ]
@@ -123,6 +124,7 @@ jobs:
                         python -m changelog_builder --token token --ci --pr ${{ github.event.number }} ../../.changelog/current/* 2>&1
                         echo '```'
                     } >> $GITHUB_STEP_SUMMARY
+                if: ${{ steps.diff.outputs.num_lines != 0 }}
     
     todo-checker:
         name: Check for added todo messages


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Currently, the automerge of the dependabot fails. Dependabot does not create changelog stubs. Although this is generally okay for some files to change without explicit changelog, the generation of the GitHub step summary in the actions tab involves so far a generation of the total Changelog. This fails if there is no matching changelog present.

## Concerns/issues

Should be save to merge, as in the workflow, either the error _no changelog found_ is triggered of the python script is run.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ ] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
