### PR TITLE
Allow use of browserless server

### DIFF
--- a/lib/Controller/Implementation/ConfigImplementation.php
+++ b/lib/Controller/Implementation/ConfigImplementation.php
@@ -32,6 +32,7 @@ class ConfigImplementation {
 	}
 
 	protected const KEY_VISIBLE_INFO_BLOCKS = 'visibleInfoBlocks';
+    protected const KEY_BROWSERLESS_ADDRESS = 'browserless_address';
 
 	/**
 	 * Get the current configuration of the app
@@ -46,6 +47,7 @@ class ConfigImplementation {
 			'update_interval' => $this->dbCacheService->getSearchIndexUpdateInterval(),
 			'print_image' => $this->service->getPrintImage(),
 			self::KEY_VISIBLE_INFO_BLOCKS => $this->service->getVisibleInfoBlocks(),
+            self::KEY_BROWSERLESS_ADDRESS => $this->service->getBrowserlessAddress(),
 		], Http::STATUS_OK);
 	}
 
@@ -74,6 +76,10 @@ class ConfigImplementation {
 		if (isset($data['print_image'])) {
 			$this->service->setPrintImage((bool)$data['print_image']);
 		}
+
+        if (isset($data['browserlessAddress'])) {
+            $this->service->setBrowserlessAddress($data['browserlessAddress']);
+        }
 
 		if (isset($data[self::KEY_VISIBLE_INFO_BLOCKS])) {
 			$this->service->setVisibleInfoBlocks($data[self::KEY_VISIBLE_INFO_BLOCKS]);

--- a/lib/Helper/Filter/JSON/RecipeIdTypeFilter.php
+++ b/lib/Helper/Filter/JSON/RecipeIdTypeFilter.php
@@ -8,11 +8,15 @@ namespace OCA\Cookbook\Helper\Filter\JSON;
  * The id should be a string and no integer.
  */
 class RecipeIdTypeFilter extends AbstractJSONFilter {
-	public function apply(array &$json): bool {
-		$copy = $json;
-		if (array_key_exists('id', $json)) {
-			$json['id'] = strval($json['id']);
-		}
+    public function apply(array &$json): bool {
+        $copy = $json;
+        if (array_key_exists('id', $json)) {
+            $json['id'] = strval($json['id']);
+        }
+        // Check and fix `id` under `author`
+        if (array_key_exists('author', $json) && is_array($json['author']) && array_key_exists('id', $json['author'])) {
+            $json['id'] = strval($json['author']['id']);
+        }
 
 		return $json !== $copy;
 	}

--- a/lib/Helper/UserConfigHelper.php
+++ b/lib/Helper/UserConfigHelper.php
@@ -41,6 +41,7 @@ class UserConfigHelper {
 	protected const KEY_PRINT_IMAGE = 'print_image';
 	protected const KEY_VISIBLE_INFO_BLOCKS = 'visible_info_blocks';
 	protected const KEY_FOLDER = 'folder';
+    protected const KEY_BROWSERLESS_ADDRESS = 'browserless_address';
 
 	/**
 	 * Checks if the user is logged in and the configuration can be obtained at all
@@ -155,6 +156,27 @@ class UserConfigHelper {
 			$this->setRawValue(self::KEY_PRINT_IMAGE, '0');
 		}
 	}
+    /**
+     * Gets the browserless address from the configuration
+     *
+     * @return string The browserless address
+     * @throws UserNotLoggedInException if no user is logged in
+     */
+    public function getBrowserlessAddress(): string {
+        $rawValue = $this->getRawValue(self::KEY_BROWSERLESS_ADDRESS);
+
+        return $rawValue;
+    }
+
+    /**
+     * Sets the browserless address in the configuration
+     *
+     * @param string $address The browserless address to store
+     * @throws UserNotLoggedInException if no user is logged in
+     */
+    public function setBrowserlessAddress(string $address): void {
+        $this->setRawValue(self::KEY_BROWSERLESS_ADDRESS, $address);
+    }
 
 	/**
 	 * Determines which info blocks are displayed next to the recipe

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -564,6 +564,14 @@ class RecipeService {
 		return $this->userConfigHelper->getVisibleInfoBlocks();
 	}
 
+	public function getBrowserlessAddress() {
+		return $this->userConfigHelper->getBrowserlessAddress(); // Default to an empty string if not set
+	}
+
+	public function setBrowserlessAddress(string $address) {
+		$this->userConfigHelper->setBrowserlessAddress($address);
+	}
+
 	/**
 	 * Get recipe file contents as an array
 	 *

--- a/src/components/Modals/SettingsDialog.vue
+++ b/src/components/Modals/SettingsDialog.vue
@@ -47,6 +47,25 @@
             </fieldset>
         </NcAppSettingsSection>
         <NcAppSettingsSection
+            id="settings-browserless-address"
+            :name="t('cookbook', 'Browserless Address')"
+            class="app-settings-section"
+        >
+            <fieldset>
+                <ul>
+                    <li>
+                        <label class="settings-input">{{ t('cookbook', 'Browserless Address') }}</label>
+                        <input
+                            type="text"
+                            v-model="browserlessAddress"
+                            class="input settings-input"
+                            :placeholder="t('cookbook', 'Enter Browserless address (e.g., http://localhost:3000)')"
+                        />
+                    </li>
+                </ul>
+            </fieldset>
+        </NcAppSettingsSection>
+        <NcAppSettingsSection
             id="settings-recipe-display"
             :name="t('cookbook', 'Recipe display settings')"
             class="app-settings-section"
@@ -258,6 +277,10 @@ const visibleInfoBlocks = ref([...INFO_BLOCK_KEYS]);
  * @type {import('vue').Ref<boolean>}
  */
 const writeChanges = ref(true);
+/**
+ * @type {import('vue').Ref<string>}
+ */
+const browserlessAddress = ref('');
 
 // Watchers
 watch(
@@ -383,6 +406,23 @@ const pickRecipeFolder = () => {
             );
         });
 };
+watch(
+    () => browserlessAddress.value,
+    async (newVal, oldVal) => {
+        if (!writeChanges.value) {
+            return;
+        }
+        try {
+            await api.config.browserlessAddress.update(newVal);
+            await store.dispatch('refreshConfig');
+        } catch {
+            await showSimpleAlertModal(
+                t('cookbook', 'Could not save Browserless address'),
+            );
+            browserlessAddress.value = oldVal; // Revert if save fails
+        }
+    }
+);
 
 /**
  * Reindex all recipes
@@ -434,6 +474,7 @@ const handleShowSettings = () => {
     showFiltersInRecipeList.value =
         store.state.localSettings.showFiltersInRecipeList;
     updateInterval.value = config.update_interval;
+    browserlessAddress.value = config.browserlessAddress;
     recipeFolder.value = config.folder;
 
     nextTick(() => {

--- a/src/js/api-interface.js
+++ b/src/js/api-interface.js
@@ -112,6 +112,10 @@ function reindex() {
     return instance.post(`${baseUrl}/reindex`);
 }
 
+function updateBrowserlessAddress(newAddress) {
+    return instance.post(`${baseUrl}/config`, { browserlessAddress: newAddress });
+}
+
 export default {
     recipes: {
         create: createNewRecipe,
@@ -145,6 +149,9 @@ export default {
         },
         visibleInfoBlocks: {
             update: updateVisibleInfoBlocks,
+        },
+        browserlessAddress: {
+            update: updateBrowserlessAddress,
         },
     },
 };


### PR DESCRIPTION

## Topic and Scope

I wanted to import recipes from gousto.co.uk however they require JavaScript to load the schema json. To achieve this I added a setting for the browserless address and adjusted the HTML download so that if the setting is set it will proxy the html download via browserless. https://github.com/browserless/browserless#hosting-providers

Open to making this more general allowing other services to be used. Browserless seemed the simplest tool currently.   

## Concerns/issues

There is an issue where the browserless address field in the settings page does not populate, I've reached the end of my vue and php skills I'm sure it's something simple. Feel free to make as many changes as you like my php skill is not great.  

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ X] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ X] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ -] I notified the matrix channel if I introduced an API change
