### PR TITLE
fix: replace --delete-delay by --delete-before to work on macos

### DIFF
--- a/.changelog/current/2540-allow-mac-automated-builds.md
+++ b/.changelog/current/2540-allow-mac-automated-builds.md
@@ -1,0 +1,4 @@
+# Maintenance
+
+- Make the automated test compatible with MacOS
+

--- a/.github/actions/run-tests/reset-from-container.sh
+++ b/.github/actions/run-tests/reset-from-container.sh
@@ -82,7 +82,7 @@ start_container() {
 restore_db_synced_data() {
 	local db_path="/db/${1}"
 	echo "Restoring synced DB data from $SF_DIR/sql to $db_path"
-	sudo rsync -a --delete --delete-delay "$SF_DIR/sql/" "$db_path"
+	sudo rsync -a --delete --delete-before "$SF_DIR/sql/" "$db_path"
 }
 
 test_mysql_is_running() {
@@ -129,7 +129,7 @@ restore_postgres_sync () {
 # exec >> /output/reset.log 2>&1
 
 echo "Cloning data files"
-rsync --archive --delete --delete-delay "$SF_DIR/data/" /var/www/html/data/
+rsync --archive --delete --delete-before "$SF_DIR/data/" /var/www/html/data/
 
 echo "Restoring DB"
 case "$INPUT_DB" in

--- a/.github/actions/run-tests/reset-from-container.sh
+++ b/.github/actions/run-tests/reset-from-container.sh
@@ -82,7 +82,7 @@ start_container() {
 restore_db_synced_data() {
 	local db_path="/db/${1}"
 	echo "Restoring synced DB data from $SF_DIR/sql to $db_path"
-	sudo rsync -a --delete --delete-before "$SF_DIR/sql/" "$db_path"
+	sudo rsync -a --delete "$SF_DIR/sql/" "$db_path"
 }
 
 test_mysql_is_running() {
@@ -129,7 +129,7 @@ restore_postgres_sync () {
 # exec >> /output/reset.log 2>&1
 
 echo "Cloning data files"
-rsync --archive --delete --delete-before "$SF_DIR/data/" /var/www/html/data/
+rsync --archive --delete "$SF_DIR/data/" /var/www/html/data/
 
 echo "Restoring DB"
 case "$INPUT_DB" in

--- a/.github/actions/run-tests/test_runner/dumps.py
+++ b/.github/actions/run-tests/test_runner/dumps.py
@@ -16,7 +16,7 @@ except ImportError:
 
 class SubFixture:
 	
-	rsyncArgs = ['--delete', '--delete-before', '--delete-excluded', '--archive']
+	rsyncArgs = ['--delete', '--delete-excluded', '--archive']
 
 	def __init__(self):
 		pass

--- a/.github/actions/run-tests/test_runner/dumps.py
+++ b/.github/actions/run-tests/test_runner/dumps.py
@@ -16,7 +16,7 @@ except ImportError:
 
 class SubFixture:
 	
-	rsyncArgs = ['--delete', '--delete-delay', '--delete-excluded', '--archive']
+	rsyncArgs = ['--delete', '--delete-before', '--delete-excluded', '--archive']
 
 	def __init__(self):
 		pass

--- a/.github/actions/run-tests/test_runner/test_env.py
+++ b/.github/actions/run-tests/test_runner/test_env.py
@@ -225,7 +225,7 @@ class Environment:
 		excludePairs = [['--exclude', x] for x in excludes]
 		excludeParams = [x for pair in excludePairs for x in pair]
 		p.pr.run(
-			['rsync', '-a', '../../../', 'volumes/cookbook', '--delete', '--delete-delay'] + excludeParams
+			['rsync', '-a', '../../../', 'volumes/cookbook', '--delete', '--delete-before'] + excludeParams
 		).check_returncode()
 
 		l.logger.printTask('Making appinfo file')

--- a/.github/actions/run-tests/test_runner/test_env.py
+++ b/.github/actions/run-tests/test_runner/test_env.py
@@ -225,7 +225,7 @@ class Environment:
 		excludePairs = [['--exclude', x] for x in excludes]
 		excludeParams = [x for pair in excludePairs for x in pair]
 		p.pr.run(
-			['rsync', '-a', '../../../', 'volumes/cookbook', '--delete', '--delete-before'] + excludeParams
+			['rsync', '-a', '../../../', 'volumes/cookbook', '--delete'] + excludeParams
 		).check_returncode()
 
 		l.logger.printTask('Making appinfo file')

--- a/.github/actions/run-tests/tests/entrypoints/test.sh
+++ b/.github/actions/run-tests/tests/entrypoints/test.sh
@@ -59,7 +59,7 @@ export QUICK_MODE
 printCI "::group::Test prepatation in container"
 
 echo "Synchronizing cookbook codebase"
-rsync -a /cookbook/ custom_apps/cookbook/ --delete --delete-before --delete-excluded --exclude /.git --exclude /.github/actions/run-tests/volumes --exclude /docs --exclude /node_modules/
+rsync -a /cookbook/ custom_apps/cookbook/ --delete --delete-excluded --exclude /.git --exclude /.github/actions/run-tests/volumes --exclude /docs --exclude /node_modules/
 
 pushd custom_apps/cookbook
 

--- a/.github/actions/run-tests/tests/entrypoints/test.sh
+++ b/.github/actions/run-tests/tests/entrypoints/test.sh
@@ -59,7 +59,7 @@ export QUICK_MODE
 printCI "::group::Test prepatation in container"
 
 echo "Synchronizing cookbook codebase"
-rsync -a /cookbook/ custom_apps/cookbook/ --delete --delete-delay --delete-excluded --exclude /.git --exclude /.github/actions/run-tests/volumes --exclude /docs --exclude /node_modules/
+rsync -a /cookbook/ custom_apps/cookbook/ --delete --delete-before --delete-excluded --exclude /.git --exclude /.github/actions/run-tests/volumes --exclude /docs --exclude /node_modules/
 
 pushd custom_apps/cookbook
 


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

This PR fixes #2441. It replaces the `--delete-delay` of rsync by `--delete-before`, because `--delete-delay` isn't implemented in rsync on macOS.

## Concerns/issues

The flag `--delete-before` deletes removed files before copying the changed files. In this scenario the change of this flag shouldn't make any difference.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
