### PR TITLE
fix(import): replace external image URL with local path after download

### DIFF
--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -310,6 +310,17 @@ class RecipeService {
 		// If image data was fetched, write it to disk
 		if ($full_image_data) {
 			$this->imageService->setImageData($recipe_folder, $full_image_data);
+
+			// Replace external URL in JSON with the user-relative path to the local copy.
+			// Avoids leaking the source URL on edit and prevents re-downloading on the next
+			// save (the image_changed check on line above compares this field). The frontend
+			// renders `imageUrl` (an API route), not this field, so any stable non-URL value
+			// is safe.
+			if (isset($json['image']) && strpos($json['image'], 'http') === 0) {
+				$userFilesRoot = '/' . $this->user_id . '/files';
+				$json['image'] = substr($recipe_folder->getPath(), strlen($userFilesRoot)) . '/full.jpg';
+				$recipe_file->putContent(json_encode($json));
+			}
 		}
 
 		// Write .nomedia file to avoid gallery indexing


### PR DESCRIPTION
## Summary

When a recipe is imported from a URL, `RecipeService::addRecipe()` downloads the image and writes it to the recipe folder as `full.jpg` (via `ImageService::setImageData()`), but `recipe.json` keeps the original external URL in its `image` field. This patch rewrites that field to the user-relative path of the local file after the download succeeds, so:

- The source URL no longer leaks back to the user on edit (visible in the *Image* field of the editor).
- `recipe.json` self-consistently reflects what is actually on disk.
- Future re-saves don't risk a re-download from the original host if the field is touched.

## Background

The frontend (`RecipeCard.vue`, `RecipeImages.vue`) renders images via `recipe.imageUrl`, which the backend (`RecipeImplementation.php`) generates as a link to the `cookbook.recipe.image` route — i.e. the local file. So end-user browsing already does not hit the external host. This patch only fixes the persistent state of the JSON field.

I have ~30k imported recipes; on roughly half of them, `recipe.json#image` was still an external URL pointing to all sorts of food blogs. Cleaning them up after the fact was a one-shot script, but new imports keep reintroducing the divergence — hence this fix at the source.

## Test plan

- [ ] Import a recipe from a URL with an image (e.g. any recipe blog with a JSON-LD `image` field). Confirm `full.jpg` exists in the recipe folder.
- [ ] Open the imported recipe in edit mode. Confirm the *Image* field shows a path like `/Recipes/<Recipe Name>/full.jpg`, not the original URL.
- [ ] Re-save the recipe without changes. Confirm no re-download happens (no outbound HTTP, image unchanged on disk).
- [ ] Change the image to a different URL in edit mode. Confirm the new URL is fetched and the field is again rewritten to a local path on save.
- [ ] Existing recipes with an unchanged URL in `image` are untouched (the new code runs only when image data is freshly fetched).