### PR TITLE
fix americas test kitchen import "tool" prop parsing

### DIFF
--- a/lib/Helper/Filter/JSON/FixToolsFilter.php
+++ b/lib/Helper/Filter/JSON/FixToolsFilter.php
@@ -55,12 +55,7 @@ class FixToolsFilter extends AbstractJSONFilter {
 				$tools[] = $t;
 			}
 		} else {
-			$tools = array_map(function ($t) {
-				$t = trim($t);
-				$t = $this->textCleaner->cleanUp($t, false);
-
-				return $t;
-			}, $json[self::TOOLS]);
+            $tools = $this->processArrayRecursively($json[self::TOOLS]);
 			$tools = array_filter($tools, fn ($t) => ($t));
 			ksort($tools);
 			$tools = array_values($tools);
@@ -71,4 +66,17 @@ class FixToolsFilter extends AbstractJSONFilter {
 
 		return $changed;
 	}
+
+    private function processArrayRecursively($array) {
+        return array_map(function ($item) {
+            if (is_array($item)) {
+                return $this->processArrayRecursively($item);
+            } else {
+                $item = trim($item);
+                $item = $this->textCleaner->cleanUp($item, false);
+                return $item;
+            }
+        }, $array);
+    }
+
 }

--- a/src/js/helper.js
+++ b/src/js/helper.js
@@ -81,6 +81,9 @@ function isSameItemInstance(url1, url2) {
  */
 
 function escapeHTML(text) {
+		if (typeof text !== 'string') {
+        return text;
+    }
     return text.replace(
         /["&'<>]/g,
         (a) =>


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Fix [2523](https://github.com/nextcloud/cookbook/issues/2523) - allow recipes to imported from americastestkitchen.com.

## Concerns/issues

Some additional improvements may also be helpful on the frontend in order to display the `tool` prop when it's an array.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
