### PR TITLE
feat: add suitableForDiet field from schema.org RestrictedDiet vocabulary

### DIFF
--- a/lib/Helper/Filter/JSON/FixSuitableForDietFilter.php
+++ b/lib/Helper/Filter/JSON/FixSuitableForDietFilter.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace OCA\Cookbook\Helper\Filter\JSON;
+
+use OCA\Cookbook\Helper\TextCleanupHelper;
+use OCP\IL10N;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Fix the suitableForDiet field of a recipe.
+ *
+ * suitableForDiet is a schema.org RestrictedDiet property on the Recipe type.
+ * It is stored as a comma-separated list of diet identifiers (e.g. "VeganDiet,VegetarianDiet").
+ *
+ * If the field is absent, it is initialised to an empty string.
+ * If it is an array (as produced by some scrapers), it is merged into a comma-separated string.
+ * Individual entries are trimmed and deduplicated; empty entries are discarded.
+ *
+ * @see https://schema.org/suitableForDiet
+ * @see https://schema.org/RestrictedDiet
+ */
+class FixSuitableForDietFilter extends AbstractJSONFilter {
+	private const SUITABLE_FOR_DIET = 'suitableForDiet';
+
+	/** @var IL10N */
+	private $l;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	/** @var TextCleanupHelper */
+	private $textCleaner;
+
+	public function __construct(IL10N $l, LoggerInterface $logger, TextCleanupHelper $textCleanupHelper) {
+		$this->l = $l;
+		$this->logger = $logger;
+		$this->textCleaner = $textCleanupHelper;
+	}
+
+	#[\Override]
+	public function apply(array &$json): bool {
+		if (!isset($json[self::SUITABLE_FOR_DIET])) {
+			$json[self::SUITABLE_FOR_DIET] = '';
+			return true;
+		}
+
+		if (!is_string($json[self::SUITABLE_FOR_DIET]) && !is_array($json[self::SUITABLE_FOR_DIET])) {
+			$this->logger->info($this->l->t('Could not parse suitableForDiet for recipe {recipe}.', ['recipe' => $json['name']]));
+			$json[self::SUITABLE_FOR_DIET] = '';
+			return true;
+		}
+
+		if (is_string($json[self::SUITABLE_FOR_DIET])) {
+			$diets = explode(',', $json[self::SUITABLE_FOR_DIET]);
+		} else {
+			$diets = $json[self::SUITABLE_FOR_DIET];
+		}
+
+		$textCleaner = $this->textCleaner;
+
+		$diets = array_map(function ($diet) use ($textCleaner) {
+			$diet = strip_tags($diet);
+			$diet = trim($diet);
+			$diet = preg_replace('/\s+/', ' ', $diet);
+			$diet = $textCleaner->cleanUp($diet);
+			return $diet;
+		}, $diets);
+
+		$diets = array_filter($diets, fn ($d) => ($d !== ''));
+		$diets = array_unique($diets);
+
+		$csd = implode(',', $diets);
+		$changed = ($csd !== $json[self::SUITABLE_FOR_DIET]);
+		$json[self::SUITABLE_FOR_DIET] = $csd;
+
+		return $changed;
+	}
+}

--- a/lib/Helper/Filter/JSON/JSONFilter.php
+++ b/lib/Helper/Filter/JSON/JSONFilter.php
@@ -23,6 +23,7 @@ class JSONFilter {
 		FixUrlFilter $fixUrlFilter,
 		FixDurationsFilter $fixDurationsFilter,
 		FixNutritionFilter $fixNutritionFilter,
+		FixSuitableForDietFilter $fixSuitableForDietFilter,
 	) {
 		$this->filters = [
 			$schemaConformityFilter,
@@ -40,7 +41,8 @@ class JSONFilter {
 			$fixDescriptionFilter,
 			$fixUrlFilter,
 			$fixDurationsFilter,
-			$fixNutritionFilter
+			$fixNutritionFilter,
+			$fixSuitableForDietFilter,
 		];
 	}
 

--- a/tests/Unit/Helper/Filter/JSON/FixSuitableForDietFilterTest.php
+++ b/tests/Unit/Helper/Filter/JSON/FixSuitableForDietFilterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace OCA\Cookbook\tests\Unit\Helper\Filter\JSON;
+
+use OCA\Cookbook\Helper\Filter\JSON\FixSuitableForDietFilter;
+use OCA\Cookbook\Helper\TextCleanupHelper;
+use OCP\IL10N;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class FixSuitableForDietFilterTest extends TestCase {
+	/** @var FixSuitableForDietFilter */
+	private $dut;
+
+	/** @var TextCleanupHelper|MockObject */
+	private $textCleanupHelper;
+
+	/** @var array */
+	private $stub;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		/** @var Stub|IL10N $l */
+		$l = $this->createStub(IL10N::class);
+		$l->method('t')->willReturnArgument(0);
+
+		/** @var LoggerInterface */
+		$logger = $this->createStub(LoggerInterface::class);
+
+		$this->textCleanupHelper = $this->createMock(TextCleanupHelper::class);
+
+		$this->dut = new FixSuitableForDietFilter($l, $logger, $this->textCleanupHelper);
+
+		$this->stub = [
+			'name' => 'The name of the recipe',
+			'id' => 1234,
+		];
+	}
+
+	public function testNonExisting(): void {
+		$recipe = $this->stub;
+		$this->assertTrue($this->dut->apply($recipe));
+
+		$this->stub['suitableForDiet'] = '';
+		$this->assertEquals($this->stub, $recipe);
+	}
+
+	public static function dp(): array {
+		return [
+			[12, '', true],
+			['VeganDiet,VegetarianDiet', 'VeganDiet,VegetarianDiet', false],
+			[['VeganDiet', 'VegetarianDiet'], 'VeganDiet,VegetarianDiet', true],
+			['VeganDiet ,,  , GlutenFreeDiet  ', 'VeganDiet,GlutenFreeDiet', true],
+			[['VeganDiet ', '', ' GlutenFreeDiet '], 'VeganDiet,GlutenFreeDiet', true],
+			['VeganDiet,<i>  VegetarianDiet </i>', 'VeganDiet,VegetarianDiet', true],
+			['', '', false],
+			[[], '', true],
+		];
+	}
+
+	/** @dataProvider dp */
+	public function testApply($startVal, string $expectedVal, bool $changed): void {
+		$recipe = $this->stub;
+		$recipe['suitableForDiet'] = $startVal;
+
+		$this->textCleanupHelper->method('cleanUp')->willReturnArgument(0);
+
+		$ret = $this->dut->apply($recipe);
+
+		$this->stub['suitableForDiet'] = $expectedVal;
+		$this->assertEquals($changed, $ret);
+		$this->assertEquals($this->stub, $recipe);
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for the `suitableForDiet` property from the [schema.org RestrictedDiet vocabulary](https://schema.org/RestrictedDiet), closing #2180.

The schema.org `Recipe` type has supported `suitableForDiet` for several years. Websites that export recipes using JSON-LD (and some scrapers) already include this field. Without a normalisation filter, those values pass through unmodified when they happen to be well-formed, or get silently dropped when they are not.

## Changes

**`lib/Helper/Filter/JSON/FixSuitableForDietFilter.php`** (new)
A new `AbstractJSONFilter` subclass that mirrors the established pattern of `FixKeywordsFilter`:
- Initialises the field to `''` when absent
- Normalises arrays (produced by some scrapers) into comma-separated strings
- Strips HTML tags, trims whitespace, deduplicates entries
- Logs a warning and resets to `''` when the value is an unexpected type

**`lib/Helper/Filter/JSON/JSONFilter.php`**
Registers `FixSuitableForDietFilter` in the filter pipeline after `FixNutritionFilter`.

**`tests/Unit/Helper/Filter/JSON/FixSuitableForDietFilterTest.php`** (new)
Unit tests following the structure of `FixKeywordsFilterTest`, covering missing field, invalid type, string input, array input, whitespace/HTML normalisation, and deduplication.

## Notes

- No database migration is required — the field is stored in the recipe JSON file alongside all other schema.org properties.
- The field is passed through transparently by the existing JSON read/write paths once the filter ensures it is present and normalised.
- Filter/output for the API response layer (e.g. `RecipeJSONOutputFilter`) can be extended in a follow-up if the field should be guaranteed present in API responses, consistent with the `nutrition` field handling.