### PR TITLE
Use rebase strategy for dependabot merges

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -97,3 +97,4 @@ jobs:
           }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: REBASE

--- a/.github/workflows/dependabot-approve-merge.yml.patch
+++ b/.github/workflows/dependabot-approve-merge.yml.patch
@@ -1,5 +1,5 @@
 diff --git a/.github/workflows/dependabot-approve-merge.yml b/.github/workflows/dependabot-approve-merge.yml
-index 76340acb..e6cefab0 100644
+index 76340acb..a7a266cd 100644
 --- a/.github/workflows/dependabot-approve-merge.yml
 +++ b/.github/workflows/dependabot-approve-merge.yml
 @@ -11,9 +11,7 @@ name: Auto approve Dependabot PRs
@@ -12,3 +12,27 @@ index 76340acb..e6cefab0 100644
  
  permissions:
    contents: read
+@@ -99,3 +97,4 @@ jobs:
+           }}
+         with:
+           github-token: ${{ secrets.GITHUB_TOKEN }}
++          merge-method: REBASE
+diff --git a/.github/workflows/dependabot-approve-merge.yml.patch b/.github/workflows/dependabot-approve-merge.yml.patch
+index 6ebfa96b..e69de29b 100644
+--- a/.github/workflows/dependabot-approve-merge.yml.patch
++++ b/.github/workflows/dependabot-approve-merge.yml.patch
+@@ -1,14 +0,0 @@
+-diff --git a/.github/workflows/dependabot-approve-merge.yml b/.github/workflows/dependabot-approve-merge.yml
+-index 76340acb..e6cefab0 100644
+---- a/.github/workflows/dependabot-approve-merge.yml
+-+++ b/.github/workflows/dependabot-approve-merge.yml
+-@@ -11,9 +11,7 @@ name: Auto approve Dependabot PRs
+- on:
+-   pull_request_target: # zizmor: ignore[dangerous-triggers]
+-     branches:
+--      - main
+-       - master
+--      - stable*
+- 
+- permissions:
+-   contents: read


### PR DESCRIPTION
<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

This should bring back the default behavior to rebase dependabot PRs instead of merging them. This should simplify git history for simple dependency updates.

## Concerns/issues

One has to manually disable auto-merge per PR in case of more complex fixes. But this was the status quo in either case.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ ] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
