### PR TITLE
fix: links to Cookbook Client

### DIFF
--- a/.changelog/current/2547-update-client-list.md
+++ b/.changelog/current/2547-update-client-list.md
@@ -1,0 +1,4 @@
+# Documentation
+
+- Fix link to client in the GitHub pages documentation
+

--- a/docs/user/clients/Index.md
+++ b/docs/user/clients/Index.md
@@ -10,7 +10,7 @@ The currently available clients are in no particular order:
 | [Nextcloud Cookbook][micmun-nextcloud-cookbook]      | [MicMun][micmun]     | [<img src="img/f-droid.png" alt="Get it on F-Droid" height="50">][micmun-nextcloud-cookbook-fdroid] [<img src="img/g-play.png" alt="Get it on Google Play" height="50">][micmun-nextcloud-cookbook-play-store]                                                                                                                         |
 | [Nextcloud Cookbook][teifun2-nextcloud-cookbook]     | [Teifun2][teifun2]   | [<img src="img/f-droid.png" alt="Get it on F-Droid" height="50">][teifun2-nextcloud-cookbook-fdroid] [<img src="img/g-play.png" alt="Get it on Google Play" height="50">][teifun2-nextcloud-cookbook-play-store] [<img src="img/ios-store.svg" alt="Download on the App Store" height="35">][teifun2-nextcloud-cookbook-ios-app-store] |
 | [Nextcloud Cookbook][lneugebauer-nextcloud-cookbook] | [lneugebauer][]      | [<img src="img/f-droid.png" alt="Get it on F-Droid" height="50">][lneugebauer-nextcloud-cookbook-fdroid] [<img src="img/g-play.png" alt="Get it on Google Play" height="50">][lneugebauer-nextcloud-cookbook-play-store]                                                                                                               |
-| [Cookbook Client][teifun2-nextcloud-cookbook]        | [VincentMeilinger][] | [<img src="img/ios-store.svg" alt="Download on the App Store" height="35">][teifun2-nextcloud-cookbook-ios-app-store]                                                                                                                                                                                                                  |
+| [Cookbook Client][VincentMeilinger-nextcloud-cookbook] | [VincentMeilinger][] | [<img src="img/ios-store.svg" alt="Download on the App Store" height="35">][VincentMeilinger-nextcloud-cookbook-ios-app-store] |
 
 
 <!-- References -->
@@ -36,7 +36,8 @@ The currently available clients are in no particular order:
 
 <!-- VincentMeilinger -->
 [VincentMeilinger]: <https://github.com/VincentMeilinger>
-[teifun2-nextcloud-cookbook-ios-app-store]: <https://apps.apple.com/de/app/cookbook-client/id6467141985> (Nextcloud Cookbook iOS App Store)
+[VincentMeilinger-nextcloud-cookbook]: <https://github.com/VincentMeilinger/Nextcloud-Cookbook-iOS> (Nextcloud CookbookiOS)
+[VincentMeilinger-nextcloud-cookbook-ios-app-store]: <https://apps.apple.com/de/app/cookbook-client/id6467141985> (Nextcloud Cookbook iOS App Store)
 
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Adds the correct links to the Cookbook Client in the docs

## Concerns/issues

_Is the PR potentially cause any issues that might be of interest? Any other issues to be tought of?_

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ ] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
