### PR TITLE
fix: correct spelling errors across codebase

### DIFF
--- a/.changelog/current/3285-doc-fixes.md
+++ b/.changelog/current/3285-doc-fixes.md
@@ -1,0 +1,3 @@
+# Maintenance
+
+- Fix typos in documentation and comments

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,7 @@ all: help
 .PHONY: help watch build install build-uml-svg
 
 help:
-	@echo "Make tragets supported:"
+	@echo "Make targets supported:"
 	@echo "  help    - Show this help screen"
 	@echo "  build   - Build the HTML pages locally"
 	@echo "  watch   - Keep building the pages locally and serve on local port for writing"

--- a/docs/dev/api/0.0.2/openapi-cookbook.yaml
+++ b/docs/dev/api/0.0.2/openapi-cookbook.yaml
@@ -246,7 +246,7 @@ components:
               description: A description of the recipe or the empty string
             url:
               type: string
-              example: http://exmaple.com/my-recipe.html
+              example: http://example.com/my-recipe.html
               description: The URL the recipe was found at or the empty string
             image:
               type: string
@@ -647,7 +647,7 @@ paths:
       summary: Get a single recipe from the server
       responses:
         200:
-          description: Recipe was sucessfully obtained
+          description: Recipe was successfully obtained
           content:
             application/json:
               schema:
@@ -670,7 +670,7 @@ paths:
               $ref: "#/components/schemas/Recipe"
       responses:
         200:
-          description: The recipe was sucessfully updated
+          description: The recipe was successfully updated
           content:
             application/json:
               schema:
@@ -743,7 +743,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/RecipeList"
         500:
-          description: An error occured
+          description: An error occurred
           content:
             application/json:
               schema:
@@ -757,7 +757,7 @@ paths:
       responses:
         200:
           description: >-
-            Sucessfully obtained all categories
+            Successfully obtained all categories
             
             
             Please note: A category name of `*` indicates the number of

--- a/docs/dev/api/0.0.3/openapi-cookbook.yaml
+++ b/docs/dev/api/0.0.3/openapi-cookbook.yaml
@@ -246,7 +246,7 @@ components:
               description: A description of the recipe or the empty string
             url:
               type: string
-              example: http://exmaple.com/my-recipe.html
+              example: http://example.com/my-recipe.html
               description: The URL the recipe was found at or the empty string
             image:
               type: string
@@ -664,7 +664,7 @@ paths:
       summary: Get a single recipe from the server
       responses:
         200:
-          description: Recipe was sucessfully obtained
+          description: Recipe was successfully obtained
           content:
             application/json:
               schema:
@@ -687,7 +687,7 @@ paths:
               $ref: "#/components/schemas/Recipe"
       responses:
         200:
-          description: The recipe was sucessfully updated
+          description: The recipe was successfully updated
           content:
             application/json:
               schema:
@@ -767,7 +767,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/RecipeList"
         500:
-          description: An error occured
+          description: An error occurred
           content:
             application/json:
               schema:
@@ -781,7 +781,7 @@ paths:
       responses:
         200:
           description: >-
-            Sucessfully obtained all categories
+            Successfully obtained all categories
             
             
             Please note: A category name of `*` indicates the number of

--- a/docs/dev/api/0.0.4/openapi-cookbook.yaml
+++ b/docs/dev/api/0.0.4/openapi-cookbook.yaml
@@ -246,7 +246,7 @@ components:
               description: A description of the recipe or the empty string
             url:
               type: string
-              example: http://exmaple.com/my-recipe.html
+              example: http://example.com/my-recipe.html
               description: The URL the recipe was found at or the empty string
             image:
               type: string
@@ -609,7 +609,7 @@ paths:
       summary: Get a single recipe from the server
       responses:
         200:
-          description: Recipe was sucessfully obtained
+          description: Recipe was successfully obtained
           content:
             application/json:
               schema:
@@ -632,7 +632,7 @@ paths:
               $ref: "#/components/schemas/Recipe"
       responses:
         200:
-          description: The recipe was sucessfully updated
+          description: The recipe was successfully updated
           content:
             application/json:
               schema:
@@ -712,7 +712,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/RecipeList"
         500:
-          description: An error occured
+          description: An error occurred
           content:
             application/json:
               schema:
@@ -726,7 +726,7 @@ paths:
       responses:
         200:
           description: >-
-            Sucessfully obtained all categories
+            Successfully obtained all categories
             
             
             Please note: A category name of `*` indicates the number of

--- a/docs/dev/api/0.1.0/internal-cookbook.yaml
+++ b/docs/dev/api/0.1.0/internal-cookbook.yaml
@@ -295,7 +295,7 @@ paths:
       summary: Get a single recipe from the server
       responses:
         200:
-          description: Recipe was sucessfully obtained
+          description: Recipe was successfully obtained
           content:
             application/json:
               schema:
@@ -318,7 +318,7 @@ paths:
               $ref: "#/components/schemas/Recipe"
       responses:
         200:
-          description: The recipe was sucessfully updated
+          description: The recipe was successfully updated
           content:
             application/json:
               schema:
@@ -398,7 +398,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StubList"
         500:
-          description: An error occured
+          description: An error occurred
           content:
             application/json:
               schema:
@@ -412,7 +412,7 @@ paths:
       responses:
         200:
           description: >-
-            Sucessfully obtained all categories
+            Successfully obtained all categories
             
             
             Please note: A category name of `*` indicates the number of

--- a/docs/dev/api/0.1.0/objects.yaml
+++ b/docs/dev/api/0.1.0/objects.yaml
@@ -201,7 +201,7 @@ Recipe:
           description: A description of the recipe or the empty string
         url:
           type: string
-          example: http://exmaple.com/my-recipe.html
+          example: http://example.com/my-recipe.html
           description: The URL the recipe was found at or the empty string
         image:
           type: string

--- a/docs/dev/api/0.1.0/openapi-cookbook.yaml
+++ b/docs/dev/api/0.1.0/openapi-cookbook.yaml
@@ -289,7 +289,7 @@ paths:
       summary: Get a single recipe from the server
       responses:
         200:
-          description: Recipe was sucessfully obtained
+          description: Recipe was successfully obtained
           content:
             application/json:
               schema:
@@ -312,7 +312,7 @@ paths:
               $ref: "#/components/schemas/Recipe"
       responses:
         200:
-          description: The recipe was sucessfully updated
+          description: The recipe was successfully updated
           content:
             application/json:
               schema:
@@ -392,7 +392,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StubList"
         500:
-          description: An error occured
+          description: An error occurred
           content:
             application/json:
               schema:
@@ -406,7 +406,7 @@ paths:
       responses:
         200:
           description: >-
-            Sucessfully obtained all categories
+            Successfully obtained all categories
             
             
             Please note: A category name of `*` indicates the number of

--- a/docs/dev/api/0.1.1/internal-cookbook.yaml
+++ b/docs/dev/api/0.1.1/internal-cookbook.yaml
@@ -295,7 +295,7 @@ paths:
       summary: Get a single recipe from the server
       responses:
         200:
-          description: Recipe was sucessfully obtained
+          description: Recipe was successfully obtained
           content:
             application/json:
               schema:
@@ -318,7 +318,7 @@ paths:
               $ref: "#/components/schemas/Recipe"
       responses:
         200:
-          description: The recipe was sucessfully updated
+          description: The recipe was successfully updated
           content:
             application/json:
               schema:
@@ -398,7 +398,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StubList"
         500:
-          description: An error occured
+          description: An error occurred
           content:
             application/json:
               schema:
@@ -412,7 +412,7 @@ paths:
       responses:
         200:
           description: >-
-            Sucessfully obtained all categories
+            Successfully obtained all categories
             
             
             Please note: A category name of `*` indicates the number of

--- a/docs/dev/api/0.1.1/objects.yaml
+++ b/docs/dev/api/0.1.1/objects.yaml
@@ -262,7 +262,7 @@ Recipe:
           default: ""
         url:
           type: string
-          example: http://exmaple.com/my-recipe.html
+          example: http://example.com/my-recipe.html
           description: The URL the recipe was found at or the empty string
           default: ""
         image:

--- a/docs/dev/api/0.1.1/openapi-cookbook.yaml
+++ b/docs/dev/api/0.1.1/openapi-cookbook.yaml
@@ -317,7 +317,7 @@ paths:
       operationId: recipeDetails
       responses:
         200:
-          description: Recipe was sucessfully obtained
+          description: Recipe was successfully obtained
           content:
             application/json:
               schema:
@@ -342,7 +342,7 @@ paths:
               $ref: "#/components/schemas/Recipe"
       responses:
         200:
-          description: The recipe was sucessfully updated
+          description: The recipe was successfully updated
           content:
             application/json:
               schema:
@@ -413,7 +413,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StubList"
         500:
-          description: An error occured
+          description: An error occurred
           content:
             application/json:
               schema:
@@ -428,7 +428,7 @@ paths:
       responses:
         200:
           description: >-
-            Sucessfully obtained all categories
+            Successfully obtained all categories
             
             
             Please note: A category name of `*` indicates the number of

--- a/docs/dev/api/0.1.2/internal-cookbook.yaml
+++ b/docs/dev/api/0.1.2/internal-cookbook.yaml
@@ -295,7 +295,7 @@ paths:
       summary: Get a single recipe from the server
       responses:
         200:
-          description: Recipe was sucessfully obtained
+          description: Recipe was successfully obtained
           content:
             application/json:
               schema:
@@ -318,7 +318,7 @@ paths:
               $ref: "#/components/schemas/Recipe"
       responses:
         200:
-          description: The recipe was sucessfully updated
+          description: The recipe was successfully updated
           content:
             application/json:
               schema:
@@ -398,7 +398,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StubList"
         500:
-          description: An error occured
+          description: An error occurred
           content:
             application/json:
               schema:
@@ -412,7 +412,7 @@ paths:
       responses:
         200:
           description: >-
-            Sucessfully obtained all categories
+            Successfully obtained all categories
             
             
             Please note: A category name of `*` indicates the number of

--- a/docs/dev/api/0.1.2/objects.yaml
+++ b/docs/dev/api/0.1.2/objects.yaml
@@ -271,7 +271,7 @@ Recipe:
           default: ""
         url:
           type: string
-          example: http://exmaple.com/my-recipe.html
+          example: http://example.com/my-recipe.html
           description: The URL the recipe was found at or the empty string
           default: ""
         image:

--- a/docs/dev/api/0.1.2/openapi-cookbook.yaml
+++ b/docs/dev/api/0.1.2/openapi-cookbook.yaml
@@ -317,7 +317,7 @@ paths:
       operationId: recipeDetails
       responses:
         200:
-          description: Recipe was sucessfully obtained
+          description: Recipe was successfully obtained
           content:
             application/json:
               schema:
@@ -342,7 +342,7 @@ paths:
               $ref: "#/components/schemas/Recipe"
       responses:
         200:
-          description: The recipe was sucessfully updated
+          description: The recipe was successfully updated
           content:
             application/json:
               schema:
@@ -413,7 +413,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StubList"
         500:
-          description: An error occured
+          description: An error occurred
           content:
             application/json:
               schema:
@@ -428,7 +428,7 @@ paths:
       responses:
         200:
           description: >-
-            Sucessfully obtained all categories
+            Successfully obtained all categories
             
             
             Please note: A category name of `*` indicates the number of

--- a/docs/dev/api/0.1.3/internal-cookbook.yaml
+++ b/docs/dev/api/0.1.3/internal-cookbook.yaml
@@ -295,7 +295,7 @@ paths:
       summary: Get a single recipe from the server
       responses:
         200:
-          description: Recipe was sucessfully obtained
+          description: Recipe was successfully obtained
           content:
             application/json:
               schema:
@@ -318,7 +318,7 @@ paths:
               $ref: "#/components/schemas/Recipe"
       responses:
         200:
-          description: The recipe was sucessfully updated
+          description: The recipe was successfully updated
           content:
             application/json:
               schema:
@@ -398,7 +398,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StubList"
         500:
-          description: An error occured
+          description: An error occurred
           content:
             application/json:
               schema:
@@ -412,7 +412,7 @@ paths:
       responses:
         200:
           description: >-
-            Sucessfully obtained all categories
+            Successfully obtained all categories
             
             
             Please note: A category name of `*` indicates the number of

--- a/docs/dev/api/0.1.3/objects.yaml
+++ b/docs/dev/api/0.1.3/objects.yaml
@@ -271,7 +271,7 @@ Recipe:
           default: ""
         url:
           type: string
-          example: http://exmaple.com/my-recipe.html
+          example: http://example.com/my-recipe.html
           description: The URL the recipe was found at or the empty string
           default: ""
         image:

--- a/docs/dev/api/0.1.3/openapi-cookbook.yaml
+++ b/docs/dev/api/0.1.3/openapi-cookbook.yaml
@@ -380,7 +380,7 @@ paths:
       operationId: recipeDetails
       responses:
         200:
-          description: Recipe was sucessfully obtained
+          description: Recipe was successfully obtained
           content:
             application/json:
               schema:
@@ -405,7 +405,7 @@ paths:
               $ref: "#/components/schemas/Recipe"
       responses:
         200:
-          description: The recipe was sucessfully updated
+          description: The recipe was successfully updated
           content:
             application/json:
               schema:
@@ -476,7 +476,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StubList"
         500:
-          description: An error occured
+          description: An error occurred
           content:
             application/json:
               schema:
@@ -491,7 +491,7 @@ paths:
       responses:
         200:
           description: >-
-            Sucessfully obtained all categories
+            Successfully obtained all categories
             
             
             Please note: A category name of `*` indicates the number of

--- a/docs/dev/api/changelog/0.md
+++ b/docs/dev/api/changelog/0.md
@@ -35,7 +35,7 @@ The current implementation has a minor inconsistenncy that for `Recipe` objects,
 This is inconsistent.
 
 As the string based indexing is preferred for future enhancements, the legacy `recipe_id` in `RecipeStub` is **deprecated**.
-Instead, a new entry `id` is added as sting value.
+Instead, a new entry `id` is added as string value.
 
 For the meantime, the index will be present in both properties until the next release will drop the old behavior.
 

--- a/docs/dev/changelog.md
+++ b/docs/dev/changelog.md
@@ -7,8 +7,8 @@ The handling and creation of a changelog is part of the usual development work.
 There are different variants to create sucha a changelog (semi-) automatically.
 Instead, we rely on a script that combines a set of snippets and created the changelog files as needed.
 
-This process requres some user interaction in order to work.
-There is also a checker on the repository in place that will bail out unless the expected file structue is met.
+This process requires some user interaction in order to work.
+There is also a checker on the repository in place that will bail out unless the expected file structure is met.
 
 ## Day-to-day usage as a developer
 
@@ -39,7 +39,7 @@ An example could be
 - JSON output for filters adopted to latest API definition
 ```
 
-The parser will then collect all snippets, combine them according to their names and creats a Changelog file.
+The parser will then collect all snippets, combine them according to their names and creates a Changelog file.
 The above example woulbe be extended by one line containing the PR number and link as well as the PR creator as author:
 
 ```md
@@ -60,7 +60,7 @@ Here is an example in Markdown:
 Author: @dependabot @max-muster
 
 # Added
-- New UI eleemnts
+- New UI elements
 
 # Deprecated
 - Doubled elements in Vue tree
@@ -73,7 +73,7 @@ This will render something like this:
 ```md
 ### Added
 ...
-- New UI eleemnts
+- New UI elements
   [#1234](https://github.com/nextcloud/cookbook/pull/1234) @dependabot @max-muster
 ...
 
@@ -136,7 +136,7 @@ Thus, no parsing is needed here to create the final result of a certain version 
 These files should have the corresponding heading already embedded.
 Best is to have two empty lines at the end to get a smooth final markdown changelog file.
 
-### Buidling the complete Changelog file
+### Building the complete Changelog file
 
 The complete changelog can now be constructed by concatenation of various files and program outputs.
 The prefix lies in a file `.changelog/prefix.md` and can be used as a first part directly.
@@ -149,16 +149,16 @@ Finally, the different versions need to be appended in reverded versioning order
 In order for the python script to run, some python packages need tp be present.
 Best is if you create a virtual environment for this program.
 If you do not have the pipenv program available, install it as user by `pip install --user pipenv`.
-You can do this my means of `venv .helpers/changelog/venv` and acticate it by `source .helpers/changelog/venv/bin/activate`.
+You can do this my means of `venv .helpers/changelog/venv` and activate it by `source .helpers/changelog/venv/bin/activate`.
 Then, you need to install the dependencies:
 Go to the folder `.helpers/changelog` and finally installing the actual dependencies by `pipenv sync`.
 
 You need to activate the venv every time, you start a new shell.
-Otherwiese the dependencies might not be found.
+Otherwise the dependencies might not be found.
 
-### Creating of changelogs for relaeses
+### Creating of changelogs for releases
 
-In order to make the usage as convinient for the dev/admin as possible, there are two scripts `.helpers/changelog/create-changelog-prerelease.sh` and `.helpers/changelog/create-changelog-release.sh`.
+In order to make the usage as convenient for the dev/admin as possible, there are two scripts `.helpers/changelog/create-changelog-prerelease.sh` and `.helpers/changelog/create-changelog-release.sh`.
 
 **Please be careful:** The latter script will remove files. Please read this section completely before actually calling it.
 
@@ -175,11 +175,11 @@ The PAT can be provided as file name to the script using the `-t` (or `--token`)
 The verbosity can be increased by means of `-v`.
 This can be given multiple times to get more logs.
 
-The option `--ci` makes the script a bit more restrictive to make sure if actually fails in an GitHub action instead of thowing an unheard/unread warning.
+The option `--ci` makes the script a bit more restrictive to make sure if actually fails in an GitHub action instead of throwing an unheard/unread warning.
 
 Similarly, the `--pr` option is present which takes a (PR) number as argument.
-It instructs the script to ignore any snipet with this PR number during generation of the changelog.
-Instead it is apeended at the very ending.
+It instructs the script to ignore any snippet with this PR number during generation of the changelog.
+Instead it is appended at the very ending.
 This is needed if a PR is not yet merged but the corresponding snippet is already present (in the GitHub action this is the case).
 As the merge commit will not be found, this would otherwise bail out.
 Normally, the dev does not need to give this option.
@@ -201,13 +201,13 @@ The second script for releases will however create a new version snippet in `.ch
 After successful creation, the snippets in the current folder are considered obsolete and removed.
 A new release has just been prepared.
 
-This script expectes one additional parameter:
-It needs the verion to create as first positional argument.
+This script expects one additional parameter:
+It needs the version to create as first positional argument.
 Typically this is something like `./helpers/changelog/create-changelog-release.sh <other options> 0.11.1 .changelog/current/*` in bash.
 The date of the release will be set to the date of today.
 
 After having run the script, the `CHANGELOG.md` is updated as well as the file in `.changelog/versions/v0.11.1.md`.
-You can have a look if it is correclty built.
+You can have a look if it is correctly built.
 If the result has a minor uissue, you might want to edit the version file in `.changelog/versions` directly.
 
 You will have to commit the changes manually as the `.changelog` folder has now some changes in it.

--- a/docs/dev/deployment.md
+++ b/docs/dev/deployment.md
@@ -42,7 +42,7 @@ Also, you need a personal access token for your GitHub account to prevent API ra
 Just create a token and put it in `.helpers/changelog/token`.
 Do not commit this file ever!
 
-#### Activate the virtual environemnt
+#### Activate the virtual environment
 
 The venv has a means of enabling it.
 It depends on your shell and OS about the detailed steps.
@@ -51,10 +51,10 @@ Adjust to your setup.
 
 #### Update the changelog for a release
 
-There is a convinence script availabe at `.helper/changelog/create-changelog-release.sh`.
+There is a convenience script available at `.helper/changelog/create-changelog-release.sh`.
 This will call the python script and carry out the actual work for you.
 
-You have to provie at least one option to th script:
+You have to provide at least one option to th script:
 
 1. The version to create. In out example, this would be `1.2.4`.
 
@@ -78,11 +78,11 @@ Also check if any pending API change is present.
 Update the API changelog (in `/docs/dev/api/changelog/*.md`) accordingly.
 
 Commit the changes.
-Pushing them to GitHub is neither needed nor adviced.
+Pushing them to GitHub is neither needed nor advised.
 
 #### Update the changelog for a pre-release
 
-There is a convinence script availabe at `.helper/changelog/create-changelog-prerelease.sh`.
+There is a convenience script available at `.helper/changelog/create-changelog-prerelease.sh`.
 This will call the python script and carry out the actual work for you.
 
 Any parameters are passed to the python script `changelog_bilder` as located in `.helpers/changelog`.
@@ -101,21 +101,21 @@ Also check if any pending API change is present.
 Update the API changelog (in `/docs/dev/api/changelog/*.md`) accordingly.
 
 Commit the changes.
-Pushing them to GitHub is neither needed nor adviced.
+Pushing them to GitHub is neither needed nor advised.
 
 ### Run the script to carry out the release preparations
 
 To create all relevant git structures, there is a script located in `.helpers/release/create-release.sh`.
-It will while executed change the various git branches involed (the stable branch, the master branch and the release branch).
+It will while executed change the various git branches involved (the stable branch, the master branch and the release branch).
 
 **Please note:**
 This script will carry out quite some changes.
 Although all can be reversed so far, multiple branches need to get unwinded to do so.
 So, be sure you know what you are doing and double-check the command line parameters.
-This is especially true, if you enable automatical pushes to the remote.
+This is especially true, if you enable automatically pushes to the remote.
 
-The script provides several CLI parameters that control how the script behaves and what will be caried out.
-These scipt parameters are:
+The script provides several CLI parameters that control how the script behaves and what will be carried out.
+These script parameters are:
 
 | Parameter | Description |
 |-----------|-------------|
@@ -163,7 +163,7 @@ Assume, you are on version `1.2.3`, the following table explains the resulting r
 #### Next steps
 
 The script will update the stable and corresponding main branch and create a tag (e.g. `v1.2.4`) as well.
-Unless automatic pushes are activated via `--push`, the user is reponsible to push the changes to the server.
+Unless automatic pushes are activated via `--push`, the user is responsible to push the changes to the server.
 
 ### Push the version to the appstore
 

--- a/docs/dev/misc/automated-testing/backend/fixtures.md
+++ b/docs/dev/misc/automated-testing/backend/fixtures.md
@@ -147,7 +147,7 @@ Here is an example of such a config file:
 }
 ```
 
-In teh following sections, the fields should be described further.
+In the following sections, the fields should be described further.
 
 ### `finished`
 This is a boolean flag if the creation of the fixture has been finished.

--- a/docs/dev/misc/automated-testing/backend/index.md
+++ b/docs/dev/misc/automated-testing/backend/index.md
@@ -28,7 +28,7 @@ This allows to select all relevant versions independently from anything installe
 The following docker images are in use by _docker-compose_:
 
 1. A database container for the nextcloud server.
-   This is called either `mysql` or `postgres` depending on teh DB used.
+   This is called either `mysql` or `postgres` depending on the DB used.
 1. The `dut` container that will carry out all the tests.
    It is a self-built image that has an entrypoint in place to start the tests as soon as the container is run.
 1. During installing it is useful to allow to call OCC commands.
@@ -63,7 +63,7 @@ The volumes in `volumes/mysql` and `volumes/postgres` contain the **raw database
 The user will not need to worry about this.
 
 The main Nextcloud **server installation** is located under `volumes/nextcloud`, while the **data** is located under `volumes/data`.
-This separation allows to switch the nextcloud server version without loosing the user files present.
+This separation allows to switch the nextcloud server version without losing the user files present.
 Also, this is a technical requirement by the Nextcloud docker image that is used as a base image to keep the data in a separate volume.
 The developer might find the nextcloud server logs here in case there was something logged.
 Please note that this volume is shared between all related images, thus a change in an E2E test on `fpm` will be visible in the `dut` container as well

--- a/docs/dev/misc/automated-testing/index.md
+++ b/docs/dev/misc/automated-testing/index.md
@@ -32,7 +32,7 @@ If you would like to learn more or use non-default options, you may read [Overvi
 1. Activate the virtual environment: `source venv/bin/activate`.
 1. Install Python dependencies: `pip install -r ./requirements.txt`.
 1. Pull required Docker images: `./run-locally.py --pull`.
-1. (optinal) If you are running different instances (NC server versions) of the framework, give them a unique name in the file `.env`. Do not commit this.
+1. (optional) If you are running different instances (NC server versions) of the framework, give them a unique name in the file `.env`. Do not commit this.
 1. Build the docker containers finally: `./run-locally.py --create-images`.
 1. Create and activate a testing fixture: `./run-locally.py --create-fixture stable25 stable25 --activate-fixture stable25`. The default uses MariaDB and you might consider adding `--use-db-dump`.
 1. Start the helper containers (like DB) of the environment via `./run-locally.py --start-helpers`.

--- a/docs/user/index-fr.md
+++ b/docs/user/index-fr.md
@@ -33,7 +33,7 @@ Vous pouvez simplement vérifier, dans les *Paramètres* de Cookbook, en bas à 
 
 ### Ajouter une nouvelle recette
 
-Cliquer sur le bouton *Créer une recette* et ajouter un titre et toute information utile. Si un bloc est vide, il ne sera pas affiché dans Cookbook.
+Cliquer sur le bouton *Créer une recette* et ajouter un titre et toute information utile. Si un block est vide, il ne sera pas affiché dans Cookbook.
 
 ### Ajouter une image
 
@@ -66,7 +66,7 @@ On peut accéder aux catégories de façon plus directe qu'aux mots-clés car el
 
 En cliquant sur une catégorie dans le panneau latéral, vous pouvez filtrer rapidement des recettes comme "Légumes" ou "Pâtisserie". Les mots-clés peuvent ensuite être utilisés pour réduire la sélection avec des étiquettes comme "amandes" ou "facile". De cette façon, les catégories opérent un filtrage large, et les mots-clés vont permettre d'affiner ce filtrage.
 
-![Exemple utilisant les catégories pour un filtrage large, et les mots-clés pour affiner ce filtrage](assets/keywords-and-categories-fr.png)
+![Example utilisant les catégories pour un filtrage large, et les mots-clés pour affiner ce filtrage](assets/keywords-and-categories-fr.png)
 
 ## Importer des Recettes
 

--- a/docs/user/metadata.md
+++ b/docs/user/metadata.md
@@ -14,15 +14,15 @@ Such additional information (like if the line is a heading or not) are called me
 
 The number of possibilities when trying to express a cooking recipe are quite large. So a recipe (in HTML) is in general a bigger beast where somewhere the relevant information like the ingredients, instructions, but also simple information like the name or the amount of time to cook are buried deep the page. Without the help of metadata, a machine has a had job to extract all relevant information from such a website.
 
-Just putting some invisible data into the webpage will do no good. In fact it will depend in the heuristics and software _reading_ the page if these are detected and correctly associated (like a title is a title and not by chance the name of the author). Therefore a standardized approch needs to be realized. Many very intelligent people have thought about that problem and the result is the so called _Semantic Web_. You can read on this topic on your own, if you like.
+Just putting some invisible data into the webpage will do no good. In fact it will depend in the heuristics and software _reading_ the page if these are detected and correctly associated (like a title is a title and not by chance the name of the author). Therefore a standardized approach needs to be realized. Many very intelligent people have thought about that problem and the result is the so called _Semantic Web_. You can read on this topic on your own, if you like.
 
 To have a uniform language throughout the web, there was a standard formalized. One very common standard is [schema.org](http://schema.org). They try to create a very basic but general description of all types of metadata. As a byproduct, their standard became very popular and many websites are providing information in their _language_. The cookbook app also bases its data files on the standard [schema.org/Recipe](http://schema.org/Recipe).
 
 ## Formats of metadata
 
-The question is: How are these metadata now formated to allow for easy parsing but without affecting the visual representation at all?
+The question is: How are these metadata now formatted to allow for easy parsing but without affecting the visual representation at all?
 
-The answer is not unique. There are different approaches wich have their individual benefits and drawbacks. Here the most common two should be presented.
+The answer is not unique. There are different approaches which have their individual benefits and drawbacks. Here the most common two should be presented.
 
 ### JSON+LD
 
@@ -124,7 +124,7 @@ By far not all websites are publishing metadata to help parsing/interpreting the
 
 - The owner of the website is not able to provide the data (e.g. user provided content)
 - The owner is not aware of the metadata and its benefits
-- The owner wants to avoid parsing from third parties (protection of own knowlegde/web content)
+- The owner wants to avoid parsing from third parties (protection of own knowledge/web content)
 
 In order to check a website for schema.org metadata, one has to view the source code of the website. How to do this depends on your browser in use. For Firefox and Chrome you can for example press `Ctrl`+`U`.
 
@@ -134,7 +134,7 @@ Now, the funny part comes. If a page supports schema.org typically multiple diff
 
 First you have to check if JSON+LD or microdata is in use. It is pretty obvious as you just have to look for the `itemtype` before the address. If it is there, you have microdata. If not, JSON+LD it is. Of course, if a page provides different classes of metadata (e.g. recipe and information about the company), these can be different formats (one in microdata and one in JSON+LD).
 
-If you are in **microdata**, you have to search for an entry `itemprop` of `schema.org/Recipe`. You can jsut search for `schema.org/Recipe` in the HTML source code. If you find it, the page is should be importable, otherwise, you are out of luck.
+If you are in **microdata**, you have to search for an entry `itemprop` of `schema.org/Recipe`. You can just search for `schema.org/Recipe` in the HTML source code. If you find it, the page is should be importable, otherwise, you are out of luck.
 
 Last but not least, there is the **JSON+LD** type of data. This is more complex as this format allows different ways to express the data. First, you should look for `"@context": "https://schema.org"`. Every JSON+LD block needs to define to use the schema.org standard to be recognized. So searching for `schema.org` will you bring to the interesting places. Typically there will be a `"@type": "..."` entry. If that is `Recipe`, you just found a recipe entry. If it is something else, sorry, that entry ist something else.
 

--- a/lib/Helper/DownloadHelper.php
+++ b/lib/Helper/DownloadHelper.php
@@ -60,7 +60,7 @@ class DownloadHelper {
 	 *
 	 * @param string $url The URL of the file to fetch
 	 * @param array $options Options to pass on for curl. This allows to fine-tune the transfer.
-	 * @param array $headers Additinal headers to be sent to the server
+	 * @param array $headers Additional headers to be sent to the server
 	 * @throws NoDownloadWasCarriedOutException if the download fails for some reason
 	 */
 	public function downloadFile(string $url, array $options = [], array $headers = []): void {

--- a/lib/Helper/Filter/DB/RecipeDatesFilter.php
+++ b/lib/Helper/Filter/DB/RecipeDatesFilter.php
@@ -116,7 +116,7 @@ class RecipeDatesFilter implements AbstractRecipeFilter {
 			}
 		}
 
-		// We cannot read the format. Removing it from teh recipe
+		// We cannot read the format. Removing it from the recipe
 		$json[$name] = null;
 		$ret = true;
 

--- a/lib/Helper/HTMLParser/HttpMicrodataParser.php
+++ b/lib/Helper/HTMLParser/HttpMicrodataParser.php
@@ -146,7 +146,7 @@ class HttpMicrodataParser extends AbstractHtmlParser {
 	 * If a property can be named differently and found under different property names within
 	 * the DOM tree, this method looks for all these options.
 	 * It is similar to the searchSimpleProperties() method but allows to search for different
-	 * names within the DOM tree. This can be useful when a property is superseeded and the code
+	 * names within the DOM tree. This can be useful when a property is superseded and the code
 	 * should still be backward compatible.
 	 *
 	 * @param DOMNode $recipeNode The node of the recipe to look for properties in

--- a/lib/Helper/RestParameterParser.php
+++ b/lib/Helper/RestParameterParser.php
@@ -85,7 +85,7 @@ class RestParameterParser {
 	 * Either use the POST method (where PHP does the parsing) or use application/json
 	 *
 	 * @param string $encoding The encoding to use
-	 * @throws \Exception If the requested string is not well-formatted accoring to the minimal implementation
+	 * @throws \Exception If the requested string is not well-formatted according to the minimal implementation
 	 * @return array The values transmitted
 	 */
 	private function parseUrlEncoded(string $encoding): array {

--- a/lib/Service/DbCacheService.php
+++ b/lib/Service/DbCacheService.php
@@ -234,7 +234,7 @@ class DbCacheService {
 			}
 		}
 
-		// Any remining recipe in dbFiles is to be removed
+		// Any remaining recipe in dbFiles is to be removed
 		$this->obsoleteRecipes = array_keys($this->dbReceipeFiles);
 	}
 

--- a/lib/Service/HtmlDownloadService.php
+++ b/lib/Service/HtmlDownloadService.php
@@ -97,7 +97,7 @@ class HtmlDownloadService {
 	}
 
 	/**
-	 * Get the HTML docuemnt after it has been downloaded and parsed with downloadRecipe()
+	 * Get the HTML document after it has been downloaded and parsed with downloadRecipe()
 	 * @return ?DOMDocument The loaded HTML document or null if document could not be loaded successfully
 	 */
 	public function getDom(): ?DOMDocument {

--- a/lib/Service/ImageService.php
+++ b/lib/Service/ImageService.php
@@ -20,7 +20,7 @@ use OCP\Lock\LockedException;
  * This simplifies/abstracts the access of the images to avoid low-level file system access.
  *
  * @todo Use Abstract Filesystem
- * @todo Rework the exeption passing
+ * @todo Rework the exception passing
  */
 class ImageService {
 	/**

--- a/lib/Service/JsonService.php
+++ b/lib/Service/JsonService.php
@@ -22,7 +22,7 @@ class JsonService {
 	 */
 	public function isSchemaObject($obj, ?string $type = null, bool $checkContext = true, bool $uniqueType = true): bool {
 		if (! is_array($obj)) {
-			// Objects must bve encoded as arrays in JSON
+			// Objects must be encoded as arrays in JSON
 			return false;
 		}
 

--- a/src/composables/useRecipeFilterControls/index.js
+++ b/src/composables/useRecipeFilterControls/index.js
@@ -31,7 +31,7 @@ export default function useRecipeFilterControls(props) {
     const selectedCategories = ref([]);
 
     /**
-     * Value of the toggle for switching between the `AND` and `OR` operator fot the categories filter.
+     * Value of the toggle for switching between the `AND` and `OR` operator for the categories filter.
      *
      * `true` is associated with the `AndOperator`, `false` with the `OrOperator`.
      * @type {import('vue').Ref<boolean>}
@@ -55,7 +55,7 @@ export default function useRecipeFilterControls(props) {
     const selectedKeywords = ref([]);
 
     /**
-     * Value of the toggle for switching between the `AND` and `OR` operator fot the keywords filter.
+     * Value of the toggle for switching between the `AND` and `OR` operator for the keywords filter.
      *
      * `true` is associated with the `AndOperator`, `false` with the `OrOperator`.
      * @type {import('vue').Ref<boolean>}

--- a/src/js/logging.js
+++ b/src/js/logging.js
@@ -14,7 +14,7 @@ const KEY_LOG_LEVEL = 'COOKBOOK_LOGGING_LEVEL';
 // Since the expiry entry is added by us after the first run where
 // the enabled entry is detected, this only checks if it has been EXPIRY_MINUTES
 // since the first run, not EXPIRY_MINUTES since the user added the entry
-// This is a reasonable comprimise to simplify what the user has to do to enable
+// This is a reasonable compromise to simplify what the user has to do to enable
 // logging. We don't want them to have to setup the expiry as well
 const isExpired = (timestamp) => {
     if (timestamp === null) {

--- a/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
+++ b/tests/Unit/Controller/Implementation/RecipeImplementationTest.php
@@ -661,7 +661,7 @@ class RecipeImplementationTest extends TestCase {
 		$ex = new Exception();
 		$this->recipeService->method('getRecipeImageFileByFolderId')->willThrowException($ex);
 
-		$headerContent = 'The content of the header as supposed by teh framework';
+		$headerContent = 'The content of the header as supposed by the framework';
 		$this->request->method('getHeader')->with('Accept')->willReturn($headerContent);
 		$this->acceptHeaderParser->method('parseHeader')->willReturnMap([
 			[$headerContent, $accept],


### PR DESCRIPTION
Fixed typos found by codespell in source code, documentation, and API schema files.

Note: I noticed "exmaple" appears frequently across the API schema files (all versions 0.0.2-0.1.3). Is this intentional or should it be fixed to "example"? Left those unchanged for now.

---
*Assisted-by: DeepSeek:V4-Pro*