### PR TITLE
chore(CI): Updating dependabot-approve-merge.yml workflow from template

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - main
       - master
+      - stable*
 
 permissions:
   contents: read


### PR DESCRIPTION
Automated update of the dependabot-approve-merge.yml workflow from https://github.com/nextcloud/.github