### PR TITLE
chore: make the app formally compatible with NC36 to allow tests against master

### DIFF
--- a/.changelog/current/3330-nc36.md
+++ b/.changelog/current/3330-nc36.md
@@ -1,0 +1,4 @@
+# Maintenance
+
+- Make app formally compatible with NC36
+

--- a/.github/actions/deploy/appinfo/info.xml.dist
+++ b/.github/actions/deploy/appinfo/info.xml.dist
@@ -27,7 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR AGPL-3.0-or-later
     <screenshot>https://raw.githubusercontent.com/nextcloud/cookbook/stable/img/screenshot2.png</screenshot>
     <dependencies>
         <php min-version="8.0"/>
-        <nextcloud min-version="31" max-version="35"/>
+        <nextcloud min-version="31" max-version="36"/>
     </dependencies>
     <navigations>
         <navigation>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,7 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR AGPL-3.0-or-later
     <screenshot>https://raw.githubusercontent.com/nextcloud/cookbook/stable/img/screenshot2.png</screenshot>
     <dependencies>
         <php min-version="8.0"/>
-        <nextcloud min-version="31" max-version="35"/>
+        <nextcloud min-version="31" max-version="36"/>
     </dependencies>
     <navigations>
         <navigation>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Nextcloud cookbook contributors

SPDX-License-Identifier: AGPL-3.0-only OR AGPL-3.0-or-later
-->

<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

This just sets the compatibility level to NC36.

## Concerns/issues

None

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ ] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
