### PR TITLE
Mark as compatible with NC35

### DIFF
--- a/.changelog/current/3324-nc35.md
+++ b/.changelog/current/3324-nc35.md
@@ -1,0 +1,4 @@
+# Maintenance
+
+- Mark app as compatible with NC35
+

--- a/.github/actions/deploy/appinfo/info.xml.dist
+++ b/.github/actions/deploy/appinfo/info.xml.dist
@@ -27,7 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR AGPL-3.0-or-later
     <screenshot>https://raw.githubusercontent.com/nextcloud/cookbook/stable/img/screenshot2.png</screenshot>
     <dependencies>
         <php min-version="8.0"/>
-        <nextcloud min-version="31" max-version="34"/>
+        <nextcloud min-version="31" max-version="35"/>
     </dependencies>
     <navigations>
         <navigation>

--- a/.github/actions/run-tests/reset-from-container.sh
+++ b/.github/actions/run-tests/reset-from-container.sh
@@ -16,13 +16,11 @@ is_file_dump () {
 
 restore_mysql_dump () {
 	echo "Dropping old data from the database"
-	echo "Getting tables"
-	mariadb -u root -p"$MYSQL_ROOT_PASSWORD" -h mysql --skip-ssl "$MYSQL_DATABASE" <<- EOF | tail -n +2 > /tmp/mysql_tables
-		SHOW TABLES;
-		EOF
-	echo "Got:"
-	cat /tmp/mysql_tables
-	cat /tmp/mysql_tables | sed 's@.*@DROP TABLE \0;@' | mysql -u root -p"$MYSQL_ROOT_PASSWORD" -h mysql --skip-ssl "$MYSQL_DATABASE"
+	mysql -u root -p"$MYSQL_ROOT_PASSWORD" -h mysql --skip-ssl <<- EOF
+	DROP DATABASE ${MYSQL_DATABASE};
+	CREATE DATABASE ${MYSQL_DATABASE};
+	GRANT ALL ON ${MYSQL_DATABASE}.* TO '${MYSQL_USER}'@'%';
+	EOF
 
 	echo "Restoring MySQL from single file dump"
 	local dump_file="$SF_DIR/sql/dump.sql"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,18 +132,18 @@ jobs:
             database:
                 - mysql
             coreVersion:
-                - 34
+                - 35
             phpVersion:
                 - "8.5"
             httpServer:
                 - "apache"
             include:
                 -   database: sqlite
-                    coreVersion: 32
+                    coreVersion: 33
                     phpVersion: "8.3"
                     httpServer: "apache"
                 -   database: pgsql
-                    coreVersion: 33
+                    coreVersion: 34
                     phpVersion: "8.4"
                     httpServer: "nginx"
                     

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,7 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR AGPL-3.0-or-later
     <screenshot>https://raw.githubusercontent.com/nextcloud/cookbook/stable/img/screenshot2.png</screenshot>
     <dependencies>
         <php min-version="8.0"/>
-        <nextcloud min-version="31" max-version="34"/>
+        <nextcloud min-version="31" max-version="35"/>
     </dependencies>
     <navigations>
         <navigation>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Nextcloud cookbook contributors

SPDX-License-Identifier: AGPL-3.0-only OR AGPL-3.0-or-later
-->

<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

This PR marks the app as compatible with the upcoming NC 35.

## Concerns/issues

It is not thoroughly tested yet but unit tests should check most cases

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ ] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
