### PR TITLE
Fix SSRF: don't fall back to unguarded file_get_contents() on recipe image download

### DIFF
--- a/.changelog/current/3254-ssrf-for-images.md
+++ b/.changelog/current/3254-ssrf-for-images.md
@@ -1,0 +1,4 @@
+# Fixes
+
+- Prevent local access on network when downloading images
+

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -287,8 +287,15 @@ class RecipeService {
 					try {
 						$full_image_data = $this->downloadImage($json['image']);
 					} catch (Exception $ex) {
-						$this->logger->warning('Failed to download an image using curl. Falling back to PHP default behavior.');
-						$full_image_data = file_get_contents($json['image']);
+						// SECURITY: do not fall back to an unguarded fetch here.
+						// downloadImage() deliberately blocks local/internal addresses
+						// (SSRF protection via allow_local_address => false and
+						// LocalServerException). Falling back to file_get_contents()
+						// would re-issue the very request that protection just rejected,
+						// letting a recipe's "image" URL reach localhost / link-local /
+						// cloud-metadata endpoints. Fail closed and skip the image.
+						$this->logger->warning('Failed to download recipe image from URL; skipping image.', ['exception' => $ex]);
+						$full_image_data = null;
 					}
 
 				} else {


### PR DESCRIPTION
## Fix SSRF: don't fall back to unguarded `file_get_contents()` on image download failure

### Problem
When a recipe's `image` field is an `http(s)` URL, `RecipeService::addRecipe()` fetches it through `downloadImage()` → `DownloadHelper`, which sets `allow_local_address => false` and throws `LocalServerException` for localhost / link-local / internal targets (SSRF protection). The `catch` block then re-issued the **same** request with an unguarded `file_get_contents()`:

```php
try {
    $full_image_data = $this->downloadImage($json['image']);
} catch (Exception $ex) {
    $this->logger->warning('Failed to download an image using curl. Falling back to PHP default behavior.');
    $full_image_data = file_get_contents($json['image']);   // SSRF protection bypassed
}
```

A request the SSRF guard had just rejected simply became an unprotected one, so a recipe `image` URL could reach `http://127.0.0.1`, `169.254.169.254` (cloud metadata) and other internal services, with the response stored as the recipe image (readable back via the image endpoint). Any logged-in user can create/update recipes (`RecipeController::create`/`update` are `#[NoAdminRequired]`). The `image` field is never run through the `isDownloadUrlValid()` guard that the import-by-URL path uses.

### Fix
Fail closed: on download failure, log and skip the image instead of refetching it unguarded.

### Testing (reproduced live on a Nextcloud 35 instance)
- Created a recipe with `"image":"http://127.0.0.1:<port>/secret"` pointing at a local listener.
- **Before:** the listener received the request (empty `User-Agent`, i.e. `file_get_contents`, not the SSRF-safe client) → SSRF confirmed.
- **After the fix:** the listener receives **no** request; the image is skipped.

*🤖 Disclosure: prepared by Claude Code – Opus 4.8 (xhigh)*
