### PR TITLE
feat(RecipeView): Acquire screen wake lock

### DIFF
--- a/.changelog/current/2828-wakelock.md
+++ b/.changelog/current/2828-wakelock.md
@@ -1,0 +1,3 @@
+# Added
+
+- Keep the display on while viewing a recipe

--- a/src/components/AppMain.vue
+++ b/src/components/AppMain.vue
@@ -145,7 +145,7 @@ export default {
         display: block !important;
         overflow: visible !important;
         padding: 0 !important;
-        margin-left: 0 !important;
+        margin-inline-start: 0 !important;
     }
 
     #app-navigation-vue {

--- a/src/components/FormComponents/EditImageField.vue
+++ b/src/components/FormComponents/EditImageField.vue
@@ -94,8 +94,8 @@ fieldset > label {
 
 .input-container > input {
     flex: 1;
-    border-right: 0;
     border-bottom-right-radius: 0;
+    border-inline-end: 0;
     border-top-right-radius: 0;
 }
 

--- a/src/components/FormComponents/EditInputGroup.vue
+++ b/src/components/FormComponents/EditInputGroup.vue
@@ -449,15 +449,15 @@ fieldset > ul {
 fieldset > ul + button {
     width: 36px;
     padding: 0;
-    float: right;
+    float: inline-end;
     text-align: center;
 }
 
 fieldset > ul > li {
     display: flex;
     width: 100%;
-    padding-right: 0.25em;
     margin: 0 0 1em;
+    padding-inline-end: 0.25em;
 }
 
 .text > input {
@@ -476,19 +476,19 @@ li .controls > button {
     height: 34px;
     padding: 0;
     border-radius: 0;
-    border-right-color: transparent;
-    border-left-color: transparent;
     margin: 0;
+    border-inline-end-color: transparent;
+    border-inline-start-color: transparent;
 }
 
 li .controls > button:last-child {
-    border-right-width: 1px;
     border-bottom-right-radius: var(--border-radius);
+    border-inline-end-width: 1px;
     border-top-right-radius: var(--border-radius);
 }
 
 li .controls > button:last-child:not(:hover):not(:focus) {
-    border-right-color: var(--color-border-dark);
+    border-inline-end-color: var(--color-border-dark);
 }
 
 /*noinspection CssUnusedSymbol*/
@@ -496,7 +496,7 @@ li .controls > button:last-child:not(:hover):not(:focus) {
     position: relative;
     z-index: 1;
     top: 1px;
-    float: right;
+    float: inline-end;
 }
 
 .textarea > textarea {
@@ -517,7 +517,6 @@ li .controls > button:last-child:not(:hover):not(:focus) {
 .step-number {
     position: absolute;
     top: 0;
-    left: 0;
     width: 36px;
     height: 36px;
     border: 1px solid var(--color-border-dark);
@@ -525,6 +524,7 @@ li .controls > button:last-child:not(:hover):not(:focus) {
     background-color: var(--color-background-dark);
     background-position: center;
     background-repeat: no-repeat;
+    inset-inline-start: 0;
     line-height: 36px;
     outline: none;
     text-align: center;

--- a/src/components/FormComponents/EditMultiselect.vue
+++ b/src/components/FormComponents/EditMultiselect.vue
@@ -36,7 +36,7 @@ fieldset {
 
 fieldset > * {
     margin: 0;
-    float: left;
+    float: inline-start;
 }
 @media (max-width: 1199px) {
     fieldset > label {

--- a/src/components/FormComponents/EditMultiselectInputGroup.vue
+++ b/src/components/FormComponents/EditMultiselectInputGroup.vue
@@ -219,7 +219,7 @@ export default {
 
 <style scoped>
 .ml-2 {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
 }
 
 fieldset {
@@ -229,7 +229,7 @@ fieldset {
 
 fieldset > * {
     margin: 0;
-    float: left;
+    float: inline-start;
 }
 @media (max-width: 1199px) {
     fieldset > label {
@@ -258,7 +258,7 @@ fieldset > ul > li {
 }
 
 fieldset > ul > li > .key {
-    margin-right: 1em;
+    margin-inline-end: 1em;
 }
 
 fieldset > ul > li > input.val {

--- a/src/components/FormComponents/EditTimeField.vue
+++ b/src/components/FormComponents/EditTimeField.vue
@@ -110,7 +110,7 @@ fieldset {
 
 fieldset > * {
     margin: 0;
-    float: left;
+    float: inline-start;
 }
 
 fieldset > label {

--- a/src/components/List/RecipeCard.vue
+++ b/src/components/List/RecipeCard.vue
@@ -93,7 +93,7 @@ export default {
     height: 105px;
     border-radius: 3px 0 0 3px;
     background-color: #bebdbd;
-    float: left;
+    float: inline-start;
 }
 
 .recipe-card span {

--- a/src/components/List/RecipeFilterControlsModal.vue
+++ b/src/components/List/RecipeFilterControlsModal.vue
@@ -275,7 +275,7 @@ function submitFilters() {
 }
 
 .mr-2 {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
 }
 
 .mt-4 {
@@ -328,8 +328,8 @@ function submitFilters() {
     padding: 16px;
 
     .title {
-        padding-right: 30px;
         margin-bottom: 1rem;
+        padding-inline-end: 30px;
     }
 
     .option {

--- a/src/components/List/RecipeList.vue
+++ b/src/components/List/RecipeList.vue
@@ -302,7 +302,7 @@ export default {
 
 <style scoped>
 .mr-4 {
-    margin-right: 1rem;
+    margin-inline-end: 1rem;
 }
 
 .pt-2 {

--- a/src/components/Modals/SuggestionsPopup.vue
+++ b/src/components/Modals/SuggestionsPopup.vue
@@ -158,8 +158,8 @@ export default {
 
 @media (max-width: 400px) {
     .suggestions-popup {
-        left: 0 !important;
         width: 100% !important;
+        inset-inline-start: 0 !important;
     }
 }
 </style>

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -845,11 +845,11 @@ export default {
     position: absolute;
     z-index: 1000;
     top: 0;
-    left: 0;
     display: block;
     width: 100%;
     height: 100%;
     background-color: var(--color-main-background);
+    inset-inline-start: 0;
     opacity: 0.75;
 }
 

--- a/src/components/RecipeKeyword.vue
+++ b/src/components/RecipeKeyword.vue
@@ -47,17 +47,17 @@ li {
     padding: 0 0.5em;
     border: 1px solid var(--color-border-dark);
     border-radius: var(--border-radius-pill);
-    margin-right: 0.3em;
     margin-bottom: 0.3em;
+    margin-inline-end: 0.3em;
 
     /* prevent text selection - doesn't look good */
     user-select: none; /* Standard */
 }
 
 li .count {
-    margin-left: 0.35em;
     color: var(--color-text-light);
     font-size: 0.8em;
+    margin-inline-start: 0.35em;
 }
 
 .active li {

--- a/src/components/RecipeView/RecipeIngredient.vue
+++ b/src/components/RecipeView/RecipeIngredient.vue
@@ -84,12 +84,12 @@ li {
 
 li > .ingredient {
     display: inline;
-    padding-left: 1em;
+    padding-inline-start: 1em;
     text-indent: -1em;
 }
 
 li > span.icon-error {
-    margin-left: 0.3em;
+    margin-inline-start: 0.3em;
 }
 
 @media print {

--- a/src/components/RecipeView/RecipeInstruction.vue
+++ b/src/components/RecipeView/RecipeInstruction.vue
@@ -35,18 +35,17 @@ export default {
 <style scoped>
 li {
     position: relative;
-    padding-left: calc(36px + 1rem);
     margin-bottom: 2rem;
     clear: both;
     counter-increment: instruction-counter;
     cursor: pointer;
+    padding-inline-start: calc(36px + 1rem);
     white-space: pre-line;
 }
 
 li::before {
     position: absolute;
     top: 0;
-    left: 0;
     width: 36px;
     height: 36px;
     border: 1px solid var(--color-border-dark);
@@ -55,6 +54,7 @@ li::before {
     background-position: center;
     background-repeat: no-repeat;
     content: counter(instruction-counter);
+    inset-inline-start: 0;
     line-height: 36px;
     outline: none;
     text-align: center;
@@ -89,7 +89,7 @@ li input[type='checkbox'] {
 
 .markdown-instruction:deep(ol > li),
 .markdown-instruction:deep(ul > li) {
-    margin-left: 20px;
+    margin-inline-start: 20px;
 }
 
 .markdown-instruction:deep(a) {

--- a/src/components/RecipeView/RecipeNutritionInfoItem.vue
+++ b/src/components/RecipeView/RecipeNutritionInfoItem.vue
@@ -31,7 +31,7 @@ export default {
 <style scoped>
 li {
     margin-bottom: 0.5em;
-    margin-left: 1.25em;
+    margin-inline-start: 1.25em;
 }
 
 li .title {

--- a/src/components/RecipeView/RecipeTimer.vue
+++ b/src/components/RecipeView/RecipeTimer.vue
@@ -260,9 +260,9 @@ export default {
 .time button {
     position: absolute;
     top: 0;
-    left: 0;
     width: 36px;
     height: 36px;
+    inset-inline-start: 0;
     transform: translate(-50%, -50%);
 }
 

--- a/src/components/RecipeView/RecipeTool.vue
+++ b/src/components/RecipeView/RecipeTool.vue
@@ -21,7 +21,7 @@ export default {
 
 <style scoped>
 li {
-    margin-left: 1.25em;
+    margin-inline-start: 1.25em;
 }
 
 .markdown-tool:deep(a) {

--- a/src/components/RecipeView/RecipeView.vue
+++ b/src/components/RecipeView/RecipeView.vue
@@ -816,7 +816,7 @@ onMounted(() => {
         setup();
     });
 
-    if('wakeLock' in navigator) {
+    if ('wakeLock' in navigator) {
         navigator.wakeLock.request().then((sentinel) => {
             wakeLockSentinel = sentinel;
         });
@@ -905,14 +905,14 @@ export default {
 }
 
 .date {
-    margin-right: 1.5em;
+    margin-inline-end: 1.5em;
 }
 
 .date-icon {
     display: inline-block;
-    margin-right: 0.2em;
     margin-bottom: 0.2em;
     background-size: 1em;
+    margin-inline-end: 0.2em;
     vertical-align: middle;
 }
 
@@ -921,7 +921,7 @@ export default {
 }
 
 .copy-ingredients {
-    float: right;
+    float: inline-end;
 }
 
 .ingredient-highlighted {
@@ -977,9 +977,9 @@ export default {
 .times .time button {
     position: absolute;
     top: 0;
-    left: 0;
     width: 36px;
     height: 36px;
+    inset-inline-start: 0;
     transform: translate(-50%, -50%);
 }
 
@@ -1012,12 +1012,12 @@ section::after {
 
 aside {
     flex-basis: 20rem;
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
 }
 
 .content aside {
     width: 30%;
-    float: left;
+    float: inline-start;
 }
 @media screen and (max-width: 1199px) {
     .content aside {
@@ -1032,8 +1032,8 @@ aside ul {
 
 aside ul li {
     margin-bottom: 0.75ex;
-    margin-left: 1em;
     line-height: 2.5ex;
+    margin-inline-start: 1em;
 }
 
 aside ul li span,
@@ -1057,7 +1057,7 @@ aside ul li input[type='checkbox'] {
 
 .markdown-description :deep(ol > li),
 .markdown-description :deep(ul > li) {
-    margin-left: 20px;
+    margin-inline-start: 20px;
 }
 
 .markdown-description :deep(a) {
@@ -1071,7 +1071,7 @@ aside ul li input[type='checkbox'] {
 main {
     width: 70%;
     flex-basis: calc(100% - 22rem);
-    float: left;
+    float: inline-start;
     text-align: justify;
 }
 
@@ -1112,7 +1112,7 @@ main {
     background-position: center;
     background-repeat: no-repeat;
     content: counter(instruction-counter);
-    float: left;
+    float: inline-start;
     line-height: 36px;
     outline: none;
     text-align: center;

--- a/src/components/RecipeView/RecipeView.vue
+++ b/src/components/RecipeView/RecipeView.vue
@@ -816,9 +816,13 @@ onMounted(() => {
         setup();
     });
 
-    navigator.wakeLock.request().then((sentinel) => {
-        wakeLockSentinel = sentinel;
-    });
+    if('wakeLock' in navigator) {
+        navigator.wakeLock.request().then((sentinel) => {
+            wakeLockSentinel = sentinel;
+        });
+    } else {
+        log.info('WakeLock API is not supported');
+    }
 });
 
 onUnmounted(() => {

--- a/src/components/RecipeView/RecipeView.vue
+++ b/src/components/RecipeView/RecipeView.vue
@@ -349,7 +349,14 @@
 </template>
 
 <script setup>
-import { computed, getCurrentInstance, onMounted, ref, watch } from 'vue';
+import {
+    computed,
+    getCurrentInstance,
+    onMounted,
+    onUnmounted,
+    ref,
+    watch,
+} from 'vue';
 import {
     onBeforeRouteUpdate,
     useRoute,
@@ -410,6 +417,8 @@ const parsedTools = ref([]);
  * @type {import('vue').Ref<number>}
  */
 const recipeYield = ref(0);
+
+let wakeLockSentinel = null;
 
 // ===================
 // Computed properties
@@ -806,6 +815,18 @@ onMounted(() => {
     emitter.on('reloadRecipeView', () => {
         setup();
     });
+
+    navigator.wakeLock.request().then((sentinel) => {
+        wakeLockSentinel = sentinel;
+    });
+});
+
+onUnmounted(() => {
+    if (wakeLockSentinel !== null) {
+        wakeLockSentinel.release().then(() => {
+            wakeLockSentinel = null;
+        });
+    }
 });
 </script>
 


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

Closes https://github.com/nextcloud/cookbook/issues/2826

While viewing a recipe the screen of the device will no longer lock automatically, making it easier to follow a recipe while cooking in parallel.

## Concerns/issues

None that I can think of.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
