### PR TITLE
Replace #r/<id> reference text with a link icon in recipe links

### DIFF
--- a/src/js/title-rename.js
+++ b/src/js/title-rename.js
@@ -63,7 +63,7 @@ function insertMarkdownLinks(content, recipes) {
         // const re = /(^|\s|[,._+&?!-])#r\/(\d+)(?=$|\s|[.,_+&?!-])/g
         ret = ret.replace(
             rePlain,
-            `$1[${r.name} (\\#r/${id})](${getRecipeUrl(id)})$2`,
+            `$1[${r.name} 🔗](${getRecipeUrl(id)})$2`,
         );
     });
     return ret;


### PR DESCRIPTION
Closes #3068

Replaces the raw `(#r/<id>)` reference text in recipe links with a 🔗 icon, so links now show as `Recipe Name 🔗` instead of `Recipe Name (#r/1199682)`.`

- Updated `src/js/title-rename.js`