### PR TITLE
Fix default recipe image fallback to be a valid value: "full"

### DIFF
--- a/.changelog/current/2661-fix-api-behavior.md
+++ b/.changelog/current/2661-fix-api-behavior.md
@@ -1,0 +1,3 @@
+# Fixed
+
+- Default to full image size if no size is explicitly requestes (as specified in API spec)

--- a/lib/Controller/Implementation/RecipeImplementation.php
+++ b/lib/Controller/Implementation/RecipeImplementation.php
@@ -247,10 +247,8 @@ class RecipeImplementation {
 		$acceptHeader = $this->request->getHeader('Accept');
 		$acceptedExtensions = $this->acceptHeaderParser->parseHeader($acceptHeader);
 
-		$size = isset($_GET['size']) ? $_GET['size'] : null;
-
 		try {
-			$file = $this->service->getRecipeImageFileByFolderId($id, $size);
+			$file = $this->service->getRecipeImageFileByFolderId($id, $_GET['size'] ?? 'full');
 
 			return new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'image/jpeg', 'Cache-Control' => 'public, max-age=604800']);
 		} catch (\Exception $e) {

--- a/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
+++ b/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
@@ -595,7 +595,7 @@ class RecipeImplementationTest extends TestCase {
 	 * @param mixed $setSize
 	 * @param mixed $size
 	 */
-	public function testImage($setSize, $size): void {
+	public function testImage($setSize, $size, $sizeToQuery): void {
 		$this->ensureCacheCheckTriggered();
 
 		if ($setSize) {
@@ -605,7 +605,7 @@ class RecipeImplementationTest extends TestCase {
 		/** @var File|Stub */
 		$file = $this->createStub(File::class);
 		$id = 123;
-		$this->recipeService->method('getRecipeImageFileByFolderId')->with($id, $size)->willReturn($file);
+		$this->recipeService->method('getRecipeImageFileByFolderId')->with($id, $sizeToQuery)->willReturn($file);
 
 		// Make the tests stable against PHP deprecation warnings
 		$file->method('getMTime')->willReturn(100);
@@ -635,9 +635,10 @@ class RecipeImplementationTest extends TestCase {
 
 	public function dataProviderImage(): array {
 		return [
-			[false, null],
-			[true, null],
-			[true, 'full'],
+			[false, null, 'full'],
+			[true, null, 'full'],
+			[true, 'full', 'full'],
+			[true, 'small', 'small'],
 		];
 	}
 

--- a/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
+++ b/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
@@ -594,6 +594,7 @@ class RecipeImplementationTest extends TestCase {
 	 * @todo Avoid business code in controller
 	 * @param mixed $setSize
 	 * @param mixed $size
+	 * @param mixed $sizeToQuery
 	 */
 	public function testImage($setSize, $size, $sizeToQuery): void {
 		$this->ensureCacheCheckTriggered();


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Fixes issue [https://github.com/nextcloud/cookbook/issues/1453](https://github.com/nextcloud/cookbook/issues/1453) and allows the image endpoint to default to returning the full image if no `size` param is specified.

## Concerns/issues

Alternatively the `thumb` size could be used if it's preferred to default to that instead of `full`.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change