### PR TITLE
Fix the templates to not output REUSE information by accident

### DIFF
--- a/.changelog/current/3323-fix-templates.md
+++ b/.changelog/current/3323-fix-templates.md
@@ -1,0 +1,4 @@
+# Fixed
+
+- Prevent regression from #3305 to not show license information on web frontend
+

--- a/templates/index.php
+++ b/templates/index.php
@@ -1,5 +1,7 @@
+<?php
 // SPDX-FileCopyrightText: 2026 Nextcloud cookbook contributors
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
+?>
 
 <div id="app"></div>

--- a/templates/invalid_guest.php
+++ b/templates/invalid_guest.php
@@ -1,6 +1,8 @@
+<?php
 // SPDX-FileCopyrightText: 2026 Nextcloud cookbook contributors
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
+?>
 
 <div class="guest-box">
 	<div id="app"></div>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Nextcloud cookbook contributors

SPDX-License-Identifier: AGPL-3.0-only OR AGPL-3.0-or-later
-->

<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

This solves a regression introduced in #3305: Upon loading the app, for a blink the REUSE text is visible.

## Concerns/issues

None, pure hotfix

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ ] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
