### PR TITLE
chore: add PR title linter to ensure conventional commit titles

### DIFF
--- a/.changelog/current/3325-pr-lint-cc-title.md
+++ b/.changelog/current/3325-pr-lint-cc-title.md
@@ -1,0 +1,4 @@
+# Maintenance
+
+- Ensure all PR titles are valid conventional commits for simpler repository handling
+

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Jan Amann
+# SPDX-FileCopyrightText: 2026 Nextcloud cookbook contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR AGPL-3.0-or-later
+
+name: 'Lint PR title'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      # if you use required Actions:
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Nextcloud cookbook contributors

SPDX-License-Identifier: AGPL-3.0-only OR AGPL-3.0-or-later
-->

<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

If we want to automate the release process, conventional commits will be handy. This should simplify this and ensure all PR titles are conventional commits. We should then start to use "squash&merge" in order to use the title in a linear CC-clear history.

## Concerns/issues

Existing PRs need to be checked again. Let's see how much effort it will be.

