### PR TITLE
fix: shorten link symbol to other recipes

### DIFF
--- a/.changelog/current/3312-shorten-recipe-link-symbol.md
+++ b/.changelog/current/3312-shorten-recipe-link-symbol.md
@@ -1,0 +1,3 @@
+# Changed
+
+- Shorten the link symbol used when recipes reference other recipes

--- a/src/js/title-rename.js
+++ b/src/js/title-rename.js
@@ -65,10 +65,7 @@ function insertMarkdownLinks(content, recipes) {
             'g',
         );
         // const re = /(^|\s|[,._+&?!-])#r\/(\d+)(?=$|\s|[.,_+&?!-])/g
-        ret = ret.replace(
-            rePlain,
-            `$1[${r.name} 🔗](${getRecipeUrl(id)})$2`,
-        );
+        ret = ret.replace(rePlain, `$1[${r.name} 🔗](${getRecipeUrl(id)})$2`);
     });
     return ret;
 }

--- a/src/js/title-rename.js
+++ b/src/js/title-rename.js
@@ -67,7 +67,7 @@ function insertMarkdownLinks(content, recipes) {
         // const re = /(^|\s|[,._+&?!-])#r\/(\d+)(?=$|\s|[.,_+&?!-])/g
         ret = ret.replace(
             rePlain,
-            `$1[${r.name} (\\#r/${id})](${getRecipeUrl(id)})$2`,
+            `$1[${r.name} 🔗](${getRecipeUrl(id)})$2`,
         );
     });
     return ret;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Nextcloud cookbook contributors

SPDX-License-Identifier: AGPL-3.0-only OR AGPL-3.0-or-later
-->

## Topic and Scope

Shorten the link-to-other-recipes symbol so the UI is less noisy when recipes reference each other.

Fixes #3068

## Concerns/issues

None expected — presentation-only change to the link symbol.

## Formal requirements

- [x] I did check that the app can still be opened and does not throw any browser logs
- [x] I created tests for newly added PHP code (check this if no PHP changes were made)
- [x] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [x] I notified the matrix channel if I introduced an API change
