### PR TITLE
build: Remove eslint from Dependabot wishlist

### DIFF
--- a/.changelog/current/3331-no-eslint-major-updates.md
+++ b/.changelog/current/3331-no-eslint-major-updates.md
@@ -1,0 +1,3 @@
+# Maintenance
+
+- Ignore major updates of eslint NPM package

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
   open-pull-requests-limit: 10
   cooldown:
     default-days: 7
+  ignore:
+    - dependency-name: "eslint"
+      versions:
+      - "10.x"
 - package-ecosystem: composer
   directory: "/"
   schedule:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Nextcloud cookbook contributors

SPDX-License-Identifier: AGPL-3.0-only OR AGPL-3.0-or-later
-->

<!-- Thanks for contributing to the project. To help with merging the changes, please fill in some basic data. -->

## Topic and Scope

To prevent the update of eslint to version 10 as the dependencies do not allow this right now.

## Concerns/issues

We must be carefu lto remove the ignore pattern in time.

## Formal requirements

There are some formal requirements that should be satisfied. Please mark those by checking the corresponding box.

- [ ] I did check that the app can still be opened and does not throw any browser logs
- [ ] I created tests for newly added PHP code (check this if no PHP changes were made)
- [ ] I updated the OpenAPI specs and added an entry to the API changelog (check if API was not modified)
- [ ] I notified the matrix channel if I introduced an API change
