### PR TITLE
Add AvoCook to mobile clients list

### DIFF
--- a/.changelog/current/3148-update-readme.md
+++ b/.changelog/current/3148-update-readme.md
@@ -1,0 +1,4 @@
+# Maintenance
+
+- Update README and add AvoCook as possible client
+

--- a/docs/readme/clients/index.md
+++ b/docs/readme/clients/index.md
@@ -11,6 +11,7 @@ The currently available clients are in no particular order:
 | [Nextcloud Cookbook][lneugebauer-nextcloud-cookbook]   | [lneugebauer][]           | [<img src="img/f-droid.png" alt="Get it on F-Droid" height="50">][lneugebauer-nextcloud-cookbook-fdroid] [<img src="img/g-play.png" alt="Get it on Google Play" height="50">][lneugebauer-nextcloud-cookbook-play-store] |
 | [Cookbook Client][VincentMeilinger-nextcloud-cookbook] | [VincentMeilinger][]      | [<img src="img/ios-store.svg" alt="Download on the App Store" height="35">][VincentMeilinger-nextcloud-cookbook-ios-app-store]                                                                                           |
 | [Cookbook][joj0r-nextcloud-cookbook]                   | [Jonas Stene][joj0r]      | [<img src="img/open-store.svg" alt="Download from the OpenStore" height="35">][joj0r-nextcloud-cookbook-open-store]                                                                                                      |
+| [AvoCook][logarex-avocook]                             | [Logarex][logarex]        | [<img src="img/ios-store.svg" alt="Download on the App Store" height="35">][logarex-avocook-ios-app-store] [GitHub Releases (APK)][logarex-avocook-apk] |
 
 
 <!-- References -->
@@ -43,6 +44,12 @@ The currently available clients are in no particular order:
 [joj0r]: <https://github.com/joj0r>
 [joj0r-nextcloud-cookbook]: <https://github.com/joj0r/UT_Cookbook> (Cookbook)
 [joj0r-nextcloud-cookbook-open-store]: <https://next.open-store.io/app/cookbook.stene/> (Nextcloud Cookbook OpenStore)
+
+<!-- Logarex -->
+[logarex]: <https://github.com/Logarex>
+[logarex-avocook]: <https://github.com/Logarex/AvoCook> (AvoCook)
+[logarex-avocook-ios-app-store]: <https://apps.apple.com/app/avocook/id6769012665> (AvoCook iOS App Store)
+[logarex-avocook-apk]: <https://github.com/Logarex/AvoCook/releases/latest> (AvoCook Android APK)
 
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

This PR adds **AvoCook** to the README's list of available mobile applications. 

AvoCook is a new cross-platform mobile client for Nextcloud Cookbook built with Expo/React Native. It supports iOS (via App Store) and Android (via APK on GitHub Releases). Key features include:
- Direct Nextcloud server connection via app password.
- Offline mode with local SQLite storage.
- Synchronization queue for creations/edits while offline.
- Recipe parsing and imports (JSON-LD schema.org).

## Concerns/issues

None. This is purely a documentation update to add a new community client. No code or API changes were made.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change