### PR TITLE
Basic handling of shared recipes

### DIFF
--- a/lib/Controller/Implementation/ConfigImplementation.php
+++ b/lib/Controller/Implementation/ConfigImplementation.php
@@ -4,6 +4,8 @@ namespace OCA\Cookbook\Controller\Implementation;
 
 use OCA\Cookbook\Helper\RestParameterParser;
 use OCA\Cookbook\Helper\UserFolderHelper;
+use OCA\Cookbook\Helper\MyRecipesFolderHelper;
+use OCA\Cookbook\Helper\SharedRecipesFolderHelper;
 use OCA\Cookbook\Service\DbCacheService;
 use OCA\Cookbook\Service\RecipeService;
 use OCP\AppFramework\Http;
@@ -18,17 +20,25 @@ class ConfigImplementation {
 	private $restParser;
 	/** @var UserFolderHelper */
 	private $userFolder;
+	/** @var MyRecipesFolderHelper */
+	private $myRecipesFolder;
+	/** @var SharedRecipesFolderHelper */
+	private $sharedRecipesFolder;
 
 	public function __construct(
 		RecipeService $recipeService,
 		DbCacheService $dbCacheService,
 		RestParameterParser $restParser,
 		UserFolderHelper $userFolder,
+		MyRecipesFolderHelper $myRecipesFolder,
+		SharedRecipesFolderHelper $sharedRecipesFolder,
 	) {
 		$this->service = $recipeService;
 		$this->dbCacheService = $dbCacheService;
 		$this->restParser = $restParser;
 		$this->userFolder = $userFolder;
+		$this->myRecipesFolder = $myRecipesFolder;
+		$this->sharedRecipesFolder = $sharedRecipesFolder;
 	}
 
 	protected const KEY_VISIBLE_INFO_BLOCKS = 'visibleInfoBlocks';
@@ -43,6 +53,8 @@ class ConfigImplementation {
 
 		return new JSONResponse([
 			'folder' => $this->userFolder->getPath(),
+			'my_recipes_folder' => $this->myRecipesFolder->getPath(),
+			'shared_recipes_folder' => $this->sharedRecipesFolder->getPath(),
 			'update_interval' => $this->dbCacheService->getSearchIndexUpdateInterval(),
 			'print_image' => $this->service->getPrintImage(),
 			self::KEY_VISIBLE_INFO_BLOCKS => $this->service->getVisibleInfoBlocks(),
@@ -64,6 +76,16 @@ class ConfigImplementation {
 
 		if (isset($data['folder'])) {
 			$this->userFolder->setPath($data['folder']);
+			$this->dbCacheService->updateCache();
+		}
+
+		if (isset($data['my_recipes_folder'])) {
+			$this->myRecipesFolder->setPath($data['my_recipes_folder']);
+			$this->dbCacheService->updateCache();
+		}
+
+		if (isset($data['shared_recipes_folder'])) {
+			$this->sharedRecipesFolder->setPath($data['shared_recipes_folder']);
 			$this->dbCacheService->updateCache();
 		}
 

--- a/lib/Controller/Implementation/ConfigImplementation.php
+++ b/lib/Controller/Implementation/ConfigImplementation.php
@@ -2,10 +2,10 @@
 
 namespace OCA\Cookbook\Controller\Implementation;
 
-use OCA\Cookbook\Helper\RestParameterParser;
-use OCA\Cookbook\Helper\UserFolderHelper;
 use OCA\Cookbook\Helper\MyRecipesFolderHelper;
+use OCA\Cookbook\Helper\RestParameterParser;
 use OCA\Cookbook\Helper\SharedRecipesFolderHelper;
+use OCA\Cookbook\Helper\UserFolderHelper;
 use OCA\Cookbook\Service\DbCacheService;
 use OCA\Cookbook\Service\RecipeService;
 use OCP\AppFramework\Http;

--- a/lib/Controller/MainController.php
+++ b/lib/Controller/MainController.php
@@ -4,9 +4,9 @@ namespace OCA\Cookbook\Controller;
 
 use OCA\Cookbook\Exception\FolderNotWritableException;
 use OCA\Cookbook\Exception\UserNotLoggedInException;
-use OCA\Cookbook\Helper\UserFolderHelper;
 use OCA\Cookbook\Helper\MyRecipesFolderHelper;
 use OCA\Cookbook\Helper\SharedRecipesFolderHelper;
+use OCA\Cookbook\Helper\UserFolderHelper;
 use OCA\Cookbook\Service\DbCacheService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;

--- a/lib/Controller/MainController.php
+++ b/lib/Controller/MainController.php
@@ -5,6 +5,8 @@ namespace OCA\Cookbook\Controller;
 use OCA\Cookbook\Exception\UserFolderNotWritableException;
 use OCA\Cookbook\Exception\UserNotLoggedInException;
 use OCA\Cookbook\Helper\UserFolderHelper;
+use OCA\Cookbook\Helper\MyRecipesFolderHelper;
+use OCA\Cookbook\Helper\SharedRecipesFolderHelper;
 use OCA\Cookbook\Service\DbCacheService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -20,18 +22,26 @@ class MainController extends Controller {
 	private $dbCacheService;
 	/** @var UserFolderHelper */
 	private $userFolder;
+	/** @var MyRecipesFolderHelper */
+	private $myRecipesFolder;
+	/** @var SharedRecipesFolderHelper */
+	private $sharedRecipesFolder;
 
 	public function __construct(
 		string $AppName,
 		IRequest $request,
 		DbCacheService $dbCacheService,
 		UserFolderHelper $userFolder,
+		MyRecipesFolderHelper $myRecipesFolder,
+		SharedRecipesFolderHelper $sharedRecipesFolder,
 	) {
 		parent::__construct($AppName, $request);
 
 		$this->appName = $AppName;
 		$this->dbCacheService = $dbCacheService;
 		$this->userFolder = $userFolder;
+		$this->myRecipesFolder = $myRecipesFolder;
+		$this->sharedRecipesFolder = $sharedRecipesFolder;
 	}
 
 	/**
@@ -43,8 +53,10 @@ class MainController extends Controller {
 	#[NoCSRFRequired]
 	public function index(): TemplateResponse {
 		try {
-			// Check if the user folder can be accessed
+			// Check if the user folders can be accessed
 			$this->userFolder->getFolder();
+			$this->myRecipesFolder->getFolder();
+			$this->sharedRecipesFolder->getFolder();
 		} catch (UserFolderNotWritableException $ex) {
 			Util::addScript('cookbook', 'cookbook-guest');
 			return new TemplateResponse($this->appName, 'invalid_guest');

--- a/lib/Controller/MainController.php
+++ b/lib/Controller/MainController.php
@@ -2,7 +2,7 @@
 
 namespace OCA\Cookbook\Controller;
 
-use OCA\Cookbook\Exception\UserFolderNotWritableException;
+use OCA\Cookbook\Exception\FolderNotWritableException;
 use OCA\Cookbook\Exception\UserNotLoggedInException;
 use OCA\Cookbook\Helper\UserFolderHelper;
 use OCA\Cookbook\Helper\MyRecipesFolderHelper;
@@ -57,7 +57,7 @@ class MainController extends Controller {
 			$this->userFolder->getFolder();
 			$this->myRecipesFolder->getFolder();
 			$this->sharedRecipesFolder->getFolder();
-		} catch (UserFolderNotWritableException $ex) {
+		} catch (FolderNotWritableException $ex) {
 			Util::addScript('cookbook', 'cookbook-guest');
 			return new TemplateResponse($this->appName, 'invalid_guest');
 		}

--- a/lib/Exception/FolderNotValidException.php
+++ b/lib/Exception/FolderNotValidException.php
@@ -2,7 +2,7 @@
 
 namespace OCA\Cookbook\Exception;
 
-class UserFolderNotWritableException extends \Exception {
+class FolderNotValidException extends \Exception {
 	public function __construct($message = '', $code = 0, $previous = null) {
 		parent::__construct($message, $code, $previous);
 	}

--- a/lib/Exception/FolderNotWritableException.php
+++ b/lib/Exception/FolderNotWritableException.php
@@ -2,7 +2,7 @@
 
 namespace OCA\Cookbook\Exception;
 
-class UserFolderNotValidException extends \Exception {
+class FolderNotWritableException extends \Exception {
 	public function __construct($message = '', $code = 0, $previous = null) {
 		parent::__construct($message, $code, $previous);
 	}

--- a/lib/Helper/FolderHelper.php
+++ b/lib/Helper/FolderHelper.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace OCA\Cookbook\Helper;
+
+use OCA\Cookbook\Exception\FolderNotValidException;
+use OCA\Cookbook\Exception\FolderNotWritableException;
+use OCA\Cookbook\Exception\UserNotLoggedInException;
+use OCP\Files\FileInfo;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\IL10N;
+
+/**
+ * This class caches the access to a folder throughout the app.
+ *
+ */
+class FolderHelper {
+	/**
+	 * @var UserConfigHelper
+	 */
+	protected $config;
+
+	/**
+	 * @var IL10N
+	 */
+	protected $l;
+
+	/**
+	 * @var ?string
+	 */
+	protected $userId;
+
+	/**
+	 * @var IRootFolder
+	 */
+	protected $root;
+
+	/**
+	 * The folder or null if this is not yet cached
+	 *
+	 * @var ?Node
+	 */
+	protected $cache;
+
+	public function __construct(
+		?string $UserId,
+		IRootFolder $root,
+		IL10N $l,
+		UserConfigHelper $configHelper,
+	) {
+		$this->userId = $UserId;
+		$this->root = $root;
+		$this->l = $l;
+		$this->config = $configHelper;
+
+		$this->cache = null;
+	}
+
+	/**
+	 * Set the path relative to the user's root folder
+	 *
+	 * @param string The relative path name
+	 * @throws NotImplementedException If the function is not implemented in the child class
+	 */
+	public function setPath(string $path) {
+		throw new NotImplementedException();
+	}
+
+	/**
+	 * Get the path relative to the user's root folder
+	 *
+	 * @return string The relative path name
+	 * @throws NotImplementedException If the function is not implemented in the child class
+	 */
+	public function getPath(): string {
+		throw new NotImplementedException();
+	}
+
+	/**
+	 * Get the current folder 
+	 *
+	 * @return Folder The folder
+	 * @throws FolderNotValidException If the folder is a file or could not be generated
+	 * @throws UserNotLoggedInException If there is no logged-in user at that time
+	 */
+	public function getFolder(): Folder {
+		// Ensure the cache is built.
+		if (is_null($this->cache)) {
+			$path = $this->getPath();
+
+			// Correct path to be relative to nc root
+			$path = '/' . $this->userId . '/files/' . $path;
+			$path = str_replace('//', '/', $path);
+
+
+			$this->cache = $this->getOrCreateFolder($path);
+		}
+
+		return $this->cache;
+	}
+
+	/**
+	 * Get or Create the folder at path 
+	 *
+	 * @param string The folder's relative path name
+	 * @return Folder The folder at path
+	 * @throws FolderNotValidException If the folder is a file or could not be generated
+	 * @throws FolderNotWritableException If the folder cannot be written
+	 */
+	private function getOrCreateFolder(string $path): Folder {
+		try {
+			$node = $this->root->get($path);
+		} catch (NotFoundException $ex) {
+			try {
+				$node = $this->root->newFolder($path);
+			} catch (NotPermittedException $ex1) {
+				throw new FolderNotValidException(
+					$this->l->t('The folder cannot be created due to missing permissions.'),
+					0,
+					$ex1
+				);
+			}
+		}
+
+		if ($node->getType() !== FileInfo::TYPE_FOLDER) {
+			throw new FolderNotValidException(
+				$this->l->t('The configured folder is a file.')
+			);
+		}
+
+		if (!$node->isCreatable()) {
+			throw new FolderNotWritableException(
+				$this->l->t('User cannot create folder')
+			);
+		}
+
+		return $node;
+	}
+}

--- a/lib/Helper/FolderHelper.php
+++ b/lib/Helper/FolderHelper.php
@@ -2,6 +2,7 @@
 
 namespace OCA\Cookbook\Helper;
 
+use NotImplementedException;
 use OCA\Cookbook\Exception\FolderNotValidException;
 use OCA\Cookbook\Exception\FolderNotWritableException;
 use OCA\Cookbook\Exception\UserNotLoggedInException;
@@ -65,6 +66,7 @@ class FolderHelper {
 	 * @param string The relative path name
 	 * @throws NotImplementedException If the function is not implemented in the child class
 	 */
+	#[\Override]
 	public function setPath(string $path) {
 		throw new NotImplementedException();
 	}
@@ -75,6 +77,7 @@ class FolderHelper {
 	 * @return string The relative path name
 	 * @throws NotImplementedException If the function is not implemented in the child class
 	 */
+	#[\Override]
 	public function getPath(): string {
 		throw new NotImplementedException();
 	}
@@ -110,7 +113,7 @@ class FolderHelper {
 	 * @throws FolderNotValidException If the folder is a file or could not be generated
 	 * @throws FolderNotWritableException If the folder cannot be written
 	 */
-	private function getOrCreateFolder(string $path): Folder {
+	protected function getOrCreateFolder(string $path): Folder {
 		try {
 			$node = $this->root->get($path);
 		} catch (NotFoundException $ex) {

--- a/lib/Helper/FolderHelper.php
+++ b/lib/Helper/FolderHelper.php
@@ -83,7 +83,7 @@ class FolderHelper {
 	}
 
 	/**
-	 * Get the current folder 
+	 * Get the current folder
 	 *
 	 * @return Folder The folder
 	 * @throws FolderNotValidException If the folder is a file or could not be generated
@@ -106,7 +106,7 @@ class FolderHelper {
 	}
 
 	/**
-	 * Get or Create the folder at path 
+	 * Get or Create the folder at path
 	 *
 	 * @param string The folder's relative path name
 	 * @return Folder The folder at path

--- a/lib/Helper/MyRecipesFolderHelper.php
+++ b/lib/Helper/MyRecipesFolderHelper.php
@@ -3,6 +3,7 @@
 namespace OCA\Cookbook\Helper;
 
 use OCA\Cookbook\Helper\FolderHelper;
+use OCA\Cookbook\Exception\UserNotLoggedInException;
 
 /**
  * This class caches the access to the user's recipe folder throughout the app.
@@ -15,6 +16,7 @@ class MyRecipesFolderHelper extends FolderHelper {
 	 *
 	 * @param string $path The name of the path to be used for the recipes
 	 */
+	#[\Override]
 	public function setPath(string $path) {
 		$this->config->setMyRecipesFolderName($path);
 		$this->cache = null;
@@ -26,6 +28,7 @@ class MyRecipesFolderHelper extends FolderHelper {
 	 * @return string The relative path name
 	 * @throws UserNotLoggedInException If there is currently no logged in user
 	 */
+	#[\Override]
 	public function getPath(): string {
 		$path = $this->config->getMyRecipesFolderName();
 

--- a/lib/Helper/MyRecipesFolderHelper.php
+++ b/lib/Helper/MyRecipesFolderHelper.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Cookbook\Helper;
 
-use OCA\Cookbook\Helper\FolderHelper;
 use OCA\Cookbook\Exception\UserNotLoggedInException;
 
 /**

--- a/lib/Helper/MyRecipesFolderHelper.php
+++ b/lib/Helper/MyRecipesFolderHelper.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace OCA\Cookbook\Helper;
+
+use OCA\Cookbook\Helper\FolderHelper;
+
+/**
+ * This class caches the access to the user's recipe folder throughout the app.
+ *
+ * The user's recipes folder is the path, were all recipes are stored.
+ */
+class MyRecipesFolderHelper extends FolderHelper {
+	/**
+	 * Set the current path in the settings relative to the user's root folder
+	 *
+	 * @param string $path The name of the path to be used for the recipes
+	 */
+	public function setPath(string $path) {
+		$this->config->setMyRecipesFolderName($path);
+		$this->cache = null;
+	}
+
+	/**
+	 * Get the path of the user's recipes relative to the user's root folder
+	 *
+	 * @return string The relative path name
+	 * @throws UserNotLoggedInException If there is currently no logged in user
+	 */
+	public function getPath(): string {
+		$path = $this->config->getMyRecipesFolderName();
+
+		// TODO This was in the original code. Is it still needed?
+		// $path = str_replace('//', '/', $path);
+
+		return $path;
+	}
+}

--- a/lib/Helper/SharedRecipesFolderHelper.php
+++ b/lib/Helper/SharedRecipesFolderHelper.php
@@ -3,6 +3,7 @@
 namespace OCA\Cookbook\Helper;
 
 use OCA\Cookbook\Helper\FolderHelper;
+use OCA\Cookbook\Exception\UserNotLoggedInException;
 
 /**
  * This class caches the access to the shared recipes folder throughout the app.
@@ -15,6 +16,7 @@ class SharedRecipesFolderHelper extends FolderHelper {
 	 *
 	 * @param string $path The name of the path to be used for the recipes
 	 */
+	#[\Override]
 	public function setPath(string $path) {
 		$this->config->setSharedRecipesFolderName($path);
 		$this->cache = null;
@@ -26,6 +28,7 @@ class SharedRecipesFolderHelper extends FolderHelper {
 	 * @return string The relative path name
 	 * @throws UserNotLoggedInException If there is currently no logged in user
 	 */
+	#[\Override]
 	public function getPath(): string {
 		$path = $this->config->getSharedRecipesFolderName();
 

--- a/lib/Helper/SharedRecipesFolderHelper.php
+++ b/lib/Helper/SharedRecipesFolderHelper.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Cookbook\Helper;
 
-use OCA\Cookbook\Helper\FolderHelper;
 use OCA\Cookbook\Exception\UserNotLoggedInException;
 
 /**

--- a/lib/Helper/SharedRecipesFolderHelper.php
+++ b/lib/Helper/SharedRecipesFolderHelper.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace OCA\Cookbook\Helper;
+
+use OCA\Cookbook\Helper\FolderHelper;
+
+/**
+ * This class caches the access to the shared recipes folder throughout the app.
+ *
+ * The shared recipes folder is the path, were all recipes are stored.
+ */
+class SharedRecipesFolderHelper extends FolderHelper {
+	/**
+	 * Set the current path in the settings relative to the user's root folder
+	 *
+	 * @param string $path The name of the path to be used for the recipes
+	 */
+	public function setPath(string $path) {
+		$this->config->setSharedRecipesFolderName($path);
+		$this->cache = null;
+	}
+
+	/**
+	 * Get the path of the shared recipes relative to the user's root folder
+	 *
+	 * @return string The relative path name
+	 * @throws UserNotLoggedInException If there is currently no logged in user
+	 */
+	public function getPath(): string {
+		$path = $this->config->getSharedRecipesFolderName();
+
+		// TODO This was in the original code. Is it still needed?
+		// $path = str_replace('//', '/', $path);
+
+		return $path;
+	}
+}

--- a/lib/Helper/UserConfigHelper.php
+++ b/lib/Helper/UserConfigHelper.php
@@ -41,6 +41,8 @@ class UserConfigHelper {
 	protected const KEY_PRINT_IMAGE = 'print_image';
 	protected const KEY_VISIBLE_INFO_BLOCKS = 'visible_info_blocks';
 	protected const KEY_FOLDER = 'folder';
+	protected const KEY_MY_RECIPES_FOLDER = 'my_recipes_folder';
+	protected const KEY_SHARED_RECIPES_FOLDER = 'shared_recipes_folder';
 
 	/**
 	 * Checks if the user is logged in and the configuration can be obtained at all
@@ -197,7 +199,7 @@ class UserConfigHelper {
 	 * Do not use this method directly.
 	 * Instead use the methods of the UserFolderHelper class
 	 *
-	 * @return string The name of the folder within the users files
+	 * @return string The name of the folder within the user's files
 	 * @throws UserNotLoggedInException if no user is logged in
 	 */
 	public function getFolderName(): string {
@@ -225,5 +227,83 @@ class UserConfigHelper {
 	 */
 	public function setFolderName(string $value): void {
 		$this->setRawValue(self::KEY_FOLDER, $value);
+	}
+
+	/**
+	 * Get the name of the user's recipe folder.
+	 *
+	 * If no folder is stored in the config yet, a default setting will be generated and saved.
+	 *
+	 * **Note:**
+	 * Do not use this method directly.
+	 * Instead use the methods of the MyRecipesFolderHelper class
+	 *
+	 * @return string The name of the folder within the user's files
+	 * @throws UserNotLoggedInException if no user is logged in
+	 */
+	public function getMyRecipesFolderName(): string {
+		$rawValue = $this->getRawValue(self::KEY_MY_RECIPES_FOLDER);
+
+		if ($rawValue === '') {
+			$path = getFolderName() . '/' . $this->l->t('My Recipes');
+			$this->setFolderName($path);
+
+			return $path;
+		}
+
+		return $rawValue;
+	}
+
+	/**
+	 * Set the folder for the user's recipe folder.
+	 *
+	 * **Note:**
+	 * Do not use this method directly.
+	 * Instead use the methods of the MyRecipesFolderHelper class
+	 *
+	 * @param string $value The name of the folder within the user's files
+	 * @throws UserNotLoggedInException if no user is logged in
+	 */
+	public function setMyRecipesFolderName(string $value): void {
+		$this->setRawValue(self::KEY_MY_RECIPES_FOLDER, $value);
+	}
+
+	/**
+	 * Get the name of the shared recipes folder.
+	 *
+	 * If no folder is stored in the config yet, a default setting will be generated and saved.
+	 *
+	 * **Note:**
+	 * Do not use this method directly.
+	 * Instead use the methods of the SharedRecipesFolderHelper class
+	 *
+	 * @return string The name of the folder within the user's files
+	 * @throws UserNotLoggedInException if no user is logged in
+	 */
+	public function getSharedRecipesFolderName(): string {
+		$rawValue = $this->getRawValue(self::KEY_SHARED_RECIPES_FOLDER);
+
+		if ($rawValue === '') {
+			$path = getFolderName() . '/' . $this->l->t('Shared Recipes');
+			$this->setFolderName($path);
+
+			return $path;
+		}
+
+		return $rawValue;
+	}
+
+	/**
+	 * Set the folder for the shared recipes folder.
+	 *
+	 * **Note:**
+	 * Do not use this method directly.
+	 * Instead use the methods of the SharedRecipesFolderHelper class
+	 *
+	 * @param string $value The name of the folder within the user's files
+	 * @throws UserNotLoggedInException if no user is logged in
+	 */
+	public function setSharedRecipesFolderName(string $value): void {
+		$this->setRawValue(self::KEY_SHARED_RECIPES_FOLDER, $value);
 	}
 }

--- a/lib/Helper/UserConfigHelper.php
+++ b/lib/Helper/UserConfigHelper.php
@@ -245,7 +245,7 @@ class UserConfigHelper {
 		$rawValue = $this->getRawValue(self::KEY_MY_RECIPES_FOLDER);
 
 		if ($rawValue === '') {
-			$path = getFolderName() . '/' . $this->l->t('My Recipes');
+			$path = $this->getFolderName() . '/' . $this->l->t('My Recipes');
 			$this->setFolderName($path);
 
 			return $path;
@@ -284,7 +284,7 @@ class UserConfigHelper {
 		$rawValue = $this->getRawValue(self::KEY_SHARED_RECIPES_FOLDER);
 
 		if ($rawValue === '') {
-			$path = getFolderName() . '/' . $this->l->t('Shared Recipes');
+			$path = $this->getFolderName() . '/' . $this->l->t('Shared Recipes');
 			$this->setFolderName($path);
 
 			return $path;

--- a/lib/Helper/UserFolderHelper.php
+++ b/lib/Helper/UserFolderHelper.php
@@ -2,64 +2,14 @@
 
 namespace OCA\Cookbook\Helper;
 
-use OCA\Cookbook\Exception\UserFolderNotValidException;
-use OCA\Cookbook\Exception\UserFolderNotWritableException;
-use OCA\Cookbook\Exception\UserNotLoggedInException;
-use OCP\Files\FileInfo;
-use OCP\Files\Folder;
-use OCP\Files\IRootFolder;
-use OCP\Files\Node;
-use OCP\Files\NotFoundException;
-use OCP\Files\NotPermittedException;
-use OCP\IL10N;
+use OCA\Cookbook\Helper\FolderHelper;
 
 /**
  * This class caches the access to the user folder throughout the app.
  *
  * The user folder is the path, were all recipes are stored.
  */
-class UserFolderHelper {
-	/**
-	 * @var UserConfigHelper
-	 */
-	private $config;
-
-	/**
-	 * @var IL10N
-	 */
-	private $l;
-
-	/**
-	 * @var ?string
-	 */
-	private $userId;
-
-	/**
-	 * @var IRootFolder
-	 */
-	private $root;
-
-	/**
-	 * The folder with all recipes or null if this is not yet cached
-	 *
-	 * @var ?Node
-	 */
-	private $cache;
-
-	public function __construct(
-		?string $UserId,
-		IRootFolder $root,
-		IL10N $l,
-		UserConfigHelper $configHelper,
-	) {
-		$this->userId = $UserId;
-		$this->root = $root;
-		$this->l = $l;
-		$this->config = $configHelper;
-
-		$this->cache = null;
-	}
-
+class UserFolderHelper extends FolderHelper {
 	/**
 	 * Set the current path in the settings relative to the user's root folder
 	 *
@@ -71,7 +21,7 @@ class UserFolderHelper {
 	}
 
 	/**
-	 * Get the path of the recipes relative to the user's root folder
+	 * Get the path of the user app folder relative to the user's root folder
 	 *
 	 * @return string The relative path name
 	 * @throws UserNotLoggedInException If there is currently no logged in user
@@ -83,58 +33,5 @@ class UserFolderHelper {
 		// $path = str_replace('//', '/', $path);
 
 		return $path;
-	}
-
-	/**
-	 * Get the current folder where all recipes are stored of the user
-	 *
-	 * @return Folder The folder containing all recipes
-	 * @throws UserFolderNotValidException If the saved user folder is a file or could not be generated
-	 * @throws UserNotLoggedInException If there is no logged-in user at that time
-	 */
-	public function getFolder(): Folder {
-		// Ensure the cache is built.
-		if (is_null($this->cache)) {
-			$path = $this->getPath();
-
-			// Correct path to be relative to nc root
-			$path = '/' . $this->userId . '/files/' . $path;
-			$path = str_replace('//', '/', $path);
-
-
-			$this->cache = $this->getOrCreateFolder($path);
-		}
-
-		return $this->cache;
-	}
-
-	private function getOrCreateFolder(string $path): Folder {
-		try {
-			$node = $this->root->get($path);
-		} catch (NotFoundException $ex) {
-			try {
-				$node = $this->root->newFolder($path);
-			} catch (NotPermittedException $ex1) {
-				throw new UserFolderNotValidException(
-					$this->l->t('The user folder cannot be created due to missing permissions.'),
-					0,
-					$ex1
-				);
-			}
-		}
-
-		if ($node->getType() !== FileInfo::TYPE_FOLDER) {
-			throw new UserFolderNotValidException(
-				$this->l->t('The configured user folder is a file.')
-			);
-		}
-
-		if (!$node->isCreatable()) {
-			throw new UserFolderNotWritableException(
-				$this->l->t('User cannot create recipe folder')
-			);
-		}
-
-		return $node;
 	}
 }

--- a/lib/Helper/UserFolderHelper.php
+++ b/lib/Helper/UserFolderHelper.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Cookbook\Helper;
 
-use OCA\Cookbook\Helper\FolderHelper;
 use OCA\Cookbook\Exception\UserNotLoggedInException;
 
 /**

--- a/lib/Helper/UserFolderHelper.php
+++ b/lib/Helper/UserFolderHelper.php
@@ -3,6 +3,7 @@
 namespace OCA\Cookbook\Helper;
 
 use OCA\Cookbook\Helper\FolderHelper;
+use OCA\Cookbook\Exception\UserNotLoggedInException;
 
 /**
  * This class caches the access to the user folder throughout the app.
@@ -15,6 +16,7 @@ class UserFolderHelper extends FolderHelper {
 	 *
 	 * @param string $path The name of the path to be used for the recipes
 	 */
+	#[\Override]
 	public function setPath(string $path) {
 		$this->config->setFolderName($path);
 		$this->cache = null;
@@ -26,6 +28,7 @@ class UserFolderHelper extends FolderHelper {
 	 * @return string The relative path name
 	 * @throws UserNotLoggedInException If there is currently no logged in user
 	 */
+	#[\Override]
 	public function getPath(): string {
 		$path = $this->config->getFolderName();
 

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -216,14 +216,14 @@ class RecipeService {
 		$json['dateModified'] = $now;
 
 		// Create/move recipe folder
-		$user_folder = $this->userFolder->getFolder();
+		$my_recipes_folder = $this->myRecipesFolder->getFolder();
 		$recipe_folder = null;
 
 		$recipeFolderName = $this->recipeNameHelper->getFolderName($json['name']);
 
 		if (isset($json['id']) && $json['id']) {
 			// Recipe already has an id, update it
-			$recipe_folder = $user_folder->getById($json['id'])[0];
+			$recipe_folder = $my_recipes_folder->getById($json['id'])[0];
 			if (!($recipe_folder instanceof Folder)) {
 				throw new \RuntimeException($this->il10n->t('Unexpected node received for recipe folder.'));
 			}
@@ -233,7 +233,7 @@ class RecipeService {
 
 			// The recipe is being renamed, move the folder
 			if ($old_path !== $new_path) {
-				if ($user_folder->nodeExists($recipeFolderName)) {
+				if ($my_recipes_folder->nodeExists($recipeFolderName)) {
 					throw new RecipeExistsException($this->il10n->t('Another recipe with that name already exists'));
 				}
 
@@ -244,11 +244,11 @@ class RecipeService {
 			// This is a new recipe, create it
 			$json['dateCreated'] = $now;
 
-			if ($user_folder->nodeExists($recipeFolderName)) {
+			if ($my_recipes_folder->nodeExists($recipeFolderName)) {
 				throw new RecipeExistsException($this->il10n->t('Another recipe with that name already exists'));
 			}
 
-			$recipe_folder = $user_folder->newFolder($recipeFolderName);
+			$recipe_folder = $my_recipes_folder->newFolder($recipeFolderName);
 		}
 
 		// Write JSON file to disk
@@ -367,8 +367,16 @@ class RecipeService {
 	 * @return array
 	 */
 	public function getRecipeFiles() {
-		$user_folder = $this->userFolder->getFolder();
-		$recipe_folders = $user_folder->getDirectoryListing();
+		$my_recipes_folder = $this->myRecipesFolder->getFolder();
+		$recipe_folders = $my_recipes_folder->getDirectoryListing();
+
+		$shared_recipes_folder = $this->sharedRecipesFolder->getFolder();
+		$shared_recipes_folders = $shared_recipes_folder->getDirectoryListing();
+
+		foreach ($shared_recipes_folders as $shared_recipe_folder) {
+			$recipe_folders = [...$recipe_folders, ...$shared_recipe_folder->getDirectoryListing()];
+		}
+
 		$recipe_files = [];
 
 		foreach ($recipe_folders as $recipe_folder) {
@@ -408,25 +416,56 @@ class RecipeService {
 
 		// Restructure files if needed
 		$user_folder = $this->userFolder->getFolder();
+		$my_recipes_folder = $this->myRecipesFolder->getFolder();
+		$shared_recipes_folder = $this->sharedRecipesFolder->getFolder();
 
-		foreach ($user_folder->getDirectoryListing() as $node) {
+		if (!$user_folder->isSubNode($my_recipes_folder) || !$user_folder->isSubNode($shared_recipes_folder)) {
+			$this->logger->warning('Cannot migrate cookbook file structure as Cookbook subfolders are not within the main Cookbook folder.');
+			throw $ex;
+		}
+
+		if ($user_folder->getOwner() !== getCurrentUser())
+		{
+			// moving user folder to a shared folder since it's not owned by the current user
+			$user_folder->move($shared_recipes_folder->getPath() . '/' . $user_folder->getOwner()->getUserId());
+			$user_folder = $this->userFolder->getFolder();
+		}
+
+		$recipe_folders = [...$user_folder->getDirectoryListing(), ...$my_recipes_folder->getDirectoryListing()];
+
+		foreach ($recipe_folders as $node) {
 			// Move JSON files from the user directory into its own folder
 			if ($this->isRecipeFile($node)) {
 				$recipe_name = str_replace('.json', '', $node->getName());
 
 				$node->move($node->getPath() . '_tmp');
 
-				$recipe_folder = $user_folder->newFolder($recipe_name);
+				$recipe_folder = $my_recipes_folder->newFolder($recipe_name);
 
 				$node->move($recipe_folder->getPath() . '/recipe.json');
 
-			} elseif ($node instanceof Folder && strpos($node->getName(), '.json')) {
-				// Rename folders with .json extensions (this was likely caused by a migration bug)
-				$node->move(str_replace('.json', '', $node->getPath()));
+			} elseif ($node instanceof Folder) {
+				if(strpos($node->getName(), '.json')) {
+					// Rename folders with .json extensions (this was likely caused by a migration bug)
+					$node->move($my_recipes_folder->getPath() . '/' . str_replace('.json', '', $node->getName()));
+				} elseif ($this->getRecipeFileByFolderId($node->getId()))
+				{
+					if (($node->getOwner() == getCurrentUser()) && ($node->getParent() != $my_recipes_folder)) {
+						$node->move($my_recipes_folder->getPath() . '/' . $node->getName());
+					} elseif (($node->getOwner() !== getCurrentUser()) && ($node->getParent()->getParent() != $shared_recipes_folder)) {
+						$other_user_folder = $shared_recipes_folder->getOrCreateFolder($node->getOwner()->GetUserId());
+						if ($other_user_folder->GetOwner() == getCurrentUser()) {
+							$node->move($other_user_folder->getPath() . '/' . $node->getName());
+						} elseif (($other_user_folder->GetOwner() !== getCurrentUser()) && ($other_user_folder->nodeExists($node->getName()))) {
+							$node->delete();
+						} else {
+							$this->logger->warning('Could not determine what to do about recipe "' . $node->getName() . '". Please fix it manually (currently located at "' . $node->getPath() . '")');
+						}
+					}
+				}
 			}
 		}
 	}
-
 	/**
 	 * Gets all keywords from the index
 	 *

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -8,13 +8,16 @@ use OCA\Cookbook\Exception\HtmlParsingException;
 use OCA\Cookbook\Exception\ImportException;
 use OCA\Cookbook\Exception\NoRecipeNameGivenException;
 use OCA\Cookbook\Exception\RecipeExistsException;
-use OCA\Cookbook\Exception\UserFolderNotWritableException;
+use OCA\Cookbook\Exception\FolderNotValidException;
+use OCA\Cookbook\Exception\FolderNotWritableException;
 use OCA\Cookbook\Helper\DownloadHelper;
 use OCA\Cookbook\Helper\FileSystem\RecipeNameHelper;
 use OCA\Cookbook\Helper\Filter\JSON\JSONFilter;
 use OCA\Cookbook\Helper\ImageService\ImageSize;
 use OCA\Cookbook\Helper\UserConfigHelper;
 use OCA\Cookbook\Helper\UserFolderHelper;
+use OCA\Cookbook\Helper\MyRecipesFolderHelper;
+use OCA\Cookbook\Helper\SharedRecipesFolderHelper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\File;
 use OCP\Files\Folder;
@@ -39,6 +42,14 @@ class RecipeService {
 	 * @var UserFolderHelper
 	 */
 	private $userFolder;
+	/**
+	 * @var MyRecipesFolderHelper
+	 */
+	private $myRecipesFolder;
+	/**
+	 * @var SharedRecipesFolderHelper
+	 */
+	private $sharedRecipesFolder;
 	private $logger;
 
 	/**
@@ -75,6 +86,8 @@ class RecipeService {
 		RecipeDb $db,
 		UserConfigHelper $userConfigHelper,
 		UserFolderHelper $userFolder,
+		MyRecipesFolderHelper $myRecipesFolder,
+		SharedRecipesFolderHelper $sharedRecipesFolder,
 		ImageService $imageService,
 		RecipeNameHelper $recipeNameHelper,
 		IL10N $il10n,
@@ -399,7 +412,7 @@ class RecipeService {
 	public function updateSearchIndex() {
 		try {
 			$this->migrateFolderStructure();
-		} catch (UserFolderNotWritableException $ex) {
+		} catch (FolderNotWritableException $ex) {
 			// Ignore migration if not permitted.
 			$this->logger->warning('Cannot migrate cookbook file structure as not permitted.');
 			throw $ex;
@@ -421,13 +434,13 @@ class RecipeService {
 
 		if (!$user_folder->isSubNode($my_recipes_folder) || !$user_folder->isSubNode($shared_recipes_folder)) {
 			$this->logger->warning('Cannot migrate cookbook file structure as Cookbook subfolders are not within the main Cookbook folder.');
-			throw $ex;
+			throw new FolderNotValidException('Cannot migrate cookbook file structure as Cookbook subfolders are not within the main Cookbook folder.');
 		}
 
-		if ($user_folder->getOwner() !== getCurrentUser())
+		if ($user_folder->getOwner()->getUID() !== $this->user_id)
 		{
 			// moving user folder to a shared folder since it's not owned by the current user
-			$user_folder->move($shared_recipes_folder->getPath() . '/' . $user_folder->getOwner()->getUserId());
+			$user_folder->move($shared_recipes_folder->getPath() . '/' . $user_folder->getOwner()->getUID());
 			$user_folder = $this->userFolder->getFolder();
 		}
 
@@ -450,13 +463,13 @@ class RecipeService {
 					$node->move($my_recipes_folder->getPath() . '/' . str_replace('.json', '', $node->getName()));
 				} elseif ($this->getRecipeFileByFolderId($node->getId()))
 				{
-					if (($node->getOwner() == getCurrentUser()) && ($node->getParent() != $my_recipes_folder)) {
+					if (($node->getOwner()->getUID() == $this->user_id) && ($node->getParent() != $my_recipes_folder)) {
 						$node->move($my_recipes_folder->getPath() . '/' . $node->getName());
-					} elseif (($node->getOwner() !== getCurrentUser()) && ($node->getParent()->getParent() != $shared_recipes_folder)) {
-						$other_user_folder = $shared_recipes_folder->getOrCreateFolder($node->getOwner()->GetUserId());
-						if ($other_user_folder->GetOwner() == getCurrentUser()) {
+					} elseif (($node->getOwner()->getUID() !== $this->user_id) && ($node->getParent()->getParent() != $shared_recipes_folder)) {
+						$other_user_folder = $shared_recipes_folder->newFolder($node->getOwner()->GetUID());
+						if ($other_user_folder->GetOwner()->getUID() == $this->user_id) {
 							$node->move($other_user_folder->getPath() . '/' . $node->getName());
-						} elseif (($other_user_folder->GetOwner() !== getCurrentUser()) && ($other_user_folder->nodeExists($node->getName()))) {
+						} elseif (($other_user_folder->GetOwner()->getUID() !== $this->user_id) && ($other_user_folder->nodeExists($node->getName()))) {
 							$node->delete();
 						} else {
 							$this->logger->warning('Could not determine what to do about recipe "' . $node->getName() . '". Please fix it manually (currently located at "' . $node->getPath() . '")');

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -4,20 +4,20 @@ namespace OCA\Cookbook\Service;
 
 use Exception;
 use OCA\Cookbook\Db\RecipeDb;
+use OCA\Cookbook\Exception\FolderNotValidException;
+use OCA\Cookbook\Exception\FolderNotWritableException;
 use OCA\Cookbook\Exception\HtmlParsingException;
 use OCA\Cookbook\Exception\ImportException;
 use OCA\Cookbook\Exception\NoRecipeNameGivenException;
 use OCA\Cookbook\Exception\RecipeExistsException;
-use OCA\Cookbook\Exception\FolderNotValidException;
-use OCA\Cookbook\Exception\FolderNotWritableException;
 use OCA\Cookbook\Helper\DownloadHelper;
 use OCA\Cookbook\Helper\FileSystem\RecipeNameHelper;
 use OCA\Cookbook\Helper\Filter\JSON\JSONFilter;
 use OCA\Cookbook\Helper\ImageService\ImageSize;
-use OCA\Cookbook\Helper\UserConfigHelper;
-use OCA\Cookbook\Helper\UserFolderHelper;
 use OCA\Cookbook\Helper\MyRecipesFolderHelper;
 use OCA\Cookbook\Helper\SharedRecipesFolderHelper;
+use OCA\Cookbook\Helper\UserConfigHelper;
+use OCA\Cookbook\Helper\UserFolderHelper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\File;
 use OCP\Files\Folder;
@@ -437,8 +437,7 @@ class RecipeService {
 			throw new FolderNotValidException('Cannot migrate cookbook file structure as Cookbook subfolders are not within the main Cookbook folder.');
 		}
 
-		if ($user_folder->getOwner()->getUID() !== $this->user_id)
-		{
+		if ($user_folder->getOwner()->getUID() !== $this->user_id) {
 			// moving user folder to a shared folder since it's not owned by the current user
 			$user_folder->move($shared_recipes_folder->getPath() . '/' . $user_folder->getOwner()->getUID());
 			$user_folder = $this->userFolder->getFolder();
@@ -458,11 +457,10 @@ class RecipeService {
 				$node->move($recipe_folder->getPath() . '/recipe.json');
 
 			} elseif ($node instanceof Folder) {
-				if(strpos($node->getName(), '.json')) {
+				if (strpos($node->getName(), '.json')) {
 					// Rename folders with .json extensions (this was likely caused by a migration bug)
 					$node->move($my_recipes_folder->getPath() . '/' . str_replace('.json', '', $node->getName()));
-				} elseif ($this->getRecipeFileByFolderId($node->getId()))
-				{
+				} elseif ($this->getRecipeFileByFolderId($node->getId())) {
 					if (($node->getOwner()->getUID() == $this->user_id) && ($node->getParent() != $my_recipes_folder)) {
 						$node->move($my_recipes_folder->getPath() . '/' . $node->getName());
 					} elseif (($node->getOwner()->getUID() !== $this->user_id) && ($node->getParent()->getParent() != $shared_recipes_folder)) {

--- a/src/components/Modals/SettingsDialog.vue
+++ b/src/components/Modals/SettingsDialog.vue
@@ -33,6 +33,28 @@
                         />
                     </li>
                     <li>
+                        <label class="settings-input">{{
+                            t('cookbook', 'My Recipes folder')
+                        }}</label>
+                        <input
+                            type="text"
+                            :value="myRecipesFolder"
+                            :placeholder="t('cookbook', 'Please pick a folder')"
+                            @click="pickMyRecipesFolder"
+                        />
+                    </li>
+                    <li>
+                        <label class="settings-input">{{
+                            t('cookbook', 'Shared Recipes folder')
+                        }}</label>
+                        <input
+                            type="text"
+                            :value="SharedRecipesFolder"
+                            :placeholder="t('cookbook', 'Please pick a folder')"
+                            @click="pickSharedRecipesFolder"
+                        />
+                    </li>
+                    <li>
                         <label class="settings-input">
                             {{ t('cookbook', 'Update interval in minutes') }}
                         </label>
@@ -370,6 +392,88 @@ const pickRecipeFolder = () => {
                     showSimpleAlertModal(
                         // prettier-ignore
                         t('cookbook','Could not set recipe folder to {path}',
+                        {
+                            path
+                        }
+                    ),
+                    ),
+                );
+        })
+        .catch((ev) => {
+            log.warn(
+                `Could not select new recipe folder. Error Message: ${ev.message}`,
+            );
+        });
+};
+
+/**
+ * Select a recipe folder using the Nextcloud file picker
+ */
+const pickMyRecipesFolder = () => {
+    const filePicker = getFilePickerBuilder(
+        t('cookbook', 'Path to your personal recipe collection'),
+    )
+        .addMimeTypeFilter('httpd/unix-directory')
+        .allowDirectories(true)
+        .setType(FilePickerType.Choose)
+        .build();
+    filePicker
+        .pick()
+        .then((path) => {
+            store
+                .dispatch('updateMyRecipesDirectory', { dir: path })
+                .then(() => store.dispatch('refreshConfig'))
+                .then(() => {
+                    recipeFolder.value = path;
+                    if (route.path !== '/') {
+                        router.push('/');
+                    }
+                })
+                .catch(() =>
+                    showSimpleAlertModal(
+                        // prettier-ignore
+                        t('cookbook','Could not set my recipes folder to {path}',
+                        {
+                            path
+                        }
+                    ),
+                    ),
+                );
+        })
+        .catch((ev) => {
+            log.warn(
+                `Could not select new recipe folder. Error Message: ${ev.message}`,
+            );
+        });
+};
+
+/**
+ * Select a recipe folder using the Nextcloud file picker
+ */
+const pickSharedRecipesFolder = () => {
+    const filePicker = getFilePickerBuilder(
+        t('cookbook', 'Path to your shared recipe collection'),
+    )
+        .addMimeTypeFilter('httpd/unix-directory')
+        .allowDirectories(true)
+        .setType(FilePickerType.Choose)
+        .build();
+    filePicker
+        .pick()
+        .then((path) => {
+            store
+                .dispatch('updateSharedRecipesDirectory', { dir: path })
+                .then(() => store.dispatch('refreshConfig'))
+                .then(() => {
+                    recipeFolder.value = path;
+                    if (route.path !== '/') {
+                        router.push('/');
+                    }
+                })
+                .catch(() =>
+                    showSimpleAlertModal(
+                        // prettier-ignore
+                        t('cookbook','Could not set shared recipes folder to {path}',
                         {
                             path
                         }

--- a/src/components/Modals/SettingsDialog.vue
+++ b/src/components/Modals/SettingsDialog.vue
@@ -411,11 +411,12 @@ const pickRecipeFolder = () => {
  */
 const pickMyRecipesFolder = () => {
     const filePicker = getFilePickerBuilder(
-        t('cookbook', 'Path to your personal recipe collection'),
+        t('cookbook', 'Path to your personal recipes collection'),
     )
         .addMimeTypeFilter('httpd/unix-directory')
         .allowDirectories(true)
         .setType(FilePickerType.Choose)
+        .startAt(recipeFolder)
         .build();
     filePicker
         .pick()
@@ -424,7 +425,7 @@ const pickMyRecipesFolder = () => {
                 .dispatch('updateMyRecipesDirectory', { dir: path })
                 .then(() => store.dispatch('refreshConfig'))
                 .then(() => {
-                    recipeFolder.value = path;
+                    myRecipesFolder.value = path;
                     if (route.path !== '/') {
                         router.push('/');
                     }
@@ -442,7 +443,7 @@ const pickMyRecipesFolder = () => {
         })
         .catch((ev) => {
             log.warn(
-                `Could not select new recipe folder. Error Message: ${ev.message}`,
+                `Could not select new my recipes folder. Error Message: ${ev.message}`,
             );
         });
 };
@@ -452,11 +453,12 @@ const pickMyRecipesFolder = () => {
  */
 const pickSharedRecipesFolder = () => {
     const filePicker = getFilePickerBuilder(
-        t('cookbook', 'Path to your shared recipe collection'),
+        t('cookbook', 'Path to your shared recipes collection'),
     )
         .addMimeTypeFilter('httpd/unix-directory')
         .allowDirectories(true)
         .setType(FilePickerType.Choose)
+        .startAt(recipeFolder)
         .build();
     filePicker
         .pick()
@@ -465,7 +467,7 @@ const pickSharedRecipesFolder = () => {
                 .dispatch('updateSharedRecipesDirectory', { dir: path })
                 .then(() => store.dispatch('refreshConfig'))
                 .then(() => {
-                    recipeFolder.value = path;
+                    SharedRecipesFolder.value = path;
                     if (route.path !== '/') {
                         router.push('/');
                     }
@@ -483,7 +485,7 @@ const pickSharedRecipesFolder = () => {
         })
         .catch((ev) => {
             log.warn(
-                `Could not select new recipe folder. Error Message: ${ev.message}`,
+                `Could not select new shared recipes folder. Error Message: ${ev.message}`,
             );
         });
 };

--- a/src/js/api-interface.js
+++ b/src/js/api-interface.js
@@ -104,6 +104,14 @@ function updateRecipeDirectory(newDir) {
     return instance.post(`${baseUrl}/config`, { folder: newDir });
 }
 
+function updateMyRecipesDirectory(newDir) {
+    return instance.post(`${baseUrl}/config`, { my_recipes_folder: newDir });
+}
+
+function updateSharedRecipesDirectory(newDir) {
+    return instance.post(`${baseUrl}/config`, { shared_recipes_folder: newDir });
+}
+
 function updateVisibleInfoBlocks(visibleInfoBlocks) {
     return instance.post(`${baseUrl}/config`, { visibleInfoBlocks });
 }
@@ -134,8 +142,14 @@ export default {
     },
     config: {
         get: getConfig,
-        directory: {
+        mainDirectory: {
             update: updateRecipeDirectory,
+        },
+        myRecipesDirectory: {
+            update: updateMyRecipesDirectory,
+        },
+        sharedRecipesDirectory: {
+            update: updateSharedRecipesDirectory,
         },
         printImage: {
             update: updatePrintImageSetting,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -239,7 +239,7 @@ const store = new Vuex.Store({
 		updateRecipeDirectory(c, { dir }) {
 			c.commit('setUpdatingRecipeDirectory', { b: true });
 			c.dispatch('setRecipe', { recipe: null });
-			const request = api.config.directory.update(dir);
+			const request = api.config.mainDirectory.update(dir);
 
 			return request.then(() => {
 				c.dispatch('setAppNavigationRefreshRequired', {
@@ -251,7 +251,7 @@ const store = new Vuex.Store({
 		updateMyRecipesDirectory(c, { dir }) {
 			c.commit('setUpdatingMyRecipesDirectory', { b: true });
 			c.dispatch('setRecipe', { recipe: null });
-			const request = api.config.directory.update(dir);
+			const request = api.config.myRecipesDirectory.update(dir);
 
 			return request.then(() => {
 				c.dispatch('setAppNavigationRefreshRequired', {
@@ -263,7 +263,7 @@ const store = new Vuex.Store({
 		updateSharedRecipesDirectory(c, { dir }) {
 			c.commit('setUpdatingSharedRecipesDirectory', { b: true });
 			c.dispatch('setRecipe', { recipe: null });
-			const request = api.config.directory.update(dir);
+			const request = api.config.SharedRecipesDirectory.update(dir);
 
 			return request.then(() => {
 				c.dispatch('setAppNavigationRefreshRequired', {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -248,6 +248,30 @@ const store = new Vuex.Store({
 				c.commit('setUpdatingRecipeDirectory', { b: false });
 			});
 		},
+		updateMyRecipesDirectory(c, { dir }) {
+			c.commit('setUpdatingMyRecipesDirectory', { b: true });
+			c.dispatch('setRecipe', { recipe: null });
+			const request = api.config.directory.update(dir);
+
+			return request.then(() => {
+				c.dispatch('setAppNavigationRefreshRequired', {
+					isRequired: true,
+				});
+				c.commit('setUpdatingMyRecipesDirectory', { b: false });
+			});
+		},
+		updateSharedRecipesDirectory(c, { dir }) {
+			c.commit('setUpdatingSharedRecipesDirectory', { b: true });
+			c.dispatch('setRecipe', { recipe: null });
+			const request = api.config.directory.update(dir);
+
+			return request.then(() => {
+				c.dispatch('setAppNavigationRefreshRequired', {
+					isRequired: true,
+				});
+				c.commit('setUpdatingSharedRecipesDirectory', { b: false });
+			});
+		},
 		/**
 		 * Update existing recipe on the server
 		 */

--- a/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
+++ b/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
@@ -26,7 +26,7 @@ use Psr\Log\LoggerInterface;
 
 /**
  * @covers \OCA\Cookbook\Controller\Implementation\RecipeImplementation
- * @covers \OCA\Cookbook\Exception\UserFolderNotWritableException
+ * @covers \OCA\Cookbook\Exception\FolderNotWritableException
  * @covers \OCA\Cookbook\Exception\RecipeExistsException
  * @covers \OCA\Cookbook\Exception\NoRecipeNameGivenException
  */

--- a/tests/Unit/Controller/MainControllerTest.php
+++ b/tests/Unit/Controller/MainControllerTest.php
@@ -4,9 +4,9 @@ namespace OCA\Cookbook\tests\Unit\Controller;
 
 use OCA\Cookbook\Controller\MainController;
 use OCA\Cookbook\Exception\FolderNotWritableException;
-use OCA\Cookbook\Helper\UserFolderHelper;
 use OCA\Cookbook\Helper\MyRecipesFolderHelper;
 use OCA\Cookbook\Helper\SharedRecipesFolderHelper;
+use OCA\Cookbook\Helper\UserFolderHelper;
 use OCA\Cookbook\Service\DbCacheService;
 use OCP\Files\Folder;
 use OCP\IRequest;

--- a/tests/Unit/Controller/MainControllerTest.php
+++ b/tests/Unit/Controller/MainControllerTest.php
@@ -3,8 +3,10 @@
 namespace OCA\Cookbook\tests\Unit\Controller;
 
 use OCA\Cookbook\Controller\MainController;
-use OCA\Cookbook\Exception\UserFolderNotWritableException;
+use OCA\Cookbook\Exception\FolderNotWritableException;
 use OCA\Cookbook\Helper\UserFolderHelper;
+use OCA\Cookbook\Helper\MyRecipesFolderHelper;
+use OCA\Cookbook\Helper\SharedRecipesFolderHelper;
 use OCA\Cookbook\Service\DbCacheService;
 use OCP\Files\Folder;
 use OCP\IRequest;
@@ -13,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \OCA\Cookbook\Controller\MainController
- * @covers \OCA\Cookbook\Exception\UserFolderNotWritableException
+ * @covers \OCA\Cookbook\Exception\FolderNotWritableException
  */
 class MainControllerTest extends TestCase {
 	/**
@@ -24,6 +26,14 @@ class MainControllerTest extends TestCase {
 	 * @var UserFolderHelper|MockObject
 	 */
 	private $userFolder;
+	/**
+	 * @var MyRecipesFolderHelper|MockObject
+	 */
+	private $myRecipesFolder;
+	/**
+	 * @var SharedRecipesFolderHelper|MockObject
+	 */
+	private $sharedRecipesFolder;
 
 	/**
 	 * @var MainController
@@ -36,12 +46,16 @@ class MainControllerTest extends TestCase {
 		$request = $this->createStub(IRequest::class);
 		$this->dbCacheService = $this->createMock(DbCacheService::class);
 		$this->userFolder = $this->createMock(UserFolderHelper::class);
+		$this->myRecipesFolder = $this->createMock(MyRecipesFolderHelper::class);
+		$this->sharedRecipesFolder = $this->createMock(SharedRecipesFolderHelper::class);
 
 		$this->sut = new MainController(
 			'cookbook',
 			$request,
 			$this->dbCacheService,
-			$this->userFolder
+			$this->userFolder,
+			$this->myRecipesFolder,
+			$this->sharedRecipesFolder
 		);
 	}
 
@@ -52,7 +66,11 @@ class MainControllerTest extends TestCase {
 	public function testIndex(): void {
 		$this->ensureCacheCheckTriggered();
 		$userFolder = $this->createStub(Folder::class);
+		$myRecipesFolder = $this->createStub(Folder::class);
+		$sharedRecipesFolder = $this->createStub(Folder::class);
 		$this->userFolder->method('getFolder')->willReturn($userFolder);
+		$this->myRecipesFolder->method('getFolder')->willReturn($myRecipesFolder);
+		$this->sharedRecipesFolder->method('getFolder')->willReturn($sharedRecipesFolder);
 
 		$ret = $this->sut->index();
 
@@ -61,7 +79,9 @@ class MainControllerTest extends TestCase {
 	}
 
 	public function testIndexInvalidUser(): void {
-		$this->userFolder->method('getFolder')->willThrowException(new UserFolderNotWritableException());
+		$this->userFolder->method('getFolder')->willThrowException(new FolderNotWritableException());
+		$this->myRecipesFolder->method('getFolder')->willThrowException(new FolderNotWritableException());
+		$this->sharedRecipesFolder->method('getFolder')->willThrowException(new FolderNotWritableException());
 		$ret = $this->sut->index();
 		$this->assertEquals(200, $ret->getStatus());
 		$this->assertEquals('invalid_guest', $ret->getTemplateName());

--- a/tests/Unit/Controller/UtilApiControllerTest.php
+++ b/tests/Unit/Controller/UtilApiControllerTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \OCA\Cookbook\Controller\UtilApiController
- * @covers \OCA\Cookbook\Exception\UserFolderNotWritableException
+ * @covers \OCA\Cookbook\Exception\FolderNotWritableException
  */
 class UtilApiControllerTest extends TestCase {
 	/**

--- a/tests/Unit/Helper/MyRecipesFolderHelperTest.php
+++ b/tests/Unit/Helper/MyRecipesFolderHelperTest.php
@@ -4,8 +4,8 @@ namespace OCA\Cookbook\tests\Unit\Helper;
 
 use OCA\Cookbook\Exception\FolderNotValidException;
 use OCA\Cookbook\Exception\FolderNotWritableException;
-use OCA\Cookbook\Helper\UserConfigHelper;
 use OCA\Cookbook\Helper\MyRecipesFolderHelper;
+use OCA\Cookbook\Helper\UserConfigHelper;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;

--- a/tests/Unit/Helper/MyRecipesFolderHelperTest.php
+++ b/tests/Unit/Helper/MyRecipesFolderHelperTest.php
@@ -5,7 +5,7 @@ namespace OCA\Cookbook\tests\Unit\Helper;
 use OCA\Cookbook\Exception\FolderNotValidException;
 use OCA\Cookbook\Exception\FolderNotWritableException;
 use OCA\Cookbook\Helper\UserConfigHelper;
-use OCA\Cookbook\Helper\UserFolderHelper;
+use OCA\Cookbook\Helper\MyRecipesFolderHelper;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -19,11 +19,11 @@ use ReflectionClass;
 use ReflectionProperty;
 
 /**
- * @covers \OCA\Cookbook\Helper\UserFolderHelper
+ * @covers \OCA\Cookbook\Helper\MyRecipesFolderHelper
  * @covers \OCA\Cookbook\Exception\FolderNotValidException
  * @covers \OCA\Cookbook\Exception\FolderNotWritableException
  */
-class UserFolderHelperTest extends TestCase {
+class MyRecipesFolderHelperTest extends TestCase {
 	/**
 	 * @var UserConfigHelper|MockObject
 	 */
@@ -38,9 +38,9 @@ class UserFolderHelperTest extends TestCase {
 	private $root;
 
 	/**
-	 * @var UserFolderHelper
+	 * @var MyRecipesFolderHelper
 	 */
-	private $userFolder;
+	private $myRecipesFolder;
 
 	/**
 	 * @var ReflectionProperty
@@ -62,11 +62,11 @@ class UserFolderHelperTest extends TestCase {
 
 		$this->config = $this->createMock(UserConfigHelper::class);
 
-		$reflection = new ReflectionClass(UserFolderHelper::class);
+		$reflection = new ReflectionClass(MyRecipesFolderHelper::class);
 		$this->cacheProp = $reflection->getProperty('cache');
 		$this->cacheProp->setAccessible(true);
 
-		$this->userFolder = new UserFolderHelper(
+		$this->myRecipesFolder = new MyRecipesFolderHelper(
 			$this->userId, $this->root, $l, $this->config
 		);
 	}
@@ -76,27 +76,27 @@ class UserFolderHelperTest extends TestCase {
 
 		$this->config->expects($this->once())->method('setFolderName')->with($newPath);
 
-		$this->userFolder->setPath($newPath);
+		$this->myRecipesFolder->setPath($newPath);
 
-		$this->assertNull($this->cacheProp->getValue($this->userFolder));
+		$this->assertNull($this->cacheProp->getValue($this->myRecipesFolder));
 	}
 
 	public function testGetPath() {
 		$retPath = '/Recipes';
 		$this->config->method('getFolderName')->willReturn($retPath);
 
-		$this->assertEquals($retPath, $this->userFolder->getPath());
+		$this->assertEquals($retPath, $this->myRecipesFolder->getPath());
 	}
 
 	public function testCachedPath() {
 		$folderStub = $this->createStub(Folder::class);
 
-		$this->cacheProp->setValue($this->userFolder, $folderStub);
+		$this->cacheProp->setValue($this->myRecipesFolder, $folderStub);
 
 		$this->root->expects($this->never())->method('get');
 		$this->root->expects($this->never())->method('newFolder');
 
-		$this->assertSame($folderStub, $this->userFolder->getFolder());
+		$this->assertSame($folderStub, $this->myRecipesFolder->getFolder());
 	}
 
 	public static function dpExisting() {
@@ -129,7 +129,7 @@ class UserFolderHelperTest extends TestCase {
 		$folderStub->method('getType')->willReturn(FileInfo::TYPE_FOLDER);
 		$folderStub->method('isCreatable')->willReturn(true);
 
-		$this->assertSame($folderStub, $this->userFolder->getFolder());
+		$this->assertSame($folderStub, $this->myRecipesFolder->getFolder());
 	}
 
 	public function testNoWritingPermissionGetFolder() {
@@ -144,7 +144,7 @@ class UserFolderHelperTest extends TestCase {
 		$this->config->method('getFolderName')->willReturn($path);
 
 		$this->expectException(FolderNotValidException::class);
-		$this->userFolder->getFolder();
+		$this->myRecipesFolder->getFolder();
 	}
 
 	public function testWrongTypeGetFolder() {
@@ -163,7 +163,7 @@ class UserFolderHelperTest extends TestCase {
 		$nodeStub->method('getType')->willReturn(FileInfo::TYPE_FILE);
 
 		$this->expectException(FolderNotValidException::class);
-		$this->userFolder->getFolder();
+		$this->myRecipesFolder->getFolder();
 	}
 
 	public function testReadOnlyGetFolder() {
@@ -183,6 +183,6 @@ class UserFolderHelperTest extends TestCase {
 		$nodeStub->method('isCreatable')->willReturn(false);
 
 		$this->expectException(FolderNotWritableException::class);
-		$this->userFolder->getFolder();
+		$this->myRecipesFolder->getFolder();
 	}
 }

--- a/tests/Unit/Helper/SharedRecipesFolderHelperTest.php
+++ b/tests/Unit/Helper/SharedRecipesFolderHelperTest.php
@@ -5,7 +5,7 @@ namespace OCA\Cookbook\tests\Unit\Helper;
 use OCA\Cookbook\Exception\FolderNotValidException;
 use OCA\Cookbook\Exception\FolderNotWritableException;
 use OCA\Cookbook\Helper\UserConfigHelper;
-use OCA\Cookbook\Helper\UserFolderHelper;
+use OCA\Cookbook\Helper\SharedRecipesFolderHelper;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -19,11 +19,11 @@ use ReflectionClass;
 use ReflectionProperty;
 
 /**
- * @covers \OCA\Cookbook\Helper\UserFolderHelper
+ * @covers \OCA\Cookbook\Helper\SharedRecipesFolderHelper
  * @covers \OCA\Cookbook\Exception\FolderNotValidException
  * @covers \OCA\Cookbook\Exception\FolderNotWritableException
  */
-class UserFolderHelperTest extends TestCase {
+class SharedRecipesFolderHelperTest extends TestCase {
 	/**
 	 * @var UserConfigHelper|MockObject
 	 */
@@ -38,9 +38,9 @@ class UserFolderHelperTest extends TestCase {
 	private $root;
 
 	/**
-	 * @var UserFolderHelper
+	 * @var SharedRecipesFolderHelper
 	 */
-	private $userFolder;
+	private $sharedRecipesFolder;
 
 	/**
 	 * @var ReflectionProperty
@@ -62,11 +62,11 @@ class UserFolderHelperTest extends TestCase {
 
 		$this->config = $this->createMock(UserConfigHelper::class);
 
-		$reflection = new ReflectionClass(UserFolderHelper::class);
+		$reflection = new ReflectionClass(SharedRecipesFolderHelper::class);
 		$this->cacheProp = $reflection->getProperty('cache');
 		$this->cacheProp->setAccessible(true);
 
-		$this->userFolder = new UserFolderHelper(
+		$this->sharedRecipesFolder = new SharedRecipesFolderHelper(
 			$this->userId, $this->root, $l, $this->config
 		);
 	}
@@ -76,27 +76,27 @@ class UserFolderHelperTest extends TestCase {
 
 		$this->config->expects($this->once())->method('setFolderName')->with($newPath);
 
-		$this->userFolder->setPath($newPath);
+		$this->sharedRecipesFolder->setPath($newPath);
 
-		$this->assertNull($this->cacheProp->getValue($this->userFolder));
+		$this->assertNull($this->cacheProp->getValue($this->sharedRecipesFolder));
 	}
 
 	public function testGetPath() {
 		$retPath = '/Recipes';
 		$this->config->method('getFolderName')->willReturn($retPath);
 
-		$this->assertEquals($retPath, $this->userFolder->getPath());
+		$this->assertEquals($retPath, $this->sharedRecipesFolder->getPath());
 	}
 
 	public function testCachedPath() {
 		$folderStub = $this->createStub(Folder::class);
 
-		$this->cacheProp->setValue($this->userFolder, $folderStub);
+		$this->cacheProp->setValue($this->sharedRecipesFolder, $folderStub);
 
 		$this->root->expects($this->never())->method('get');
 		$this->root->expects($this->never())->method('newFolder');
 
-		$this->assertSame($folderStub, $this->userFolder->getFolder());
+		$this->assertSame($folderStub, $this->sharedRecipesFolder->getFolder());
 	}
 
 	public static function dpExisting() {
@@ -129,7 +129,7 @@ class UserFolderHelperTest extends TestCase {
 		$folderStub->method('getType')->willReturn(FileInfo::TYPE_FOLDER);
 		$folderStub->method('isCreatable')->willReturn(true);
 
-		$this->assertSame($folderStub, $this->userFolder->getFolder());
+		$this->assertSame($folderStub, $this->sharedRecipesFolder->getFolder());
 	}
 
 	public function testNoWritingPermissionGetFolder() {
@@ -144,7 +144,7 @@ class UserFolderHelperTest extends TestCase {
 		$this->config->method('getFolderName')->willReturn($path);
 
 		$this->expectException(FolderNotValidException::class);
-		$this->userFolder->getFolder();
+		$this->sharedRecipesFolder->getFolder();
 	}
 
 	public function testWrongTypeGetFolder() {
@@ -163,7 +163,7 @@ class UserFolderHelperTest extends TestCase {
 		$nodeStub->method('getType')->willReturn(FileInfo::TYPE_FILE);
 
 		$this->expectException(FolderNotValidException::class);
-		$this->userFolder->getFolder();
+		$this->sharedRecipesFolder->getFolder();
 	}
 
 	public function testReadOnlyGetFolder() {
@@ -183,6 +183,6 @@ class UserFolderHelperTest extends TestCase {
 		$nodeStub->method('isCreatable')->willReturn(false);
 
 		$this->expectException(FolderNotWritableException::class);
-		$this->userFolder->getFolder();
+		$this->sharedRecipesFolder->getFolder();
 	}
 }

--- a/tests/Unit/Helper/SharedRecipesFolderHelperTest.php
+++ b/tests/Unit/Helper/SharedRecipesFolderHelperTest.php
@@ -4,8 +4,8 @@ namespace OCA\Cookbook\tests\Unit\Helper;
 
 use OCA\Cookbook\Exception\FolderNotValidException;
 use OCA\Cookbook\Exception\FolderNotWritableException;
-use OCA\Cookbook\Helper\UserConfigHelper;
 use OCA\Cookbook\Helper\SharedRecipesFolderHelper;
+use OCA\Cookbook\Helper\UserConfigHelper;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
-  <file src="lib/Helper/UserFolderHelper.php">
-    <MissingDependency>
-      <code><![CDATA[$this->root]]></code>
-      <code><![CDATA[$this->root]]></code>
-      <code><![CDATA[IRootFolder]]></code>
-      <code><![CDATA[IRootFolder]]></code>
-    </MissingDependency>
-  </file>
+<files psalm-version="6.15.1@28dc127af1b5aecd52314f6f645bafc10d0e11f9">
   <file src="lib/Service/RecipeService.php">
     <MissingDependency>
       <code><![CDATA[$this->root]]></code>


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

This PR is meant to allow for shared recipes handling.

It manages the separation of the Recipe folder into two parts : 

- the user's recipes, defaulting to "{UserFolder}/My Recipes" folder
- the recipes shared to the user, defaulting to "{UserFolder}/Shared Recipes/{User Id}" folder

Should fix #120

## Concerns/issues

This PR does need careful handling on the migration part, and will need further test cases.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ ] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
